### PR TITLE
PLF-8727: dropup menu according to position

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIRightClickPopupMenu.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIRightClickPopupMenu.js
@@ -251,10 +251,13 @@
 	      break;
 	    default:
 	      // if it isn't fit to be showed down BUT is fit to to be showed up
-	      if ((eXo.core.Mouse.mouseyInClient + ctxMenuContainer.offsetHeight) > browserHeight
-	          && (intTop > ctxMenuContainer.offsetHeight)) {
-	        intTop -= ctxMenuContainer.offsetHeight;
+	      if ((eXo.core.Mouse.mouseyInClient + intTop) > browserHeight )
+          {
+              $(".uiRightClickPopupMenu").addClass("dropup");
 	      }
+		else {
+            $(".uiRightClickPopupMenu").addClass("dropup");
+            	}
 	      break;
 	    }
 	

--- a/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIRightClickPopupMenu.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIRightClickPopupMenu.js
@@ -256,7 +256,7 @@
               $(".uiRightClickPopupMenu").addClass("dropup");
 	      }
 		else {
-            $(".uiRightClickPopupMenu").addClass("dropup");
+            $(".uiRightClickPopupMenu").removeClass("dropup");
             	}
 	      break;
 	    }


### PR DESCRIPTION
If the displayed menu would exceed the screen height(The click y position + right click Menu offsetHeight), the added booststrap class "dropup" will assure that this menu will appear in upper direction, if not, this class would be removed in order to restore the original display mode "dropdown"