### PR TITLE
Fix Refreshing Hamburger menu after ajax UI refresh

### DIFF
--- a/portlet/web/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
+++ b/portlet/web/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
@@ -83,6 +83,10 @@ export default {
         this.hamburgerMenu = false;
       }
     });
+    const extensions = extensionRegistry.loadExtensions('exo-hamburger-menu-navigation', 'exo-hamburger-menu-navigation-items');
+    if (extensions) {
+      extensions.forEach(contentDetail => delete contentDetail.loaded);
+    }
     this.refreshMenu();
   },
   mounted() {


### PR DESCRIPTION
When refreshing UI using ajax using WebUI on UIWorkingWorkspace, the Hamburger menu DOM get refreshed and becomes empty.
Thus, the DOM computing has to start again like it's a page refresh. So here the PR will consider menu items as not loaded.