### PR TITLE
Task-36579 : Add type on token

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/onboarding/OnboardingHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/onboarding/OnboardingHandler.java
@@ -46,6 +46,7 @@ import javax.servlet.http.HttpSession;
 import nl.captcha.text.producer.DefaultTextProducer;
 import nl.captcha.text.renderer.DefaultWordRenderer;
 import org.apache.tools.ant.taskdefs.condition.Http;
+import org.exoplatform.web.security.security.RemindPasswordTokenService;
 import org.gatein.common.logging.Logger;
 import org.gatein.common.logging.LoggerFactory;
 import org.gatein.wci.security.Credentials;
@@ -120,6 +121,7 @@ public class OnboardingHandler extends WebRequestHandler {
         PasswordRecoveryServiceImpl service = getService(PasswordRecoveryServiceImpl.class);
         ResourceBundleService bundleService = getService(ResourceBundleService.class);
         ResourceBundle bundle = bundleService.getResourceBundle(bundleService.getSharedResourceBundleNames(), locale);
+        RemindPasswordTokenService remindPasswordTokenService= getService(RemindPasswordTokenService.class);
 
         String token = context.getParameter(TOKEN);
     
@@ -135,7 +137,7 @@ public class OnboardingHandler extends WebRequestHandler {
             String tokenId = context.getParameter(TOKEN);
 
             //. Check tokenID is expired or not
-            Credentials credentials = service.verifyToken(tokenId);
+            Credentials credentials = service.verifyToken(tokenId,remindPasswordTokenService.ONBOARD_TOKEN);
             if (credentials == null) {
                 //. TokenId is expired
                 return dispatch("/onboarding/jsp/token_expired.jsp", servletContext, req, res);

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryHandler.java
@@ -32,6 +32,7 @@ import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.services.resources.LocaleContextInfo;
 import org.exoplatform.services.resources.LocalePolicy;
 
+import org.exoplatform.web.security.security.RemindPasswordTokenService;
 import org.gatein.common.logging.Logger;
 import org.gatein.common.logging.LoggerFactory;
 
@@ -104,6 +105,7 @@ public class PasswordRecoveryHandler extends WebRequestHandler {
 
         PasswordRecoveryServiceImpl service = getService(PasswordRecoveryServiceImpl.class);
         ResourceBundleService bundleService = getService(ResourceBundleService.class);
+        RemindPasswordTokenService remindPasswordTokenService= getService(RemindPasswordTokenService.class);
         OrganizationService orgService = getService(OrganizationService.class);
         ResourceBundle bundle = bundleService.getResourceBundle(bundleService.getSharedResourceBundleNames(), locale);
 
@@ -116,7 +118,7 @@ public class PasswordRecoveryHandler extends WebRequestHandler {
             String tokenId = context.getParameter(TOKEN);
 
             //. Check tokenID is expired or not
-            Credentials credentials = service.verifyToken(tokenId);
+            Credentials credentials = service.verifyToken(tokenId,remindPasswordTokenService.FORGOT_PASSWORD_TOKEN);
             if (credentials == null) {
                 //. TokenId is expired
                 return dispatch("/forgotpassword/jsp/token_expired.jsp", servletContext, req, res);

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryService.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryService.java
@@ -33,7 +33,7 @@ import java.util.Locale;
 public interface PasswordRecoveryService {
   void addConnector(ChangePasswordConnector connector);
 
-  Credentials verifyToken(String tokenId);
+  Credentials verifyToken(String tokenId, String type);
 
   boolean changePass(final String tokenId, final String username, final String password);
 

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryService.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryService.java
@@ -34,7 +34,10 @@ public interface PasswordRecoveryService {
   void addConnector(ChangePasswordConnector connector);
 
   Credentials verifyToken(String tokenId, String type);
-
+  
+  Credentials verifyToken(String tokenId);
+  
+  
   boolean changePass(final String tokenId, final String username, final String password);
 
   public boolean sendRecoverPasswordEmail(User user, Locale defaultLocale, HttpServletRequest req);

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
@@ -98,6 +98,11 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
     }
     
     @Override
+    public Credentials verifyToken(String tokenId) {
+        return verifyToken(tokenId,"");
+    }
+    
+    @Override
     public boolean allowChangePassword(String username) throws Exception {
       User user = orgService.getUserHandler().findUserByName(username);//To be changed later by checking internal store information from social user profile
       return user != null && (user.isInternalStore() || this.changePasswordConnectorMap.get(this.changePasswordConnectorName).isAllowChangeExternalPassword());

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
@@ -89,8 +89,8 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
     
     
     @Override
-    public Credentials verifyToken(String tokenId) {
-        Token token = remindPasswordTokenService.getToken(tokenId);
+    public Credentials verifyToken(String tokenId, String type) {
+        Token token = remindPasswordTokenService.getToken(tokenId,type);
         if (token == null || token.isExpired()) {
             return null;
         }
@@ -129,7 +129,7 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
         ResourceBundle bundle = bundleService.getResourceBundle(bundleService.getSharedResourceBundleNames(), locale);
 
         Credentials credentials = new Credentials(user.getUserName(), "");
-        String tokenId = remindPasswordTokenService.createToken(credentials);
+        String tokenId = remindPasswordTokenService.createToken(credentials, remindPasswordTokenService.ONBOARD_TOKEN);
         StringBuilder redirectUrl = new StringBuilder();
         redirectUrl.append(url);
         redirectUrl.append("/" + OnboardingHandler.NAME);
@@ -190,7 +190,7 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
         ResourceBundle bundle = bundleService.getResourceBundle(bundleService.getSharedResourceBundleNames(), locale);
 
         Credentials credentials = new Credentials(user.getUserName(), "");
-        String tokenId = remindPasswordTokenService.createToken(credentials);
+        String tokenId = remindPasswordTokenService.createToken(credentials,remindPasswordTokenService.FORGOT_PASSWORD_TOKEN);
 
         Router router = webController.getRouter();
         Map<QualifiedName, String> params = new HashMap<>();

--- a/component/web/security/src/main/java/org/exoplatform/web/security/security/AbstractTokenService.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/security/AbstractTokenService.java
@@ -192,9 +192,13 @@ public abstract class AbstractTokenService<T extends Token, K> implements Starta
     }
 
     public abstract T getToken(K id);
-
+    
+    public abstract T getToken(K id, String tokenType);
+    
+    
     public abstract T deleteToken(K id);
-
+    
+    public abstract T deleteToken(K id, String tokenType);
     /**
      * Decode a key from its string representation.
      *

--- a/component/web/security/src/main/java/org/exoplatform/web/security/security/TransientTokenService.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/security/TransientTokenService.java
@@ -50,20 +50,29 @@ public class TransientTokenService extends PlainTokenService<GateInToken, String
     }
 
     @Override
-    public GateInToken getToken(String id) {
+    public GateInToken getToken(String id, String type) {
         return tokens.get(id);
+    }
+    
+    @Override
+    public GateInToken getToken(String id) {
+        return getToken(id,"");
     }
 
     @Override
     protected String decodeKey(String stringKey) {
         return stringKey;
     }
-
+    
     @Override
-    public GateInToken deleteToken(String id) {
+    public GateInToken deleteToken(String id,String tokenType) {
         GateInToken token = tokens.get(id);
         tokens.remove(id);
         return token;
+    }
+    @Override
+    public GateInToken deleteToken(String id) {
+        return deleteToken(id,"");
     }
 
     @Override

--- a/component/web/security/src/test/java/org/exoplatform/web/security/AbstractCookieTokenServiceTest.java
+++ b/component/web/security/src/test/java/org/exoplatform/web/security/AbstractCookieTokenServiceTest.java
@@ -31,6 +31,7 @@ import org.exoplatform.web.security.security.CookieTokenService;
 
 @ConfiguredBy({ @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/tokenservice-configuration.xml") })
 public abstract class AbstractCookieTokenServiceTest extends AbstractTokenServiceTest<CookieTokenService> {
+    public String type="testType";
 
     @Override
     public void testGetToken() throws Exception {
@@ -77,6 +78,53 @@ public abstract class AbstractCookieTokenServiceTest extends AbstractTokenServic
         assertEquals(0, service.size());
 
         service.deleteToken(tokenId1);
+    }
+    
+    @Override
+    public void testGetTokenWithType() throws Exception {
+        String tokenId = service.createToken(new Credentials("root", "gtn"),type);
+        assertEquals(service.getValidityTime(), 2);
+        
+        GateInToken token = service.getToken(tokenId,type);
+        assertEquals(token.getPayload().getUsername(), "root");
+        assertEquals(token.getPayload().getPassword(), "gtn");
+        service.deleteToken(tokenId,type);
+    }
+    
+    @Override
+    public void testGetAllTokenWithType() throws Exception {
+        /* Do nothing there is no CookieTokenService.getAllTokens(); */
+    }
+    
+    @Override
+    public void testSizeWithType() throws Exception {
+        String token = service.createToken(new Credentials("root", "gtn"),type);
+        assertEquals(service.size(), 1);
+        service.deleteToken(token,type);
+    }
+    
+    @Override
+    public void testDeleteTokenWithType() throws Exception {
+        String tokenId = service.createToken(new Credentials("root", "gtn"),type);
+        GateInToken deletedToken = service.deleteToken(tokenId,type);
+        assertNotNull(deletedToken);
+        assertNotSame(service.getToken(tokenId,type), deletedToken);
+        assertNull(service.getToken(tokenId,type));
+        assertEquals(0, service.size());
+        service.deleteToken(tokenId,type);
+    }
+    
+    @Override
+    public void testCleanExpiredTokensWithType() throws Exception {
+        assertEquals(2, service.getValidityTime());
+        String tokenId1 = service.createToken(new Credentials("user1", "gtn"),type);
+        assertEquals(1, service.size());
+        
+        Thread.sleep(2100);
+        service.cleanExpiredTokens();
+        assertEquals(0, service.size());
+        
+        service.deleteToken(tokenId1,type);
     }
 
 }

--- a/component/web/security/src/test/java/org/exoplatform/web/security/AbstractTokenServiceTest.java
+++ b/component/web/security/src/test/java/org/exoplatform/web/security/AbstractTokenServiceTest.java
@@ -51,4 +51,14 @@ public abstract class AbstractTokenServiceTest<S extends AbstractTokenService<?,
     public abstract void testDeleteToken() throws Exception;
 
     public abstract void testCleanExpiredTokens() throws Exception;
+    
+    public abstract void testGetTokenWithType() throws Exception;
+    
+    public abstract void testGetAllTokenWithType() throws Exception;
+    
+    public abstract void testSizeWithType() throws Exception;
+    
+    public abstract void testDeleteTokenWithType() throws Exception;
+    
+    public abstract void testCleanExpiredTokensWithType() throws Exception;
 }

--- a/component/web/security/src/test/java/org/exoplatform/web/security/SimpleGeneratorCookieTokenService.java
+++ b/component/web/security/src/test/java/org/exoplatform/web/security/SimpleGeneratorCookieTokenService.java
@@ -45,6 +45,11 @@ public class SimpleGeneratorCookieTokenService extends CookieTokenService {
         super(replaceHashService(initParams), tokenStore, codecInitializer);
     }
 
+    
+    public void resetCounter() {
+        counter=0;
+        noRandom=0;
+    }
     /**
      * @param initParams
      * @return

--- a/component/web/security/src/test/java/org/exoplatform/web/security/TestSimpleGeneratorService.java
+++ b/component/web/security/src/test/java/org/exoplatform/web/security/TestSimpleGeneratorService.java
@@ -34,6 +34,7 @@ import org.exoplatform.container.PortalContainer;
 @ConfiguredBy({ @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/tokenservice-configuration.xml") })
 public class TestSimpleGeneratorService extends AbstractKernelTest {
     private SimpleGeneratorCookieTokenService service;
+    String type="testtype";
 
     protected void setUp() throws Exception {
         PortalContainer container = getContainer();
@@ -49,6 +50,7 @@ public class TestSimpleGeneratorService extends AbstractKernelTest {
      * Test that duplicated token is never generated
      */
     public void testDuplicatedTokenGeneration() throws Exception {
+        service.resetCounter();
         String token1 = service.createToken(new Credentials("root1", "gtn1"));
         assertEquals("random0.rememberme0", token1);
         assertEquals(service.getCounter(), 1);
@@ -65,5 +67,46 @@ public class TestSimpleGeneratorService extends AbstractKernelTest {
         assertEquals("root1", service.getToken(token1).getPayload().getUsername());
         assertEquals("root2", service.getToken(token2).getPayload().getUsername());
         assertEquals("-root3", service.getToken(token3).getPayload().getUsername());
+        
+        service.deleteToken(token1);
+        service.deleteToken(token2);
+        service.deleteToken(token3);
+    }
+    
+    /**
+     * Test that duplicated token is never generated
+     */
+    public void testDuplicatedTokenWithTypeGeneration() throws Exception {
+        service.resetCounter();
+        String token1 = service.createToken(new Credentials("root1", "gtn1"),type);
+        assertEquals("random0.rememberme0", token1);
+        assertEquals(service.getCounter(), 1);
+        
+        String token2 = service.createToken(new Credentials("root2", "gtn2"),type);
+        assertEquals("random1.rememberme1", token2);
+        assertEquals(service.getCounter(), 2);
+        
+        String token3 = service.createToken(new Credentials("-root3", "gtn3"),type);
+        assertEquals("random2.rememberme2", token3);
+        // Counter should be 4 now due to duplicated token generation
+        assertEquals(service.getCounter(), 4);
+        
+        assertEquals("root1", service.getToken(token1,type).getPayload().getUsername());
+        assertEquals("root2", service.getToken(token2,type).getPayload().getUsername());
+        assertEquals("-root3", service.getToken(token3,type).getPayload().getUsername());
+    
+        service.deleteToken(token1,type);
+        service.deleteToken(token2,type);
+        service.deleteToken(token3,type);
+    }
+    
+    public void testTokenValidationWithDifferentTypes() throws Exception {
+        service.resetCounter();
+        String token1 = service.createToken(new Credentials("root1", "gtn1"),type);
+        assertEquals("random0.rememberme0", token1);
+        assertEquals(service.getCounter(), 1);
+        assertNull(service.getToken(token1,"otherType"));
+        service.deleteToken(token1,type);
+    
     }
 }

--- a/component/web/security/src/test/java/org/exoplatform/web/security/TestTransientTokenService.java
+++ b/component/web/security/src/test/java/org/exoplatform/web/security/TestTransientTokenService.java
@@ -93,4 +93,32 @@ public class TestTransientTokenService extends AbstractTokenServiceTest<Transien
 
         service.deleteToken(tokenId1);
     }
+    
+    @Override
+    public void testGetTokenWithType() throws Exception {
+        //TransientTokenService have no type for token
+    }
+    
+    @Override
+    public void testGetAllTokenWithType() throws Exception {
+        //TransientTokenService have no type for token
+    }
+    
+    @Override
+    public void testSizeWithType() throws Exception {
+        //TransientTokenService have no type for token
+    
+    }
+    
+    @Override
+    public void testDeleteTokenWithType() throws Exception {
+        //TransientTokenService have no type for token
+    
+    }
+    
+    @Override
+    public void testCleanExpiredTokensWithType() throws Exception {
+        //TransientTokenService have no type for token
+    
+    }
 }

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/login/UIForgetPassword.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/login/UIForgetPassword.java
@@ -127,7 +127,7 @@ public class UIForgetPassword extends UIForm {
             // Create token
             RemindPasswordTokenService tokenService = uiForm.getApplicationComponent(RemindPasswordTokenService.class);
             Credentials credentials = new Credentials(user.getUserName(), "");
-            tokenId = tokenService.createToken(credentials);
+            tokenId = tokenService.createToken(credentials,tokenService.FORGOT_PASSWORD_TOKEN);
 
             String portalName = URLEncoder.encode(Util.getUIPortal().getName(), "UTF-8");
 


### PR DESCRIPTION
Before this commit, the token is used for forgot-password, onboarding, and external users registration. So the token for external users registration can be used to make the onboarding
This commit add a type on token so that the forgot-password token can be used only for forgot password, and so on for other types