### PR TITLE
Fix user language saving and move configuration

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/portal/web-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/portal/web-configuration.xml
@@ -26,6 +26,10 @@
     xmlns="http://www.exoplaform.org/xml/ns/kernel_1_2.xsd">
 
   <component>
+    <type>org.exoplatform.web.application.ApplicationLifecycleExtension</type>
+  </component>
+
+  <component>
     <type>org.exoplatform.web.filter.ExtensibleFilter</type>
   </component>
 
@@ -112,6 +116,15 @@
           </object>
         </object-param>
       </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.web.application.ApplicationLifecycleExtension</target-component>
+    <component-plugin>
+      <name>LocalizationLifecycle</name>
+      <set-method>addPortalApplicationLifecycle</set-method>
+      <type>org.exoplatform.portal.application.localization.LocalizationLifecycle</type>
     </component-plugin>
   </external-component-plugins>
 

--- a/web/portal/src/main/webapp/WEB-INF/webui-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/webui-configuration.xml
@@ -36,7 +36,6 @@
       <listener>org.exoplatform.portal.application.PortalStatisticLifecycle</listener>
       <listener>org.exoplatform.webui.application.MonitorApplicationLifecycle</listener>
       <listener>org.exoplatform.portal.application.UserProfileLifecycle</listener>
-      <listener>org.exoplatform.portal.application.localization.LocalizationLifecycle</listener>
       <listener>org.exoplatform.web.application.ExtensiblePortalApplicationLifecycle</listener>
     </application-lifecycle-listeners>
 


### PR DESCRIPTION
(Sorry the PR seems as huge while it's just formatting)
The method 'saveLocaleToUserProfile' wasn't triggered all time when the user switches to a different language. This modification ensure to compare last used locale of user with current locale defined for HTTP request and save it if changed switch `LocalePolicy` service implementation.