### PR TITLE
Task-37043: Fix js error from french inputs placeholder (with ') of onboarding and external registration pages

### DIFF
--- a/web/portal/src/main/webapp/externalRegistration/jsp/reset_password.jsp
+++ b/web/portal/src/main/webapp/externalRegistration/jsp/reset_password.jsp
@@ -118,28 +118,28 @@
             <form name="registerForm" action="<%= contextPath + externalRegistrationURLPath %>" method="post">
               <div class="userCredentials">
                 <span class="iconUser"></span>
-                <input class="username" data-validation="require" name="firstName" type="text" value="<%=(firstName != null ? firstName : "")%>"  placeholder="<%=res.getString("external.registration.firstName")%>" onblur="this.placeholder = '<%=res.getString("external.registration.firstName")%>'" onfocus="this.placeholder = ''"/>
+                <input class="username" data-validation="require" name="firstName" type="text" value="<%=(firstName != null ? firstName : "")%>"  placeholder="<%=res.getString("external.registration.firstName")%>">
               </div>
               <div class="userCredentials">
                 <span class="iconUser"></span>
-                <input class="username" data-validation="require" name="lastName" type="text" value="<%=(lastName != null ? lastName : "")%>" placeholder="<%=res.getString("external.registration.lastName")%>" onblur="this.placeholder = '<%=res.getString("external.registration.lastName")%>'" onfocus="this.placeholder = ''"/>
+                <input class="username" data-validation="require" name="lastName" type="text" value="<%=(lastName != null ? lastName : "")%>" placeholder="<%=res.getString("external.registration.lastName")%>">
               </div>
               <div class="userCredentials">
                 <span class="iconPswrd"></span>
-                <input data-validation="require" id="password" type="password" name="password" autocomplete="off" value="<%=(password != null ? password : "")%>"  placeholder="<%=res.getString("portal.login.Password")%>" onblur="this.placeholder = '<%=res.getString("portal.login.Password")%>'" onfocus="this.placeholder = ''">
+                <input data-validation="require" id="password" type="password" name="password" autocomplete="off" value="<%=(password != null ? password : "")%>"  placeholder="<%=res.getString("portal.login.Password")%>">
               </div>
               <p class="passwordCondition">
                 <i class="uiIconInfo"></i><%=passwordCondition != null ? passwordCondition : res.getString("external.registration.passwordCondition")%>
               </p>
               <div class="userCredentials">
                 <span class="iconPswrd"></span>
-                <input data-validation="require" id="confirm_password" type="password" name="password2" autocomplete="off" value="<%=(password2 != null ? password2 : "")%>"  placeholder="<%=res.getString("external.registration.confirmPassword")%>" onblur="this.placeholder = '<%=res.getString("external.registration.confirmPassword")%>'" onfocus="this.placeholder = ''">
+                <input data-validation="require" id="confirm_password" type="password" name="password2" autocomplete="off" value="<%=(password2 != null ? password2 : "")%>"  placeholder="<%=res.getString("external.registration.confirmPassword")%>">
               </div>
               <p class="captchaCondition"></i><%=res.getString("external.registration.captchaCondition")%></p>
               <div id="captcha">
                 <img src="/portal/external-registration?serveCaptcha=true" alt="Captcha image for visual validation">
 				<br/>
-                <input data-validation="require" name="captcha" type="text" id="inputCaptcha"  placeholder="<%=res.getString("external.registration.captcha")%>" onblur="this.placeholder = '<%=res.getString("external.registration.captcha")%>'" onfocus="this.placeholder = ''">
+                <input data-validation="require" name="captcha" type="text" id="inputCaptcha"  placeholder="<%=res.getString("external.registration.captcha")%>">
               </div>
               <div id="UIPortalLoginFormAction" class="loginButton">
                 <button class="button" type="submit" disabled="disabled"><%=res.getString("external.registration.confirm")%></button>

--- a/web/portal/src/main/webapp/onboarding/jsp/reset_password.jsp
+++ b/web/portal/src/main/webapp/onboarding/jsp/reset_password.jsp
@@ -129,24 +129,24 @@
 					<form name="registerForm" action="<%= contextPath + onboardingPasswordPath %>" method="post">
 						<div class="userCredentials">
 							<span class="iconUser"></span>
-							<input class="username" data-validation="require" name="username" type="text" value="<%=username%>" readonly="readonly" />
+							<input class="username" data-validation="require" name="username" type="text" value="<%=username%>" readonly="readonly">
 						</div>
 						<div class="userCredentials">
 						  <span class="iconPswrd"></span>
-						  <input data-validation="require" type="password" name="password" id="password" autocomplete="off" value="<%=(password != null ? password : "")%>"  placeholder="<%=res.getString("portal.login.Password")%>" onblur="this.placeholder = '<%=res.getString("portal.login.Password")%>'" onfocus="this.placeholder = ''">
+						  <input data-validation="require" type="password" name="password" id="password" autocomplete="off" value="<%=(password != null ? password : "")%>"  placeholder="<%=res.getString("portal.login.Password")%>">
 					      <i class="uiIconError passwordFormat"></i>
 						</div>
 						<p class="passwordCondition"><i class="uiIconInfo"></i><%=passwordCondition != null ? passwordCondition : res.getString("onboarding.login.passwordCondition")%></p>
 						<div class="userCredentials">
 						  <span class="iconPswrd"></span>
-						   <input data-validation="require" type="password" name="password2" id="confirm_password" autocomplete="off" value="<%=(password2 != null ? password2 : "")%>"  placeholder="<%=res.getString("onboarding.login.confirmPassword")%>" onblur="this.placeholder = '<%=res.getString("onboarding.login.confirmPassword")%>'" onfocus="this.placeholder = ''">
+						   <input data-validation="require" type="password" name="password2" id="confirm_password" autocomplete="off" value="<%=(password2 != null ? password2 : "")%>"  placeholder="<%=res.getString("onboarding.login.confirmPassword")%>">
 						</div>
 						<% if (success == null || success.isEmpty()) {%>
 						<p class="captchaCondition"></i><%=res.getString("onboarding.login.captchaCondition")%></p>
 						<div id="captcha">
 							<img src="/portal/on-boarding?serveCaptcha=true" alt="Captcha image for visual validation">
 							<br/>
-							<input data-validation="require" name="captcha" type="text" id="inputCaptcha"  placeholder="<%=res.getString("onboarding.login.captcha")%>" onblur="this.placeholder = '<%=res.getString("onboarding.login.captcha")%>'" onfocus="this.placeholder = ''">
+							<input data-validation="require" name="captcha" type="text" id="inputCaptcha"  placeholder="<%=res.getString("onboarding.login.captcha")%>">
 						</div>
 						<%}%>
 						<div id="UIPortalLoginFormAction" class="loginButton">


### PR DESCRIPTION
When displaying the onboarding and external registration in French, the placeholder of username field is Nom d'utilisateur which uses ' character in string. So this statement (after JSP compilation):
onblur="this.placeholder = '<%=res.getString("portal.login.Password")%>'" onfocus="this.placeholder = ''"
becomes
onblur="this.placeholder = 'Nom d'utilisateur'" onfocus="this.placeholder = ''"
which will make a JS error.
In fact, the placeholder is natively managed by browser and shouldn't be modified on user event (as made for other eXo UIs)