### PR TITLE
Fix Parent Container Class retrieving when editing a page layout

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIContainerList.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIContainerList.gtmpl
@@ -4,13 +4,11 @@
 	def categories = uicomponent.getCategories();
 	def selectedCategory = uicomponent.getSelectedCategory();
 	
-  String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
-
 	def rcontext = _ctx.getRequestContext();
 	JavascriptManager jsManager = rcontext.getJavascriptManager();
 	jsManager.require("SHARED/portalDragDrop", "portalDragDrop").addScripts("portalDragDrop.init(['DragObjectPortlet']);");
 %>	
-<div class="uiContainerList <%=uiComponentClass%>" id="$uicomponent.id">
+<div class="uiContainerList id="$uicomponent.id">
 	<div class="accordion verticalTabStyle1">
  		<% 
  			String cTab, cName, description, displayName;


### PR DESCRIPTION
When editing a page layout the UIContainerList.gtmpl is used that disn't inherit from org.exoplatform.portal.webui.container.UIContainer, thus the new methods getProfiles and getCssClass aren't available