### PR TITLE
Log a warn when a UIcomponent is not found when retrieved by its ID

### DIFF
--- a/webui/portlet/src/main/java/org/exoplatform/webui/core/lifecycle/UIApplicationLifecycle.java
+++ b/webui/portlet/src/main/java/org/exoplatform/webui/core/lifecycle/UIApplicationLifecycle.java
@@ -51,6 +51,8 @@ public class UIApplicationLifecycle extends Lifecycle<UIPortletApplication> {
                 super.processAction(uicomponent, context);
             else if (uiTarget != null)
                 uiTarget.processAction(context);
+            else
+                log.warn("Could not find UIComponent with ID {}", componentId);
         }
     }
 


### PR DESCRIPTION
There is no alert when an UIcomponent could not be retrieved by its ID, all actions are ignored and  the portlet will just render.
The PR will add a warning when an action called for a  missing UIComponent in the portlet