### PR TITLE
Add kernel profiles and css class to pages containers

### DIFF
--- a/component/portal/src/main/java/gatein_objects_1_7.xsd
+++ b/component/portal/src/main/java/gatein_objects_1_7.xsd
@@ -1,0 +1,305 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (C) 2009 eXo Platform SAS.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema
+    targetNamespace="http://www.gatein.org/xml/ns/gatein_objects_1_7"
+    xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_7"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified"
+    version="1.0">
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <!-- A top page element -->
+  <xs:element name="page" type="pageType"/>
+
+  <!-- A top page-set element -->
+  <xs:element name="page-set" type="pageSetType"/>
+
+  <!-- A top portal-config element -->
+  <xs:element name="portal-config" type="portalConfigType"/>
+
+  <!-- A top container element -->
+  <xs:element name="container" type="containerType"/>
+
+  <!-- A top node-navigation element -->
+  <xs:element name="node-navigation" type="nodeNavigationType"/>
+
+  <!-- A localized string -->
+  <xs:complexType name="localizedString">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="xml:lang"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- The type of a top navigation node -->
+  <xs:complexType name="nodeNavigationType">
+    <xs:sequence>
+      <xs:element name="priority" type="xs:positiveInteger" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="page-nodes" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="parent-uri" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="node" type="nodeType" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- The type of a navigation node -->
+  <xs:complexType name="nodeType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string"/>
+      <xs:element name="label" type="localizedString" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="icon" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="start-publication-date" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="end-publication-date" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="visibility" type="visibility" default="DISPLAYED" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="page-reference" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="properties" type="propertiesType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="node" type="nodeType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="visibility">
+    <xs:restriction base='xs:string'>
+      <xs:enumeration value="DISPLAYED"/>
+      <xs:enumeration value="HIDDEN"/>
+      <xs:enumeration value="TEMPORAL"/>
+      <xs:enumeration value="SYSTEM"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="pageSetType">
+    <xs:sequence>
+      <xs:element name="page" type="pageType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="portalConfigType">
+    <xs:sequence>
+      <xs:element name="portal-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="label" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="locale" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="access-permissions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="edit-permission" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="skin" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="properties" type="propertiesType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="portal-redirects" type="redirectsType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="portal-layout" minOccurs="1" maxOccurs="1">
+        <xs:complexType>
+          <xs:group ref="containerChildrenGroup"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="propertiesType">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="entry" type="propertiesEntryType" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="propertiesEntryType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="key" type="xs:string"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:group name="containerChildrenGroup">
+    <xs:sequence>
+      <xs:element name="move-apps-permissions" type="xs:string" minOccurs="0" maxOccurs="1" default="Everyone"/>
+      <xs:element name="move-containers-permissions" type="xs:string" minOccurs="0" maxOccurs="1" default="Everyone"/>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="portlet-application" type="portletApplicationType" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="gadget-application" type="gadgetApplicationType" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="container" type="containerType" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="page-body" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="site-body" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="pageType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="factory-id" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="access-permissions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="edit-permission" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="show-max-window" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:group ref="containerChildrenGroup"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="containerType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="icon" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="access-permissions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="factory-id" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:group ref="containerChildrenGroup"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+    <xs:attribute name="template" type="xs:string"/>
+    <xs:attribute name="attribute" type="xs:string"/>
+    <xs:attribute name="width" type="xs:string"/>
+    <xs:attribute name="height" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="portletApplicationType">
+    <xs:sequence>
+      <xs:choice>
+        <xs:element name="portlet" type="portletType"/>
+        <xs:element name="wsrp" type="xs:string"/>
+      </xs:choice>
+      <xs:group ref="applicationGroup"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="gadgetApplicationType">
+    <xs:sequence>
+      <xs:element name="gadget" type="gadgetType" minOccurs="1" maxOccurs="1"/>
+      <xs:group ref="applicationGroup"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:group name="applicationGroup">
+    <xs:sequence>
+      <xs:element name="theme" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="access-permissions" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="show-info-bar" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="show-application-state" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="show-application-mode" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="icon" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="width" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="height" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="portletType">
+    <xs:sequence>
+      <xs:element name="application-ref" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="portlet-ref" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="preferences" type="portletPreferencesType" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="gadgetType">
+    <xs:sequence>
+      <xs:element name="gadget-ref" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="portletPreferencesType">
+    <xs:sequence>
+      <xs:element name="preference" type="portletPreferenceType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="portletPreferenceType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="read-only" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="redirectsType">
+    <xs:sequence>
+      <xs:element name="portal-redirect" type="redirectType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:complexType name="redirectType">
+    <xs:sequence>
+      <xs:element name="redirect-site" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="enabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="conditions" type="conditionsType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="node-mapping" type="mappingsType" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="conditionsType">
+    <xs:sequence>
+      <xs:element name="condition" type="conditionType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="conditionType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="user-agent" type="userAgentType" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="device-properties" type="devicePropertiesType" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="userAgentType">
+    <xs:sequence>
+      <xs:element name="contains" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="does-not-contain" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="devicePropertiesType">
+    <xs:sequence>
+      <xs:element name="device-property" type="devicePropertyType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="devicePropertyType">
+    <xs:sequence>
+      <xs:element name="property-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="greater-than" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="less-than" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="equals" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="matches" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="mappingsType">
+    <xs:sequence>
+      <xs:element name="use-node-name-matching" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unresolved-nodes" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="node-map" type="nodeMapType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="nodeMapType">
+    <xs:sequence>
+      <xs:element name="origin-node" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="redirect-node" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/component/portal/src/main/java/gatein_objects_1_8.xsd
+++ b/component/portal/src/main/java/gatein_objects_1_8.xsd
@@ -1,0 +1,306 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (C) 2020 eXo Platform SAS.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema
+    targetNamespace="http://www.exoplatform.org/xml/ns/gatein_objects_1_8"
+    xmlns="http://www.exoplatform.org/xml/ns/gatein_objects_1_8"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified"
+    version="1.0">
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <!-- A top page element -->
+  <xs:element name="page" type="pageType"/>
+
+  <!-- A top page-set element -->
+  <xs:element name="page-set" type="pageSetType"/>
+
+  <!-- A top portal-config element -->
+  <xs:element name="portal-config" type="portalConfigType"/>
+
+  <!-- A top container element -->
+  <xs:element name="container" type="containerType"/>
+
+  <!-- A top node-navigation element -->
+  <xs:element name="node-navigation" type="nodeNavigationType"/>
+
+  <!-- A localized string -->
+  <xs:complexType name="localizedString">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="xml:lang"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- The type of a top navigation node -->
+  <xs:complexType name="nodeNavigationType">
+    <xs:sequence>
+      <xs:element name="priority" type="xs:positiveInteger" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="page-nodes" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="parent-uri" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="node" type="nodeType" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- The type of a navigation node -->
+  <xs:complexType name="nodeType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string"/>
+      <xs:element name="label" type="localizedString" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="icon" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="start-publication-date" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="end-publication-date" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="visibility" type="visibility" default="DISPLAYED" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="page-reference" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="node" type="nodeType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="visibility">
+    <xs:restriction base='xs:string'>
+      <xs:enumeration value="DISPLAYED"/>
+      <xs:enumeration value="HIDDEN"/>
+      <xs:enumeration value="TEMPORAL"/>
+      <xs:enumeration value="SYSTEM"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="pageSetType">
+    <xs:sequence>
+      <xs:element name="page" type="pageType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="portalConfigType">
+    <xs:sequence>
+      <xs:element name="portal-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="label" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="locale" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="access-permissions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="edit-permission" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="skin" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="properties" type="propertiesType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="portal-redirects" type="redirectsType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="portal-layout" minOccurs="1" maxOccurs="1">
+        <xs:complexType>
+          <xs:group ref="containerChildrenGroup"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="propertiesType">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="entry" type="propertiesEntryType" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="propertiesEntryType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="key" type="xs:string"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:group name="containerChildrenGroup">
+    <xs:sequence>
+      <xs:element name="move-apps-permissions" type="xs:string" minOccurs="0" maxOccurs="1" default="Everyone"/>
+      <xs:element name="move-containers-permissions" type="xs:string" minOccurs="0" maxOccurs="1" default="Everyone"/>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="portlet-application" type="portletApplicationType" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="gadget-application" type="gadgetApplicationType" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="container" type="containerType" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="page-body" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="site-body" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="pageType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="factory-id" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="access-permissions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="edit-permission" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="show-max-window" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:group ref="containerChildrenGroup"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="containerType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="icon" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="access-permissions" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="factory-id" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:group ref="containerChildrenGroup"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+    <xs:attribute name="template" type="xs:string"/>
+    <xs:attribute name="attribute" type="xs:string"/>
+    <xs:attribute name="width" type="xs:string"/>
+    <xs:attribute name="height" type="xs:string"/>
+    <xs:attribute name="cssClass" type="xs:string"/>
+    <xs:attribute name="profiles" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="portletApplicationType">
+    <xs:sequence>
+      <xs:choice>
+        <xs:element name="portlet" type="portletType"/>
+        <xs:element name="wsrp" type="xs:string"/>
+      </xs:choice>
+      <xs:group ref="applicationGroup"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="gadgetApplicationType">
+    <xs:sequence>
+      <xs:element name="gadget" type="gadgetType" minOccurs="1" maxOccurs="1"/>
+      <xs:group ref="applicationGroup"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:group name="applicationGroup">
+    <xs:sequence>
+      <xs:element name="theme" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="access-permissions" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="show-info-bar" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="show-application-state" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="show-application-mode" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="icon" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="width" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="height" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="portletType">
+    <xs:sequence>
+      <xs:element name="application-ref" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="portlet-ref" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="preferences" type="portletPreferencesType" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="gadgetType">
+    <xs:sequence>
+      <xs:element name="gadget-ref" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="portletPreferencesType">
+    <xs:sequence>
+      <xs:element name="preference" type="portletPreferenceType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="portletPreferenceType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="read-only" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="redirectsType">
+    <xs:sequence>
+      <xs:element name="portal-redirect" type="redirectType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:complexType name="redirectType">
+    <xs:sequence>
+      <xs:element name="redirect-site" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="enabled" type="xs:boolean" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="conditions" type="conditionsType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="node-mapping" type="mappingsType" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="conditionsType">
+    <xs:sequence>
+      <xs:element name="condition" type="conditionType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="conditionType">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="user-agent" type="userAgentType" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="device-properties" type="devicePropertiesType" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="userAgentType">
+    <xs:sequence>
+      <xs:element name="contains" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="does-not-contain" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="devicePropertiesType">
+    <xs:sequence>
+      <xs:element name="device-property" type="devicePropertyType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="devicePropertyType">
+    <xs:sequence>
+      <xs:element name="property-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="greater-than" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="less-than" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="equals" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="matches" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="mappingsType">
+    <xs:sequence>
+      <xs:element name="use-node-name-matching" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="unresolved-nodes" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="node-map" type="nodeMapType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="nodeMapType">
+    <xs:sequence>
+      <xs:element name="origin-node" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="redirect-node" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/component/portal/src/main/java/org/exoplatform/portal/config/model/Page.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/model/Page.java
@@ -143,7 +143,7 @@ public class Page extends Container {
     @Override
     public PageData build() {
         List<ComponentData> children = buildChildren();
-        return new PageData(storageId, id, name, icon, template, factoryId, title, description, width, height,
+        return new PageData(storageId, id, name, icon, template, factoryId, title, description, width, height, cssClass, profiles,
                 Utils.safeImmutableList(accessPermissions), children, ownerType, ownerId, editPermission, showMaxWindow,
                 Utils.safeImmutableList(moveAppsPermissions), Utils.safeImmutableList(moveContainersPermissions));
     }

--- a/component/portal/src/main/java/org/exoplatform/portal/pom/data/ContainerData.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/pom/data/ContainerData.java
@@ -57,6 +57,12 @@ public class ContainerData extends ComponentData {
     private final String height;
 
     /** . */
+    private final String cssClass;
+
+    /** . */
+    private final String profiles;
+
+    /** . */
     private final List<String> accessPermissions;
 
     private final List<String> moveAppsPermissions;
@@ -70,6 +76,40 @@ public class ContainerData extends ComponentData {
             String title, String description, String width, String height, List<String> accessPermissions,
             List<String> moveAppsPermissions, List<String> moveContainersPermissions,
             List<ComponentData> children) {
+    this(storageId,
+         id,
+         name,
+         icon,
+         template,
+         factoryId,
+         title,
+         description,
+         width,
+         height,
+         null,
+         null,
+         accessPermissions,
+         moveAppsPermissions,
+         moveContainersPermissions,
+         children);
+    }
+
+    public ContainerData(String storageId,
+                         String id,
+                         String name,
+                         String icon,
+                         String template,
+                         String factoryId,
+                         String title,
+                         String description,
+                         String width,
+                         String height,
+                         String cssClass,
+                         String profiles,
+                         List<String> accessPermissions,
+                         List<String> moveAppsPermissions,
+                         List<String> moveContainersPermissions,
+                         List<ComponentData> children) {
         super(storageId, null);
 
         //
@@ -82,6 +122,8 @@ public class ContainerData extends ComponentData {
         this.description = description;
         this.width = width;
         this.height = height;
+        this.cssClass = cssClass;
+        this.profiles = profiles;
         this.accessPermissions = accessPermissions;
         this.moveAppsPermissions = moveAppsPermissions;
         this.moveContainersPermissions = moveContainersPermissions;
@@ -145,4 +187,13 @@ public class ContainerData extends ComponentData {
     public List<String> getMoveContainersPermissions() {
         return moveContainersPermissions;
     }
+  
+    public String getCssClass() {
+      return cssClass;
+    }
+
+    public String getProfiles() {
+      return profiles;
+    }
+
 }

--- a/component/portal/src/main/java/org/exoplatform/portal/pom/data/MappedAttributes.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/pom/data/MappedAttributes.java
@@ -46,6 +46,12 @@ public class MappedAttributes {
     public static final Key<String> FACTORY_ID = Key.create("factory-id", ValueType.STRING);
 
     /** . */
+    public static final Key<String> CSS_CLASS = Key.create("css-class", ValueType.STRING);
+
+    /** . */
+    public static final Key<String> PROFILES = Key.create("profiles", ValueType.STRING);
+
+    /** . */
     public static final Key<Integer> PRIORITY = Key.create("priority", ValueType.INTEGER);
 
     /** . */

--- a/component/portal/src/main/java/org/exoplatform/portal/pom/data/PageData.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/pom/data/PageData.java
@@ -51,6 +51,49 @@ public class PageData extends ContainerData {
         this.showMaxWindow = showMaxWindow;
     }
 
+    public PageData(String storageId,
+                    String id,
+                    String name,
+                    String icon,
+                    String template,
+                    String factoryId,
+                    String title,
+                    String description,
+                    String width,
+                    String height,
+                    String cssClass,
+                    String profiles,
+                    List<String> accessPermissions,
+                    List<ComponentData> children,
+                    String ownerType,
+                    String ownerId,
+                    String editPermission,
+                    boolean showMaxWindow,
+                    List<String> moveAppsPermissions,
+                    List<String> moveContainersPermissions) {
+      super(storageId,
+            id,
+            name,
+            icon,
+            template,
+            factoryId,
+            title,
+            description,
+            width,
+            height,
+            cssClass,
+            profiles,
+            accessPermissions,
+            moveContainersPermissions,
+            moveContainersPermissions,
+            children);
+
+        //
+        this.key = new PageKey(ownerType, ownerId, name);
+        this.editPermission = editPermission;
+        this.showMaxWindow = showMaxWindow;
+    }
+
     public PageKey getKey() {
         return key;
     }

--- a/component/portal/src/main/resources/binding.xml
+++ b/component/portal/src/main/resources/binding.xml
@@ -61,6 +61,8 @@
     <value name="description" field="description" usage="optional"/>
     <value name="width" usage="optional" field="width" style="attribute"/>
     <value name="height" usage="optional" field="height" style="attribute"/>
+    <value name="cssClass" field="cssClass" usage="optional" style="attribute"/>
+    <value name="profiles" field="profiles" usage="optional" style="attribute"/>
     <value name="move-apps-permissions" field="moveAppsPermissions" usage="optional" default="Everyone" serializer="org.exoplatform.portal.config.serialize.JibxArraySerialize.serializePermissions"
           deserializer="org.exoplatform.portal.config.serialize.JibxArraySerialize.deserializePermissions"/>
     <value name="move-containers-permissions" field="moveContainersPermissions" usage="optional" default="Everyone" serializer="org.exoplatform.portal.config.serialize.JibxArraySerialize.serializePermissions"

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestSerialization.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestSerialization.java
@@ -36,7 +36,7 @@ public class TestSerialization extends AbstractGateInTest {
 
     /** . */
     private final ContainerData container = new ContainerData("foo01", "foo02", "foo03", "foo04", "foo05", "foo06", "foo07",
-            "foo08", "foo09", "foo10", Collections.singletonList("foo11"), Collections.singletonList("foo11"),
+            "foo08", "foo09", "foo10", "foo11", "foo12", Collections.singletonList("foo11"), Collections.singletonList("foo11"),
             Collections.singletonList("foo11"), Collections.<ComponentData> singletonList(body));
 
     public void testNavigationKey() throws Exception {
@@ -85,9 +85,26 @@ public class TestSerialization extends AbstractGateInTest {
     }
 
     public void testPage() throws Exception {
-        PageData obj = new PageData("foo01", "foo02", "foo03", "foo04", "foo05", "foo06", "foo07", "foo08", "foo09", "foo10",
-                Collections.singletonList("foo11"), Arrays.<ComponentData> asList(body), "foo12", "foo13", "foo14", true,
-                Collections.singletonList("foo11"), Collections.singletonList("foo11"));
+    PageData obj = new PageData("foo01",
+                                "foo02",
+                                "foo03",
+                                "foo04",
+                                "foo05",
+                                "foo06",
+                                "foo07",
+                                "foo08",
+                                "foo09",
+                                "foo10",
+                                "foo11",
+                                "foo12",
+                                Collections.singletonList("foo13"),
+                                Arrays.<ComponentData> asList(body),
+                                "foo14",
+                                "foo15",
+                                "foo16",
+                                true,
+                                Collections.singletonList("foo13"),
+                                Collections.singletonList("foo13"));
         PageData clone = IOTools.clone(obj);
         assertEquals(obj.getStorageId(), clone.getStorageId());
         assertEquals(obj.getStorageName(), clone.getStorageName());

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestDataStorage.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestDataStorage.java
@@ -799,7 +799,7 @@ public class TestDataStorage extends AbstractKernelTest {
   }
 
   protected void createSite(SiteType type, String siteName) throws Exception {
-      ContainerData container = new ContainerData(null, "testcontainer_" + siteName, "", "", "", "", "",
+      ContainerData container = new ContainerData(null, "testcontainer_" + siteName, "", "", "", "", "", "", "",
               "", "", "", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
       PortalData portal = new PortalData(null, siteName, type.getName(), null, null,
               null, new ArrayList<>(), null, null, null, container, null);

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJCBCNavigationServiceRebase.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJCBCNavigationServiceRebase.java
@@ -50,7 +50,7 @@ public class TestJCBCNavigationServiceRebase extends AbstractKernelTest {
   }
 
   protected void createSite(SiteType type, String siteName) throws Exception {
-      ContainerData container = new ContainerData(null, "testcontainer_" + siteName, "", "", "", "", "",
+      ContainerData container = new ContainerData(null, "testcontainer_" + siteName, "", "", "", "", "", "", "",
               "", "", "", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
       PortalData portal = new PortalData(null, siteName, type.getName(), null, null,
               null, new ArrayList<>(), null, null, null, container, null);

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJDBCNavigationService.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJDBCNavigationService.java
@@ -50,7 +50,7 @@ public class TestJDBCNavigationService extends AbstractKernelTest {
     }
 
     protected void createSite(SiteType type, String siteName) throws Exception {
-        ContainerData container = new ContainerData(null, "testcontainer_" + siteName, "", "", "", "", "",
+        ContainerData container = new ContainerData(null, "testcontainer_" + siteName, "", "", "", "", "", "", "",
                 "", "", "", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         PortalData portal = new PortalData(null, siteName, type.getName(), null, null,
                 null, new ArrayList<>(), null, null, null, container, null);

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJDBCNavigationServiceSave.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJDBCNavigationServiceSave.java
@@ -49,7 +49,7 @@ public class TestJDBCNavigationServiceSave extends AbstractKernelTest {
   }
 
   protected void createSite(SiteType type, String siteName) throws Exception {
-      ContainerData container = new ContainerData(null, "testcontainer_" + siteName, "", "", "", "", "",
+      ContainerData container = new ContainerData(null, "testcontainer_" + siteName, "", "", "", "", "", "", "",
               "", "", "", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
       PortalData portal = new PortalData(null, siteName, type.getName(), null, null,
               null, new ArrayList<>(), null, null, null, container, null);

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJDBCNavigationServiceUpdate.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJDBCNavigationServiceUpdate.java
@@ -61,6 +61,8 @@ public class TestJDBCNavigationServiceUpdate extends AbstractKernelTest {
                                                 "",
                                                 "",
                                                 "",
+                                                "",
+                                                "",
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJDBCNavigationServiceWrapper.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestJDBCNavigationServiceWrapper.java
@@ -61,16 +61,40 @@ public class TestJDBCNavigationServiceWrapper extends AbstractKernelTest {
     }
 
     protected void createSite(SiteType type, String siteName) throws Exception {
-        ContainerData container = new ContainerData(null, "testcontainer_" + siteName, "", "", "", "", "",
-                "", "", "", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-        PortalData portal = new PortalData(null, siteName, type.getName(), null, null,
-                null, new ArrayList<>(), null, null, null, container, null);
-        this.modelStorage.create(portal);
-
-        NavigationContext nav = new NavigationContext(type.key(siteName), new NavigationState(1));
-        this.navigationService.saveNavigation(nav);
-
-        restartTransaction();
+      ContainerData container = new ContainerData(null,
+                                                  "testcontainer_" + siteName,
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  "",
+                                                  Collections.emptyList(),
+                                                  Collections.emptyList(),
+                                                  Collections.emptyList(),
+                                                  Collections.emptyList());
+      PortalData portal = new PortalData(null,
+                                         siteName,
+                                         type.getName(),
+                                         null,
+                                         null,
+                                         null,
+                                         new ArrayList<>(),
+                                         null,
+                                         null,
+                                         null,
+                                         container,
+                                         null);
+      this.modelStorage.create(portal);
+  
+      NavigationContext nav = new NavigationContext(type.key(siteName), new NavigationState(1));
+      this.navigationService.saveNavigation(nav);
+  
+      restartTransaction();
     }
 
     protected void createNavigation(SiteType siteType, String siteName) throws Exception {

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestModelStorage.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/jdbc/service/TestModelStorage.java
@@ -216,19 +216,37 @@ public class TestModelStorage extends TestDataStorage {
     assertTrue(pConfig.getPortalLayout().getChildren() != null
         && pConfig.getPortalLayout().getChildren().size() == 0);
   }
-  
+
+  public void testGetPageChildrenFilteredByProfiles() throws Exception {
+    Page page = storage_.getPage("portal::test::test6");
+    assertNotNull(page.getChildren());
+    assertEquals(1, page.getChildren().size());
+    Container container = (Container) page.getChildren().get(0);
+
+    assertEquals("test", container.getProfiles());
+  }
+
+  public void testGetContainerClass() throws Exception {
+    Page page = storage_.getPage("portal::test::test6");
+    assertNotNull(page.getChildren());
+    assertEquals(1, page.getChildren().size());
+    Container container = (Container) page.getChildren().get(0);
+
+    assertEquals("testClass1 testClass2", container.getCssClass());
+  }
+
   public void testNullPreferenceValue() throws Exception {
     Page page = storage_.getPage("portal::test::test4");
     Application<Portlet> app = (Application<Portlet>) page.getChildren().get(0);
     PersistentApplicationState<Portlet> state = (PersistentApplicationState) app.getState();
-
+    
     //
     Portlet prefs = storage_.load(state, ApplicationType.PORTLET);
-
+    
     //
     prefs.setValue("template", null);
     storage_.save(state, prefs);
-
+    
     //
     prefs = storage_.load(state, ApplicationType.PORTLET);
     assertNotNull(prefs);

--- a/component/portal/src/test/resources/org/exoplatform/portal/mop/navigation/portal/test/pages.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/mop/navigation/portal/test/pages.xml
@@ -179,22 +179,39 @@
 
   <page>
     <name>test6</name>
-    <portlet-application>
-      <portlet>
-        <application-ref>web</application-ref>
-        <portlet-ref>BannerPortlet</portlet-ref>
-        <preferences>
-          <preference>
-            <name>template</name>
-            <value>par:/groovy/groovy/webui/component/UIBannerPortlet.gtmpl</value>
-            <read-only>false</read-only>
-          </preference>
-        </preferences>
-      </portlet>
-      <access-permissions>Everyone</access-permissions>
-      <show-info-bar>true</show-info-bar>
-    </portlet-application>
-    <container>
+    <container profiles="test" cssClass="testClass1 testClass2">
+      <portlet-application>
+        <portlet>
+          <application-ref>web</application-ref>
+          <portlet-ref>BannerPortlet</portlet-ref>
+          <preferences>
+            <preference>
+              <name>template</name>
+              <value>par:/groovy/groovy/webui/component/UIBannerPortlet.gtmpl</value>
+              <read-only>false</read-only>
+            </preference>
+          </preferences>
+        </portlet>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+      <portlet-application>
+        <portlet>
+          <application-ref>web</application-ref>
+          <portlet-ref>FooterPortlet</portlet-ref>
+          <preferences>
+            <preference>
+              <name>template</name>
+              <value>par:/groovy/groovy/webui/component/UIFooterPortlet.gtmpl</value>
+              <read-only>false</read-only>
+            </preference>
+          </preferences>
+        </portlet>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+    <container profiles="unknown" cssClass="testClass">
       <portlet-application>
         <portlet>
           <application-ref>web</application-ref>

--- a/component/web/security/src/main/java/org/exoplatform/web/security/security/AbstractTokenService.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/security/AbstractTokenService.java
@@ -45,7 +45,6 @@ import org.gatein.common.util.Base64;
 import org.gatein.common.util.Base64.EncodingOption;
 import org.gatein.wci.security.Credentials;
 import org.picocontainer.Startable;
-import sun.misc.Request;
 
 /**
  * Created by The eXo Platform SAS Author : liem.nguyen ncliam@gmail.com Jun 5, 2009

--- a/pom.xml
+++ b/pom.xml
@@ -824,7 +824,7 @@
               </property>
               <property>
                 <name>exo.profiles</name>
-                <value>${surefire.exo.profiles}</value>
+                <value>${surefire.exo.profiles},test</value>
               </property>
             </systemProperties>
           </configuration>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIColumnContainer.gtmpl
@@ -24,6 +24,8 @@
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	/** Trim the prefix UIContainer- if any, this hardcoded part is needed to update nested container via Ajax */
 	String componentId = uicomponent.getId();
 	if(componentId.startsWith("UIContainer-")){
@@ -35,14 +37,14 @@
      def reqJS = rcontext.getJavascriptManager().require("SHARED/portal", "portal");
      reqJS.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>  
-<div class="UIContainer UIColumnContainer EdittingContainer<%=uicomponent.getPermissionClasses()%>" 
+<div class="UIContainer UIColumnContainer <%=uiComponentClass%> EdittingContainer<%=uicomponent.getPermissionClasses()%>" 
 				id="${uicomponent.id}" ${cssStyle}>
 <%
   }
   else
   {   
 %>
-<div class="UIContainer UIColumnContainer <%=hasAccessPermission? "" : "ProtectedContainer"%>"
+<div class="UIContainer UIColumnContainer <%=uiComponentClass%> <%=hasAccessPermission? "" : "ProtectedContainer"%>"
         id="${uicomponent.id}" ${cssStyle}>
 <%
   }

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIContainer.gtmpl
@@ -20,6 +20,8 @@
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	/** Trim the prefix UIContainer- if any, this hardcoded part is needed to update nested container via Ajax */
 	String componentId = uicomponent.getId();
 	if(componentId.startsWith("UIContainer-")){
@@ -31,14 +33,14 @@
      def reqJS = rcontext.getJavascriptManager().require("SHARED/portal", "portal");
      reqJS.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>  
-<div class="UIContainer EdittingContainer<%=uicomponent.getPermissionClasses()%>"
+<div class="UIContainer <%=uiComponentClass%> EdittingContainer<%=uicomponent.getPermissionClasses()%>"
 				id="${uicomponent.id}" ${cssStyle}>
 <%
   }
   else
   {   
 %>
-<div class="UIContainer <%=hasAccessPermission?"": "ProtectedContainer"%>" id="${uicomponent.id}" ${cssStyle}>
+<div class="UIContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>" id="${uicomponent.id}" ${cssStyle}>
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIContainerList.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIContainerList.gtmpl
@@ -4,11 +4,13 @@
 	def categories = uicomponent.getCategories();
 	def selectedCategory = uicomponent.getSelectedCategory();
 	
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	def rcontext = _ctx.getRequestContext();
 	JavascriptManager jsManager = rcontext.getJavascriptManager();
 	jsManager.require("SHARED/portalDragDrop", "portalDragDrop").addScripts("portalDragDrop.init(['DragObjectPortlet']);");
 %>	
-<div class="uiContainerList" id="$uicomponent.id">
+<div class="uiContainerList <%=uiComponentClass%>" id="$uicomponent.id">
 	<div class="accordion verticalTabStyle1">
  		<% 
  			String cTab, cName, description, displayName;

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIHamburgerMenuContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIHamburgerMenuContainer.gtmpl
@@ -3,8 +3,10 @@
 
   AddOnService addOnService = uicomponent.getApplicationComponent(AddOnService.class);
   def hamburgerMenuItemsCount = addOnService.getApplications('hamburger-menu-items-container').size();
+
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
-<div class="VuetifyApp">
+<div class="VuetifyApp <%=uiComponentClass%>">
   <div id="HamburgerNavigationMenu" data-app="true" class="v-application HamburgerNavigationMenu v-application--is-ltr theme--light" id="app" color="transaprent" flat="">
     <div class="v-application--wrap">
         <a class="HamburgerNavigationMenuLink">

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIMobileSwipeContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIMobileSwipeContainer.gtmpl
@@ -20,6 +20,8 @@
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	/** Trim the prefix UIContainer- if any, this hardcoded part is needed to update nested container via Ajax */
 	String componentId = uicomponent.getId();
 	if(componentId.startsWith("UIContainer-")){
@@ -34,14 +36,14 @@
          .require("SHARED/portal", "portal")
          .addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>  
-<div class="UIContainer EdittingContainer<%=uicomponent.getPermissionClasses()%> UIMobileSwipeContainer"
+<div class="UIContainer <%=uiComponentClass%> EdittingContainer<%=uicomponent.getPermissionClasses()%> UIMobileSwipeContainer"
 				id="${uicomponent.id}" ${cssStyle}>
 <%
   }
   else
   {   
 %>
-<div class="UIContainer <%=hasAccessPermission?"": "ProtectedContainer"%> UIMobileSwipeContainer" id="${uicomponent.id}" ${cssStyle}>
+<div class="UIContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%> UIMobileSwipeContainer" id="${uicomponent.id}" ${cssStyle}>
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveColumnContainer.gtmpl
@@ -18,6 +18,8 @@
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	/** Trim the prefix UIContainer- if any, this hardcoded part is needed to update nested container via Ajax */
 	String componentId = uicomponent.getId();
 	if(componentId.startsWith("UIContainer-")){
@@ -29,14 +31,14 @@
      def reqJS = rcontext.getJavascriptManager().require("SHARED/portal", "portal");
      reqJS.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div class="UIContainer UIColumnContainer EdittingContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UIColumnContainer <%=uiComponentClass%> EdittingContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
 				id="${uicomponent.id}" ${cssStyle}>
 <%
   }
   else
   {
 %>
-<div class="UIContainer UIColumnContainer UIResponsiveColumnContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UIColumnContainer <%=uiComponentClass%> UIResponsiveColumnContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
         id="${uicomponent.id}" ${cssStyle}>
 <%
   }

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveContainer.gtmpl
@@ -18,6 +18,8 @@
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	/** Trim the prefix UIContainer- if any, this hardcoded part is needed to update nested container via Ajax */
 	String componentId = uicomponent.getId();
 	if(componentId.startsWith("UIContainer-")){
@@ -29,14 +31,14 @@
      def reqJS = rcontext.getJavascriptManager().require("SHARED/portal", "portal");
      reqJS.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div class="UIContainer UIColumnContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UIColumnContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>"
 				id="${uicomponent.id}" ${cssStyle}>
 <%
   }
   else
   {
 %>
-<div class="UIContainer UIResponsiveContainer <%=hasAccessPermission?"": "ProtectedContainer"%>" id="${uicomponent.id}" ${cssStyle}>
+<div class="UIContainer UIResponsiveContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>" id="${uicomponent.id}" ${cssStyle}>
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveRowContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveRowContainer.gtmpl
@@ -18,6 +18,8 @@
   if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
   if(cssStyle.length() > 0) cssStyle += "\"";
   
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
   /** Trim the prefix UIContainer- if any, this hardcoded part is needed to update nested container via Ajax */
   String componentId = uicomponent.getId();
   if(componentId.startsWith("UIContainer-")){
@@ -29,14 +31,14 @@
      def reqJS = rcontext.getJavascriptManager().require("SHARED/portal", "portal");
      reqJS.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>  
-<div class="UIContainer UIColumnContainer EdittingContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UIColumnContainer EdittingContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>"
         id="${uicomponent.id}" ${cssStyle}>
 <%
   }
   else
   {   
 %>
-<div id="${uicomponent.id}">
+<div id="${uicomponent.id}" class="<%=uiComponentClass%>">
 <div class="container">
 <div class="row">
 <%

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableBigSmallColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableBigSmallColumnContainer.gtmpl
@@ -17,6 +17,8 @@
 		uicomponent.setId(componentId.substring("UIContainer-".length()));
 	}
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	if (uiPortalApp.isEditing())
 	{
 	   JavascriptManager jsManager = rcontext.getJavascriptManager();
@@ -24,14 +26,14 @@
 	  				.addScripts("portalDragDrop.init(['UIContainer']);")
 	  				.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div class="UIContainer UITableColumnContainer EdittingContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UITableColumnContainer EdittingContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>"
 				id="${uicomponent.id}">
 <%
   }
   else
   {
 %>
-<div class="UIContainer UITableColumnContainer UIResponsiveTable66ColumnContainer <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
+<div class="UIContainer UITableColumnContainer UIResponsiveTable66ColumnContainer <%=uiComponentClass%> <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableColumnContainer.gtmpl
@@ -19,6 +19,8 @@
 		uicomponent.setId(componentId.substring("UIContainer-".length()));
 	}
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	if (uiPortalApp.isEditing())
 	{
 	   JavascriptManager jsManager = rcontext.getJavascriptManager();
@@ -26,14 +28,14 @@
 	  				.addScripts("portalDragDrop.init(['UIContainer']);")
 	  				.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div class="UIContainer UIColumnContainer EdittingContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UIColumnContainer EdittingContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>"
 				id="${uicomponent.id}">
 <%
   }
   else
   {
 %>
-<div class="UIContainer UITableColumnContainer UIResponsiveTableColumnContainer <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
+<div class="UIContainer UITableColumnContainer UIResponsiveTableColumnContainer <%=uiComponentClass%> <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableFourColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableFourColumnContainer.gtmpl
@@ -16,6 +16,8 @@
 		uicomponent.setId(componentId.substring("UIContainer-".length()));
 	}
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	if (uiPortalApp.isEditing())
 	{
 	   JavascriptManager jsManager = rcontext.getJavascriptManager();
@@ -23,14 +25,14 @@
 	  				.addScripts("portalDragDrop.init(['UIContainer']);")
 	  				.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div class="UIContainer UITableColumnContainer EdittingContainer <%=hasAccessPermission?"":"ProtectedContainer"%>"
+<div class="UIContainer UITableColumnContainer EdittingContainer <%=uiComponentClass%> <%=hasAccessPermission?"":"ProtectedContainer"%>"
 				id="${uicomponent.id}">
 <%
   }
   else
   {
 %>
-<div class="UIContainer UIColumnContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UIColumnContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>"
 				id="${uicomponent.id}" >
 <%
   }

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableSmallBigColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableSmallBigColumnContainer.gtmpl
@@ -16,6 +16,8 @@
 		uicomponent.setId(componentId.substring("UIContainer-".length()));
 	}
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	if (uiPortalApp.isEditing())
 	{
 	   JavascriptManager jsManager = rcontext.getJavascriptManager();
@@ -23,14 +25,14 @@
 	  				.addScripts("portalDragDrop.init(['UIContainer']);")
 	  				.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div class="UIContainer UIColumnContainer EdittingContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UIColumnContainer EdittingContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>"
 				id="${uicomponent.id}">
 <%
   }
   else
   {
 %>
-<div class="UIContainer UITableColumnContainer UIResponsiveTable33ColumnContainer <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
+<div class="UIContainer UITableColumnContainer UIResponsiveTable33ColumnContainer <%=uiComponentClass%> <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableThreeColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableThreeColumnContainer.gtmpl
@@ -18,6 +18,8 @@
 		uicomponent.setId(componentId.substring("UIContainer-".length()));
 	}
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	if (uiPortalApp.isEditing())
 	{
 	   JavascriptManager jsManager = rcontext.getJavascriptManager();
@@ -25,14 +27,14 @@
 	  				.addScripts("portalDragDrop.init(['UIContainer']);")
 	  				.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div class="UIContainer UIColumnContainer EdittingContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UIColumnContainer EdittingContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>"
 				id="${uicomponent.id}">
 <%
   }
   else
   {
 %>
-<div class="UIContainer UITableColumnContainer UIResponsiveTableThreeColumnContainer <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
+<div class="UIContainer UITableColumnContainer UIResponsiveTableThreeColumnContainer <%=uiComponentClass%> <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableTwoColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableTwoColumnContainer.gtmpl
@@ -17,6 +17,8 @@
 		uicomponent.setId(componentId.substring("UIContainer-".length()));
 	}
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	if (uiPortalApp.isEditing())
 	{
 	   JavascriptManager jsManager = rcontext.getJavascriptManager();
@@ -25,14 +27,14 @@
 	  				.addScripts("portalDragDrop.init(['UIContainer']);")
 	  				.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div class="UIContainer UITableColumnContainer EdittingContainer <%=hasAccessPermission?"": "ProtectedContainer"%>"
+<div class="UIContainer UITableColumnContainer EdittingContainer <%=uiComponentClass%> <%=hasAccessPermission?"": "ProtectedContainer"%>"
 				id="${uicomponent.id}" >
 <%
   }
   else
   {
 %>
-<div class="UIContainer UITableColumnContainer UIResponsiveTableTwoColumnContainer <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
+<div class="UIContainer UITableColumnContainer UIResponsiveTableTwoColumnContainer <%=uiComponentClass%> <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UISwitchingContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UISwitchingContainer.gtmpl
@@ -25,6 +25,8 @@
 		 jsManager.require("SHARED/portal", "portal").require("SHARED/toggleContainer", "toggleContainer").addScripts("toggleContainer.addContainer('"+uicomponent.id+"', '" + uicomponent.width + "');");
 	}
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	if (uiPortalApp.isEditing())
 	{
 		// JavascriptManager jsManager = rcontext.getJavascriptManager();
@@ -32,14 +34,14 @@
 				.addScripts("portalDragDrop.init(['UIContainer']);")
 				.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div class="UIContainer UITableColumnContainer UISwitchingContainer EdittingContainer<%=uicomponent.getPermissionClasses()%>"
+<div class="UIContainer UITableColumnContainer UISwitchingContainer <%=uiComponentClass%> EdittingContainer<%=uicomponent.getPermissionClasses()%>"
 				id="${uicomponent.id}">
 <%
 	}
 	else
 	{
 %>
-<div class="UIContainer UITableColumnContainer UISwitchingContainer <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
+<div class="UIContainer UITableColumnContainer UISwitchingContainer <%=uiComponentClass%> <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
 <%
 	}
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITabContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITabContainer.gtmpl
@@ -37,12 +37,14 @@
     }
   }
   
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
   String id = uicomponent.getId();  
   def modeState = Util.getUIPortalApplication().getModeState();
   def header = uicomponent.getTitle() != null ? _ctx.appRes(uicomponent.getTitle()) : null;
 %>
 <% if(children != null && children.size() > 0) { %>
-<div id="$id">
+<div id="$id" class="<%=uiComponentClass%>">
   <div class="VuetifyApp">
                       	<div id="tab$id">
                       	    <% if(modeState == 0 && header != null){ %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITableAutofitColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITableAutofitColumnContainer.gtmpl
@@ -19,6 +19,8 @@
 		uicomponent.setId(componentId.substring("UIContainer-".length()));
 	}
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	if (uiPortalApp.isEditing())
 	{
 		JavascriptManager jsManager = rcontext.getJavascriptManager();
@@ -26,14 +28,14 @@
 	  				.addScripts("portalDragDrop.init(['UIContainer']);")
 	  				.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>  
-<div class="UIContainer UITableColumnContainer EdittingContainer<%=uicomponent.getPermissionClasses()%>" 
+<div class="UIContainer UITableColumnContainer <%=uiComponentClass%> EdittingContainer<%=uicomponent.getPermissionClasses()%>" 
 				id="${uicomponent.id}">
 <%
   }
   else
   {   
 %>
-<div class="UIContainer UITableColumnContainer <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
+<div class="UIContainer UITableColumnContainer <%=uiComponentClass%> <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITableColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITableColumnContainer.gtmpl
@@ -19,6 +19,8 @@
 		uicomponent.setId(componentId.substring("UIContainer-".length()));
 	}
 
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	if (uiPortalApp.isEditing())
 	{
 	   JavascriptManager jsManager = rcontext.getJavascriptManager();
@@ -26,14 +28,14 @@
 	  				.addScripts("portalDragDrop.init(['UIContainer']);")
 	  				.addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>  
-<div class="UIContainer UITableColumnContainer EdittingContainer<%=uicomponent.getPermissionClasses()%>"
+<div class="UIContainer UITableColumnContainer <%=uiComponentClass%> EdittingContainer<%=uicomponent.getPermissionClasses()%>"
 				id="${uicomponent.id}">
 <%
   }
   else
   {   
 %>
-<div class="UIContainer UITableColumnContainer <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
+<div class="UIContainer UITableColumnContainer <%=uiComponentClass%> <%=hasAccessPermission?"":"ProtectedContainer"%>" id="${uicomponent.id}">
 <%
   }
 %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITopBarContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITopBarContainer.gtmpl
@@ -12,11 +12,13 @@
 	
 	if(!uiPortalApp.isEditing() && !hasPermission) return;
 	
+  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
+
 	JavascriptManager jsmanager = rcontext.getJavascriptManager();
 	jsmanager.require("SHARED/portal", "portal").
 	addScripts("portal.UIPortal.initMouseHover('" + uicomponent.id + "');");
 %>
-<div id="UITopBarContainerParent">
+<div id="UITopBarContainerParent" class="<%=uiComponentClass%>">
   <div class="UIContainer UITopBarContainer <%=uiPortalApp.isEditing()?"EdittingContainer":""%> <%=hasPermission?"": "ProtectedContainer"%>" id="${uicomponent.id}">
   	<div class="NormalContainerBlock">
   	<%

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UIContainer.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UIContainer.java
@@ -42,6 +42,10 @@ public class UIContainer extends UIPortalComponent {
 
     protected String description;
 
+    protected String cssClass;
+
+    protected String profiles;
+
     protected String[] moveContainersPermissions;
 
     protected String[] moveAppsPermissions;
@@ -73,6 +77,21 @@ public class UIContainer extends UIPortalComponent {
         this.description = desc;
     }
 
+    public String getCssClass() {
+      return cssClass;
+    }
+
+    public void setCssClass(String cssClass) {
+      this.cssClass = cssClass;
+    }
+
+    public String getProfiles() {
+      return profiles;
+    }
+
+    public void setProfiles(String profiles) {
+      this.profiles = profiles;
+    }
 
     public String[] getMoveContainersPermissions() {
         return moveContainersPermissions;

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
@@ -85,6 +85,8 @@ public class PortalDataMapper {
         model.setDescription(uiContainer.getDescription());
         model.setHeight(uiContainer.getHeight());
         model.setWidth(uiContainer.getWidth());
+        model.setCssClass(uiContainer.getCssClass());
+        model.setProfiles(uiContainer.getProfiles());
         model.setTemplate(uiContainer.getTemplate());
         model.setFactoryId(uiContainer.getFactoryId());
         model.setAccessPermissions(uiContainer.getAccessPermissions());
@@ -246,6 +248,8 @@ public class PortalDataMapper {
         uiContainer.setId(model.getId());
         uiContainer.setWidth(model.getWidth());
         uiContainer.setHeight(model.getHeight());
+        uiContainer.setProfiles(model.getProfiles());
+        uiContainer.setCssClass(model.getCssClass());
         uiContainer.setTitle(model.getTitle());
         uiContainer.setIcon(model.getIcon());
         uiContainer.setDescription(model.getDescription());


### PR DESCRIPTION
When uninstalling some addons, the pages that defines portlets / applications defined by deleted addons gets buggy with error message 'Portlet not found'. Knowing that each addon defines its own Kernel profile when installed, this improvement makes it easy to disable a container with its applications in rendering phase, when the Kernel profile isn't present.
Another attribute is added in Container definition in pages.xml file that allows to define a list of CSS Classes to use in container Parent.