### PR TITLE
Return empty extensions array when no extension for the given module

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/core/extensionRegistry.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/core/extensionRegistry.js
@@ -75,7 +75,7 @@
     var extensions = [];
     var module = findModule(app);
 
-    if (!module && module.extensions.length === 0) {
+    if (!module || !module.extensions) {
       return [];
     }
     


### PR DESCRIPTION
In the extension registry, when loading extensions of a given module, if the module was not registered, the loading failed.

This fix make sure to not fail in that case and return an empty array.