### PR TITLE
TASK-36120 Allow to externalize jGroups configuration file

### DIFF
--- a/component/common/src/main/resources/conf/cache/infinispan/cluster/cache-async-config.xml
+++ b/component/common/src/main/resources/conf/cache/infinispan/cluster/cache-async-config.xml
@@ -43,7 +43,7 @@
     </threads>
 
     <jgroups transport="org.infinispan.remoting.transport.jgroups.JGroupsTransport">
-        <stack-file name="stack" path="${exo.service.cluster.jgroups.config}"/>
+      <stack-file name="stack" path="${exo.service.cluster.jgroups.config:jar:/conf/jgroups/jgroups-service-tcp.xml}"/>
     </jgroups>
 
     <cache-container name="template-async" default-cache="default"  statistics="true"  async-executor="infinispan-async"

--- a/component/common/src/main/resources/conf/cache/infinispan/cluster/cache-config.xml
+++ b/component/common/src/main/resources/conf/cache/infinispan/cluster/cache-config.xml
@@ -36,7 +36,7 @@
   </threads>
 
   <jgroups transport="org.infinispan.remoting.transport.jgroups.JGroupsTransport">
-    <stack-file name="stack" path="${exo.service.cluster.jgroups.config}"/>
+    <stack-file name="stack" path="${exo.service.cluster.jgroups.config:jar:/conf/jgroups/jgroups-service-tcp.xml}"/>
   </jgroups>
 
   <cache-container name="template" default-cache="default" async-executor="infinispan-async" expiration-executor="infinispan-expiration"   listener-executor="infinispan-listener"

--- a/component/common/src/main/resources/conf/configuration.xml
+++ b/component/common/src/main/resources/conf/configuration.xml
@@ -40,22 +40,6 @@
     <key>CacheConfigurationProperties</key>
     <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
     <init-params>
-      <properties-param>
-        <name>CacheManagementProperties</name>
-        <description>Filter used to notify caches</description>
-        <property name="exo.cache.config.template" value="jar:/conf/cache/infinispan/local/cache-config.xml" />
-      </properties-param>
-      <properties-param profiles="cluster">
-        <name>CacheManagementProperties</name>
-        <description>Filter used to notify caches</description>
-        <property name="exo.cache.config.template" value="jar:/conf/cache/infinispan/cluster/cache-config.xml" />
-        <property name="exo.cache.async.config.template" value="jar:/conf/cache/infinispan/cluster/cache-async-config.xml" />
-      </properties-param>
-      <properties-param profiles="cluster">
-        <name>JGroupsProperties</name>
-        <description>Jgroups configuration</description>
-        <property name="exo.service.cluster.jgroups.config" value="jar:/conf/jgroups/jgroups-service-tcp.xml" />
-      </properties-param>
       <properties-param profiles="cluster-jgroups-udp">
         <name>JGroupsProperties</name>
         <description>Jgroups configuration</description>

--- a/component/common/src/main/resources/conf/jgroups/jgroups-service-tcp.xml
+++ b/component/common/src/main/resources/conf/jgroups/jgroups-service-tcp.xml
@@ -69,7 +69,7 @@
   <MERGE2
       max_interval="${exo.service.cluster.jgroups.merge2.max_interval:100000}"
       min_interval="${exo.service.cluster.jgroups.merge2.min_interval:20000}" />
-  <FD_SOCK />
+  <FD_SOCK start_port="${exo.service.cluster.jgroups.fd_sock.start_port:7900}" />
   <FD
       timeout="${exo.service.cluster.jgroups.fd.timeout:10000}"
       max_tries="${exo.service.cluster.jgroups.fd.max_tries:5}" />

--- a/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
@@ -259,15 +259,15 @@
     <init-params>
       <value-param>
         <name>cache.config.template</name>
-        <value>${exo.cache.config.template:jar:/conf/platform/cache/infinispan/local/cache-config.xml}</value>
+        <value>${exo.cache.config.template:jar:/conf/cache/infinispan/local/cache-config.xml}</value>
       </value-param>
       <value-param profiles="cluster">
         <name>cache.config.template</name>
-        <value>${exo.cache.config.template:jar:/conf/platform/cache/infinispan/cluster/cache-config.xml}</value>
+        <value>${exo.cache.config.template:jar:/conf/cache/infinispan/cluster/cache-config.xml}</value>
       </value-param>
       <value-param profiles="cluster">
         <name>cache.async.config.template</name>
-        <value>${exo.cache.async.config.template:jar:/conf/platform/cache/infinispan/cluster/cache-async-config.xml}</value>
+        <value>${exo.cache.async.config.template:jar:/conf/cache/infinispan/cluster/cache-async-config.xml}</value>
       </value-param>
     </init-params>
   </component>


### PR DESCRIPTION
This PR allows to use `exo.service.cluster.jgroups.config` in exo.properties file to define external location of JGroups configuration file.