### PR TITLE
Optimize DB datasource usage for quartz

### DIFF
--- a/component/common/src/main/resources/conf/configuration.xml
+++ b/component/common/src/main/resources/conf/configuration.xml
@@ -22,8 +22,8 @@
 
 <configuration
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.exoplaform.org/xml/ns/kernel_1_2.xsd http://www.exoplaform.org/xml/ns/kernel_1_2.xsd"
-    xmlns="http://www.exoplaform.org/xml/ns/kernel_1_2.xsd">
+    xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+    xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
 
   <component>
     <key>org.exoplatform.container.PropertyConfigurator</key>
@@ -82,8 +82,8 @@
   <!-- Data Initialization -->
   <external-component-plugins>
     <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
-    <component-plugin>
-      <name>CommonsChangeLogsPlugin</name>
+    <component-plugin profiles="cluster">
+      <name>QuartzChangeLogsPlugin</name>
       <set-method>addChangeLogsPlugin</set-method>
       <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
       <init-params>
@@ -91,6 +91,17 @@
           <name>changelogs</name>
           <description>Change logs of settings</description>
           <value>db/changelog/quartz.db.changelog-1.0.0.xml</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>SettingsChangeLogsPlugin</name>
+      <set-method>addChangeLogsPlugin</set-method>
+      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+      <init-params>
+        <values-param>
+          <name>changelogs</name>
+          <description>Change logs of settings</description>
           <value>db/changelog/settings.db.changelog-1.0.0.xml</value>
         </values-param>
       </init-params>

--- a/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
@@ -87,66 +87,66 @@
       </value-param>
       <value-param>
         <name>org.quartz.jobStore.class</name>
-        <value>${exo.quartz.jobStore.class}</value>
+        <value>org.quartz.simpl.RAMJobStore</value>
       </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.driverDelegateClass</name>
-        <value>${exo.quartz.jobStore.driverDelegateClass}</value>
-      </value-param>
-      <value-param>
+      <value-param profiles="cluster">
         <name>org.quartz.jobStore.useProperties</name>
         <value>${exo.quartz.jobStore.useProperties}</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.dataSource</name>
-        <value>${exo.quartz.jobStore.dataSource}</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.tablePrefix</name>
-        <value>${exo.quartz.jobStore.tablePrefix}</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.isClustered</name>
-        <value>false</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.maxMisfiresToHandleAtATime</name>
-        <value>${exo.quartz.jobStore.maxMisfiresToHandleAtATime}</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.dontSetAutoCommitFalse</name>
-        <value>${exo.quartz.jobStore.dontSetAutoCommitFalse}</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.lockHandler.class</name>
-        <value>${exo.quartz.jobStore.lockHandler.class}</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.driverDelegateInitString</name>
-        <value>${exo.quartz.jobStore.driverDelegateInitString}</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.txIsolationLevelSerializable</name>
-        <value>${exo.quartz.jobStore.txIsolationLevelSerializable}</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.selectWithLockSQL</name>
-        <value>${exo.quartz.jobStore.selectWithLockSQL}</value>
-      </value-param>
-      <value-param>
-        <name>org.quartz.jobStore.acquireTriggersWithinLock</name>
-        <value>${exo.quartz.jobStore.acquireTriggersWithinLock}</value>
       </value-param>
       <value-param profiles="cluster">
         <name>org.quartz.jobStore.isClustered</name>
         <value>true</value>
       </value-param>
       <value-param profiles="cluster">
+        <name>org.quartz.jobStore.class</name>
+        <value>${exo.quartz.jobStore.class}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.driverDelegateClass</name>
+        <value>${exo.quartz.jobStore.driverDelegateClass}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.dataSource</name>
+        <value>${exo.quartz.jobStore.dataSource}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.tablePrefix</name>
+        <value>${exo.quartz.jobStore.tablePrefix}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.maxMisfiresToHandleAtATime</name>
+        <value>${exo.quartz.jobStore.maxMisfiresToHandleAtATime}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.dontSetAutoCommitFalse</name>
+        <value>${exo.quartz.jobStore.dontSetAutoCommitFalse}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.lockHandler.class</name>
+        <value>${exo.quartz.jobStore.lockHandler.class}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.driverDelegateInitString</name>
+        <value>${exo.quartz.jobStore.driverDelegateInitString}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.txIsolationLevelSerializable</name>
+        <value>${exo.quartz.jobStore.txIsolationLevelSerializable}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.selectWithLockSQL</name>
+        <value>${exo.quartz.jobStore.selectWithLockSQL}</value>
+      </value-param>
+      <value-param profiles="cluster">
+        <name>org.quartz.jobStore.acquireTriggersWithinLock</name>
+        <value>${exo.quartz.jobStore.acquireTriggersWithinLock}</value>
+      </value-param>
+      <value-param profiles="cluster">
         <name>org.quartz.jobStore.clusterCheckinInterval</name>
         <value>${exo.quartz.jobStore.clusterCheckinInterval}</value>
       </value-param>
       <!-- Configure Datasources -->
-      <value-param>
+      <value-param profiles="cluster">
         <name>org.quartz.dataSource.quartzDS.jndiURL</name>
         <value>${exo.quartz.dataSource.quartzDS.jndiURL}</value>
       </value-param>


### PR DESCRIPTION
Quartz is using Database as default store even in standalone mode. This mode is useful only for Cluster to be able to synchronize jobs execution through nodes. For standalone mode, it's useless and consumes a lot of resources for nothing. This modification will use Quartz Jobs management in-memory in standalone and DB for cluster mode only.