### PR TITLE
Optimize fetched resources caching in browser side

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/branding/Branding.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/branding/Branding.java
@@ -15,6 +15,8 @@ public class Branding implements Serializable {
 
   private Map<String, String> themeColors      = new HashMap<>();
 
+  private long                lastUpdatedTime;
+
   public Branding() {
   }
 
@@ -48,6 +50,14 @@ public class Branding implements Serializable {
 
   public void setThemeColors(Map<String, String> themeColors) {
     this.themeColors = themeColors;
+  }
+
+  public long getLastUpdatedTime() {
+    return lastUpdatedTime;
+  }
+
+  public void setLastUpdatedTime(long lastUpdatedTime) {
+    this.lastUpdatedTime = lastUpdatedTime;
   }
 
   @Override

--- a/component/portal/src/main/java/org/exoplatform/portal/branding/BrandingService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/branding/BrandingService.java
@@ -1,9 +1,17 @@
 package org.exoplatform.portal.branding;
 
+import java.util.Map;
+
 public interface BrandingService {
 
   Branding getBrandingInformation();
 
+  /**
+   * Update the branding information Missing information in the branding object
+   * are not updated.
+   * 
+   * @param branding The new branding information
+   */
   void updateBrandingInformation(Branding branding);
 
   String getCompanyName();
@@ -20,11 +28,45 @@ public interface BrandingService {
 
   void updateTopBarTheme(String style);
 
+  /**
+   * Update branding logo. If the logo object contains the image data, they are
+   * used, otherwise if the uploadId exists it is used to retrieve the uploaded
+   * resource. If there is no data, nor uploadId, the logo is deleted.
+   * 
+   * @param logo The logo object
+   */
   void updateLogo(Logo logo);
 
   /**
    * @return CSS content of colors for theme
    */
   String getThemeCSSContent();
+
+  /**
+   * Updated last updated time of one of Branding properties
+   * 
+   * @param lastUpdatedTimestamp Timestamp in milliseconds
+   */
+  void updateLastUpdatedTime(long lastUpdatedTimestamp);
+
+  /**
+   * @return last updated time in milliseconds
+   */
+  long getLastUpdatedTime();
+
+  /**
+   * Updates CSS variables that defines the chosen theme and that will be
+   * applied and server on UI
+   * 
+   * @param themeColors {@link Map} with variable name as key and variable value
+   *          as map value
+   */
+  void updateThemeColors(Map<String, String> themeColors);
+
+  /**
+   * @return {@link Map} with variable name as key and variable value
+   *          as map value
+   */
+  Map<String, String> getThemeColors();
 
 }

--- a/component/portal/src/test/java/org/exoplatform/portal/branding/BrandingServiceImplTest.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/branding/BrandingServiceImplTest.java
@@ -241,7 +241,7 @@ public class BrandingServiceImplTest {
     brandingService.updateBrandingInformation(newBranding);
 
     // Then
-    verify(settingService, times(4)).set(settingContext.capture(), settingScope.capture(), settingKey.capture(), settingValue.capture());
+    verify(settingService, times(5)).set(settingContext.capture(), settingScope.capture(), settingKey.capture(), settingValue.capture());
     verify(settingService, times(1)).remove(eq(BrandingServiceImpl.BRANDING_CONTEXT), eq(BrandingServiceImpl.BRANDING_SCOPE), eq("secondaryColor"));
     verify(settingService, times(1)).remove(eq(BrandingServiceImpl.BRANDING_CONTEXT), eq(BrandingServiceImpl.BRANDING_SCOPE), eq("secondaryBackground"));
 
@@ -314,7 +314,7 @@ public class BrandingServiceImplTest {
     brandingService.updateBrandingInformation(newBranding);
 
     // Then
-    verify(settingService, times(1)).set(settingContextArgumentCaptor.capture(), settingScopeArgumentCaptor.capture(), settingKeyArgumentCaptor.capture(), settingValueArgumentCaptor.capture());
+    verify(settingService, times(2)).set(settingContextArgumentCaptor.capture(), settingScopeArgumentCaptor.capture(), settingKeyArgumentCaptor.capture(), settingValueArgumentCaptor.capture());
     verify(fileService, times(1)).writeFile(fileItemArgumentCaptor.capture());
     List<Context> contexts = settingContextArgumentCaptor.getAllValues();
     List<Scope> scopes = settingScopeArgumentCaptor.getAllValues();
@@ -370,7 +370,7 @@ public class BrandingServiceImplTest {
     brandingService.updateBrandingInformation(newBranding);
 
     // Then
-    verify(settingService, times(1)).set(settingContextArgumentCaptor.capture(), settingScopeArgumentCaptor.capture(), settingKeyArgumentCaptor.capture(), settingValueArgumentCaptor.capture());
+    verify(settingService, times(2)).set(settingContextArgumentCaptor.capture(), settingScopeArgumentCaptor.capture(), settingKeyArgumentCaptor.capture(), settingValueArgumentCaptor.capture());
     verify(fileService, times(1)).writeFile(fileItemArgumentCaptor.capture());
     List<Context> contexts = settingContextArgumentCaptor.getAllValues();
     List<Scope> scopes = settingScopeArgumentCaptor.getAllValues();

--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginServlet.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginServlet.java
@@ -198,7 +198,7 @@ public class LoginServlet extends AbstractHttpServlet {
                     }
 
                     // Handle remember me
-                    String rememberme = req.getParameter("rememberme");
+                    String rememberme = req.getParameter(COOKIE_NAME);
                     if ("true".equals(rememberme)) {
                         // Create token for credentials
                         CookieTokenService tokenService = AbstractTokenService.getInstance(CookieTokenService.class);
@@ -208,7 +208,7 @@ public class LoginServlet extends AbstractHttpServlet {
                                     + " for it and set it up " + "in the next response");
                         }
                         Cookie cookie = new Cookie(COOKIE_NAME, cookieToken);
-                        cookie.setPath(req.getContextPath());
+                        cookie.setPath("/");
                         cookie.setHttpOnly(true);
                         cookie.setMaxAge((int) tokenService.getValidityTime());
                         resp.addCookie(cookie);
@@ -220,7 +220,7 @@ public class LoginServlet extends AbstractHttpServlet {
                             CookieTokenService tokenService = AbstractTokenService.getInstance(CookieTokenService.class);
                             String cookieToken = tokenService.createToken(credentials);
                             Cookie cookie = new Cookie(OAUTH_COOKIE_NAME, cookieToken);
-                            cookie.setPath(req.getContextPath());
+                            cookie.setPath("/");
                             cookie.setMaxAge((int) tokenService.getValidityTime());
                             resp.addCookie(cookie);
 

--- a/portlet/web/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/portlet/web/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -54,6 +54,9 @@
         <as>$</as>
       </depends>
       <depends>
+        <module>HamburgerMenu</module>
+      </depends>
+      <depends>
         <module>extensionRegistry</module>
       </depends>
     </module>
@@ -81,6 +84,9 @@
       <depends>
         <module>jquery</module>
         <as>$</as>
+      </depends>
+      <depends>
+        <module>HamburgerMenu</module>
       </depends>
       <depends>
         <module>extensionRegistry</module>

--- a/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -62,6 +62,7 @@
   <!-- Base Javascripts for anonymous mode -->
   <module>
     <name>topbarLoading</name>
+    <load-group>baseGRP</load-group>
     <script>
       <path>/javascript/eXo/core/TopbarLoading.js</path>
     </script>
@@ -901,6 +902,7 @@
 
   <module>
     <name>bodyScrollListener</name>
+    <load-group>baseGRP</load-group>
     <script>
       <path>/javascript/eXo/portal/BodyScrollListener.js</path>
     </script>

--- a/web/portal/src/main/webapp/WEB-INF/conf/pwa/service-worker.js
+++ b/web/portal/src/main/webapp/WEB-INF/conf/pwa/service-worker.js
@@ -38,7 +38,7 @@ const cachesWhiteList = [
   manifestCacheName];
 
 workbox.routing.registerRoute(
-  new RegExp('.*manifest.json$'),
+  new RegExp('.*manifest.json.*'),
   new workbox.strategies.CacheFirst({
     cacheName: manifestCacheName,
   }),
@@ -61,7 +61,7 @@ if (!development) {
 
   workbox.routing.registerRoute(
     new RegExp('.*/rest/v1/platform/branding/css.*'),
-    new workbox.strategies.StaleWhileRevalidate({
+    new workbox.strategies.CacheFirst({
       cacheName: cssCacheName,
     }),
   );
@@ -135,9 +135,10 @@ const domMatcher = ({url, request, event}) => {
 
 const domHandler = async ({url, request, event, params}) => {
   const response = await fetch(request);
+  const headers = response.headers;
   if (response.status !== 200
-      || !response.headers.has('content-type')
-      || !response.headers.get('content-type').includes('text/html')) {
+      || !headers.has('content-type')
+      || !headers.get('content-type').includes('text/html')) {
     return response;
   }
 
@@ -161,7 +162,8 @@ const domHandler = async ({url, request, event, params}) => {
     console.error('Error while treating DOM caches of URL', url, e);
   }
   return new Response(html, {
-    headers: {'content-type': 'text/html;charset=UTF-8'},
+    headers: response.headers,
+    status: response.status,
   });
 };
 

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -80,7 +80,7 @@
     <link rel="shortcut icon" type="image/x-icon"  href="<%=docBase%>/favicon.ico" />
 
     <!-- Styles -->
-    <link id="brandingSkin" rel="stylesheet" type="text/css" href="/portal/rest/v1/platform/branding/css">
+    <link id="brandingSkin" rel="stylesheet" type="text/css" href="<%=uicomponent.getBrandingUrl()%>">
     <% for (skinConfig in portalSkins) {
          def url = skinConfig.createURL(rcontext.controllerContext);
          url.setOrientation(orientation); %>
@@ -103,7 +103,6 @@
     </script>
 
     <% for (url in headerScripts) { %>
-      <link rel="preload" href= "$url" as="script" type="text/javascript" />
       <script type="text/javascript" src="<%= url %>"></script>
     <% } %>
 

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalPWAHead.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalPWAHead.gtmpl
@@ -7,7 +7,7 @@ def rcontext = _ctx.getRequestContext() ;
 /* Loading Manifest and Service Worker configuration script at top of the head */
 def version = ResourceRequestHandler.VERSION;
 %>
-    <link rel="manifest" href="/portal/manifest.json">
+    <link rel="manifest" href="/portal/manifest.json?v=<%=version%>">
 
     <link rel="apple-touch-icon" href="/digital-workplace/skin/images/eXo.png">
 
@@ -31,40 +31,36 @@ def version = ResourceRequestHandler.VERSION;
 <%
 /* Loading needed Fonts files in top of the page as a 'preload' resource to include it in response when using HTTP/2 */
 %>
-
-<%
-/* Loading needed stylesheets in top of the page as a 'preload' resource to include it in response when using HTTP/2 */
-
-def portalSkins = uicomponent.getPortalSkins();
-def portletSkins = uicomponent.getPortletSkins();
-def customSkins = uicomponent.getCustomSkins();
-%>
-
-  <link id="brandingSkin" rel="preload" as="style" type="text/css" href="/portal/rest/v1/platform/branding/css">
-
   <!-- Fonts Preload -->
   <link rel="preload" href="/eXoSkin/skin/fonts/vuetify/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/eXoSkin/skin/fonts/vuetify/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/eXoSkin/skin/fonts/vuetify/materialdesignicons-webfont.woff2?v=3.9.97" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/eXoSkin/skin/fonts/Ionic/ionicons.ttf" as="font" type="font/ttf" crossorigin>
   <link rel="preload" href="/eXoSkin/skin/fonts/PLF-FONT-ICONS.ttf?-m9uidt" as="font" type="font/ttf" crossorigin>
-
-<% for (skinConfig in portalSkins) {
+<%
+// Loading needed stylesheets in top of the page as a 'preload' resource to include it in response
+%>
+  <link rel="preload" as="style" type="text/css" href="<%=uicomponent.getBrandingUrl()%>">
+<%
+// Loading needed stylesheets in top of the page as a 'preload' resource to include it in response
+def portalSkins = uicomponent.getPortalSkins();
+def portletSkins = uicomponent.getPortletSkins();
+def customSkins = uicomponent.getCustomSkins();
+   for (skinConfig in portalSkins) {
      def url = skinConfig.createURL(rcontext.controllerContext);
      url.setOrientation(orientation); %>
   <link rel="preload" href= "$url" as="style" type="text/css" />
-<% } %>
-<% for (portletSkin in portletSkins) {
+<% }
+   for (portletSkin in portletSkins) {
      def url = portletSkin.createURL(rcontext.controllerContext);
      url.setOrientation(orientation); %>
   <link rel="preload" href= "$url" as="style" type="text/css" />
-<% } %>
-<% for (customSkin in customSkins) {
+<% }
+   for (customSkin in customSkins) {
      def url = customSkin.createURL(rcontext.controllerContext);
      url.setOrientation(orientation); %>
   <link rel="preload" href= "$url" as="style" type="text/css" />
-<% } %>
-<%
+<% }
 def jsManager = rcontext.getJavascriptManager();
 
 def jsConfig = uicomponent.getJSConfig();
@@ -82,8 +78,5 @@ for (scriptsId in scriptsIds) {
 for (scriptPath in scriptPaths.keySet()) {
   def isRemote = scriptPaths.get(scriptPath);
 %>
-  <!-- $scriptPath -->
   <link rel="preload" href= "$scriptPath" as="script" type="text/javascript" <%=isRemote ? "crossorigin" : "" %>/>
-<%
-}
-%>
+<% } %>

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -22,9 +22,12 @@ package org.exoplatform.portal.webui.workspace;
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.commons.utils.Safe;
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.Constants;
 import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.application.RequestNavigationData;
+import org.exoplatform.portal.branding.BrandingRestResourcesV1;
+import org.exoplatform.portal.branding.BrandingService;
 import org.exoplatform.portal.config.DataStorage;
 import org.exoplatform.portal.config.UserPortalConfig;
 import org.exoplatform.portal.config.model.Container;
@@ -577,6 +580,13 @@ public class UIPortalApplication extends UIApplication {
             skins.add(skinConfig);
         }
         return skins;
+    }
+
+    public String getBrandingUrl() {
+      BrandingService brandingService = getApplicationComponent(BrandingService.class);
+      long lastUpdatedTime = brandingService.getLastUpdatedTime();
+      return "/" + PortalContainer.getCurrentPortalContainerName() + "/" + PortalContainer.getCurrentRestContextName()
+          + "/v1/platform/branding/css?v=" + lastUpdatedTime;
     }
 
     private Set<SkinConfig> getPortalPortletSkins() {

--- a/webui/portlet/src/main/java/org/exoplatform/webui/application/portlet/ParentAppStateManager.java
+++ b/webui/portlet/src/main/java/org/exoplatform/webui/application/portlet/ParentAppStateManager.java
@@ -37,7 +37,10 @@ public class ParentAppStateManager extends StateManager {
 
     @SuppressWarnings("unused")
     public void storeUIRootComponent(WebuiRequestContext context) throws Exception {
-        WebuiRequestContext pcontext = (WebuiRequestContext) context.getParentAppRequestContext();
+        WebuiRequestContext pcontext = context;
+        while (pcontext.getParentAppRequestContext() != null) {
+          pcontext = (WebuiRequestContext) context.getParentAppRequestContext();
+        }
         pcontext.getStateManager().storeUIRootComponent(context);
     }
 


### PR DESCRIPTION
This PR aims to improve resources fetching by :
- Allowing to reuse RememberMe Cookie on REST calls when user session timed out (by changing parent path of cookie)
- Adding a lastUpdateTime on Branding CSS to allow cache it efficiently in browser
- Group fetching of `baseGRP` resources that englobes multiple base functions that are widely used in all pages
- Fix Service worker to retrieve the same headers of retrieved HTML documents from Server End