### PR TITLE
MAINT-36221: if user locale is fr_FR, login page is in english (#103)

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/web.xml
+++ b/web/portal/src/main/webapp/WEB-INF/web.xml
@@ -193,6 +193,7 @@
   <filter-mapping>
     <filter-name>LocalizationFilter</filter-name>
     <url-pattern>*.jsp</url-pattern>
+    <url-pattern>/login</url-pattern>
     <url-pattern>/rest/*</url-pattern>
     <dispatcher>INCLUDE</dispatcher>
     <dispatcher>FORWARD</dispatcher>


### PR DESCRIPTION
Prior to this fix the login page was in english if user main locale is fr_FR
This fix add the LocalizationFilter on url /portal/login, which is able to use locale fr if user have locale fr_FR

(cherry picked from commit 74b1f6aec9204374d172bdec0bd218aefd40c0fd)