### PR TITLE
Switch default Cluster configuration to use TCP instead of UDP

### DIFF
--- a/component/common/src/main/resources/conf/configuration.xml
+++ b/component/common/src/main/resources/conf/configuration.xml
@@ -54,12 +54,12 @@
       <properties-param profiles="cluster">
         <name>JGroupsProperties</name>
         <description>Jgroups configuration</description>
-        <property name="exo.service.cluster.jgroups.config" value="jar:/conf/jgroups/jgroups-service-udp.xml" />
+        <property name="exo.service.cluster.jgroups.config" value="jar:/conf/jgroups/jgroups-service-tcp.xml" />
       </properties-param>
-      <properties-param profiles="cluster-jgroups-tcp">
+      <properties-param profiles="cluster-jgroups-udp">
         <name>JGroupsProperties</name>
         <description>Jgroups configuration</description>
-        <property name="exo.service.cluster.jgroups.config" value="jar:/conf/jgroups/jgroups-service-tcp.xml" />
+        <property name="exo.service.cluster.jgroups.config" value="jar:/conf/jgroups/jgroups-service-udp.xml" />
       </properties-param>
     </init-params>
   </component>


### PR DESCRIPTION
Since UDP is deprecated for production environments, we will have to switch default configuration to use TCP by default instead.