### PR TITLE
Avoid displaying administration Hidden navigations

### DIFF
--- a/portlet/web/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
+++ b/portlet/web/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
@@ -62,6 +62,9 @@ export default {
     };
   },
   computed:{
+    visibilityQueryParams() {
+      return this.navigationVisibilities.map(visibilityName => `visibility=${visibilityName}`).join('&');
+    },
     navigationTree() {
       const navigationTree = [];
       const navigationParentObjects = {};


### PR DESCRIPTION
Only administration navigations with visibility 'DISPLAYED' should be displayed.