### PR TITLE
WIKI-1439 : Improve wiki editor

### DIFF
--- a/component/common/src/test/java/org/exoplatform/commons/utils/TestHTMLEntityEncoder.java
+++ b/component/common/src/test/java/org/exoplatform/commons/utils/TestHTMLEntityEncoder.java
@@ -51,4 +51,13 @@ public class TestHTMLEntityEncoder extends TestCase {
                 "&lt;a&#x20;href&#x3d;&quot;http&#x3a;&#x2f;&#x2f;example.com&#x2f;&#x3f;name1&#x3d;value1&amp;name2&#x3d;value2&amp;name3&#x3d;a&#x2b;b&quot;&gt;link&lt;&#x2f;a&gt;",
                 htmlEncoder.encodeHTMLAttribute("<a href=\"http://example.com/?name1=value1&name2=value2&name3=a+b\">link</a>"));
     }
+
+    public void testEmoticonsHTMLEncoding() {
+        // Emoticon in the Unicode BMP (Basic Multilingual Plane) plane - Code point from 0000 to ​FFFF (16 bits)
+        assertEquals("&lt;h1&gt;HELLO WORLD &#x2714;&lt;&#x2f;h1&gt;", htmlEncoder.encode("<h1>HELLO WORLD ✔</h1>"));
+        // Emoticon in the Unicode BMP (Basic Multilingual Plane) plane with a variant
+        assertEquals("&lt;h1&gt;HELLO WORLD &#x2714;&#xfe0f;&lt;&#x2f;h1&gt;", htmlEncoder.encode("<h1>HELLO WORLD ✔️</h1>"));
+        // Emoticon in the supplementary planes - Code point from 10000 to 10FFFF - Represented in Java as 2 surrogates code points
+        assertEquals("&lt;h1&gt;HELLO WORLD &#x1f44d;&lt;&#x2f;h1&gt;", htmlEncoder.encode("<h1>HELLO WORLD \uD83D\uDC4D</h1>"));
+    }
 }


### PR DESCRIPTION
This PR improves HTMLEntityEncoder to support Unicode characters in supplementary planes. Unicode characters in supplementary planes are represented in Java with 2 chars (high and low surrogates code points), because these characters code point is stored in more than 16 bits and Java use UTF-16 so it can not 1 char.
This improvement makes HTMLEntityEncoder to support these characters.