### PR TITLE
Add OO Editors page navigation in Content category

### DIFF
--- a/portlet/web/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
+++ b/portlet/web/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
@@ -38,6 +38,7 @@ export default {
         // content
         'siteExplorer': 'content',
         'wcmAdmin': 'content',
+        'editors': 'content',
         // gamification
         'hook_management': 'gamification',
         'gamification/rules': 'gamification',


### PR DESCRIPTION
This will add OO editors page in "Content" category when the page exists