### PR TITLE
Maint-26952: check validity of role name and description length

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/MembershipTypeRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/MembershipTypeRestResourcesV1.java
@@ -76,6 +76,13 @@ public class MembershipTypeRestResourcesV1 implements ResourceContainer {
     }
     if (StringUtils.isBlank(membershipType.getName())) {
       return Response.status(Response.Status.BAD_REQUEST).entity("NAME:MANDATORY").build();
+    } else if (membershipType.getName().length() > 30 || membershipType.getName().length()<3) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("NAME:LENGTH_INVALID").build();
+    }
+    if (StringUtils.isBlank(membershipType.getDescription())) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("DESCRIPTION:MANDATORY").build();
+    } else if (membershipType.getDescription().length() > 255 || membershipType.getDescription().length()<3) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("DESCRIPTION:LENGTH_INVALID").build();
     }
     if (organizationService.getMembershipTypeHandler().findMembershipType(membershipType.getName()) != null) {
       return Response.status(Response.Status.BAD_REQUEST)

--- a/component/portal/src/test/java/org/exoplatform/portal/rest/MembershipTypeRestResourcesTest.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/rest/MembershipTypeRestResourcesTest.java
@@ -21,6 +21,8 @@ public class MembershipTypeRestResourcesTest extends BaseRestServicesTestCase {
 
   private static final String MEMBERSHIP_TYPE_2 = "mt2";
 
+  private static final String MEMBERSHIP_TYPE_3 = "mt3";
+
   protected Class<?> getComponentClass() {
     return MembershipTypeRestResourcesV1.class;
   }
@@ -68,6 +70,12 @@ public class MembershipTypeRestResourcesTest extends BaseRestServicesTestCase {
     assertNotNull(response.getEntity());
 
     data.put("name", "NEW_MEMBERSHIP_TYPE");
+    response = getResponse("POST", "/v1/membershipTypes", data.toString());
+    assertNotNull(response);
+    assertEquals(400, response.getStatus());
+
+    data.put("name", MEMBERSHIP_TYPE_3);
+    data.put("description","desc");
     response = getResponse("POST", "/v1/membershipTypes", data.toString());
     assertNotNull(response);
     assertEquals(204, response.getStatus());

--- a/component/portal/src/test/java/org/exoplatform/portal/rest/MembershipTypeRestResourcesTest.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/rest/MembershipTypeRestResourcesTest.java
@@ -23,6 +23,14 @@ public class MembershipTypeRestResourcesTest extends BaseRestServicesTestCase {
 
   private static final String MEMBERSHIP_TYPE_3 = "mt3";
 
+  private static final String MEMBERSHIP_TYPE_4 = "mt";
+
+  private static final String MEMBERSHIP_TYPE_5 = "aaaaaa aaaaaaaaaaaa aaaaaaaaaaa";
+
+  private static final String MEMBERSHIP_TYPE_6 = "mt6";
+
+  private static final String MEMBERSHIP_TYPE_7 = "mt7";
+
   protected Class<?> getComponentClass() {
     return MembershipTypeRestResourcesV1.class;
   }
@@ -79,6 +87,35 @@ public class MembershipTypeRestResourcesTest extends BaseRestServicesTestCase {
     response = getResponse("POST", "/v1/membershipTypes", data.toString());
     assertNotNull(response);
     assertEquals(204, response.getStatus());
+
+    // if the role name < 3
+    data.put("name", MEMBERSHIP_TYPE_4);
+    data.put("description","desc");
+    response = getResponse("POST", "/v1/membershipTypes", data.toString());
+    assertNotNull(response);
+    assertEquals(400, response.getStatus());
+
+    // if the role name > 30
+    data.put("name", MEMBERSHIP_TYPE_5);
+    data.put("description","desc");
+    response = getResponse("POST", "/v1/membershipTypes", data.toString());
+    assertNotNull(response);
+    assertEquals(400, response.getStatus());
+
+    // if the role description < 3
+    data.put("name", MEMBERSHIP_TYPE_6);
+    data.put("description","de");
+    response = getResponse("POST", "/v1/membershipTypes", data.toString());
+    assertNotNull(response);
+    assertEquals(400, response.getStatus());
+
+    // if the role description > 255
+    String desc = "aaaaaa aaaaaaaaaaaa aaaaaaaaaa aaaaaaaaaaaaaaa aaaaaaaaaaaaaaa aaaaaaaaaaaa aaaaaaaaaaaaa aaaaaaaaaaaaaaaaa aaaaaaaaaaa aaaaaaaa aaa aa aaa aaa aaaaa aaa aaaa aaaaa aaaaaaaaaa aaaaaaaaaaaa aaaaaaaaaaaaa aaaa aaaaaa aaaa aaaaa aaaaaa aaaaaaaaaaa aaaaaaaaaa a";
+    data.put("name", MEMBERSHIP_TYPE_7);
+    data.put("description",desc);
+    response = getResponse("POST", "/v1/membershipTypes", data.toString());
+    assertNotNull(response);
+    assertEquals(400, response.getStatus());
   }
 
   public void testUpdateMembershipType() throws Exception {


### PR DESCRIPTION
- add a check to insure that the name must be between "3" and "30" characters, The length of the text in field "Role Description" must be between "3" and "255" characters.