### PR TITLE
Task-37127 : add the possibility to paginate LDAP search result

### DIFF
--- a/component/identity/src/test/resources/conf/picketlink/exo.portal.component.identity-picketlink-idm-ldap-as-external-config.xml
+++ b/component/identity/src/test/resources/conf/picketlink/exo.portal.component.identity-picketlink-idm-ldap-as-external-config.xml
@@ -348,6 +348,14 @@
                         <name>allowNotCaseSensitiveSearch</name>
                         <value>true</value>
                     </option>
+                    <option>
+                        <name>pagedResultsExtensionSize</name>
+                        <value>10</value>
+                    </option>
+                    <option>
+                        <name>pagedResultsExtensionSupported</name>
+                        <value>true</value>
+                    </option>
                 </options>
             </identity-store>
         </identity-stores>

--- a/component/identity/src/test/resources/ldap/ldap/test-100-users-opends.ldif
+++ b/component/identity/src/test/resources/ldap/ldap/test-100-users-opends.ldif
@@ -1,0 +1,1000 @@
+dn: uid=jduke11,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke11
+cn: Java Duke11
+sn: Duke11
+userPassword: theduke
+mail: jduke11@email.com
+
+dn: uid=jduke12,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke12
+cn: Java Duke12
+sn: Duke12
+userPassword: theduke
+mail: jduke12@email.com
+
+dn: uid=jduke13,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke13
+cn: Java Duke13
+sn: Duke13
+userPassword: theduke
+mail: jduke13@email.com
+
+dn: uid=jduke14,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke14
+cn: Java Duke14
+sn: Duke14
+userPassword: theduke
+mail: jduke14@email.com
+
+dn: uid=jduke15,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke15
+cn: Java Duke15
+sn: Duke15
+userPassword: theduke
+mail: jduke15@email.com
+
+dn: uid=jduke16,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke16
+cn: Java Duke16
+sn: Duke16
+userPassword: theduke
+mail: jduke16@email.com
+
+dn: uid=jduke17,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke17
+cn: Java Duke17
+sn: Duke17
+userPassword: theduke
+mail: jduke17@email.com
+
+dn: uid=jduke18,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke18
+cn: Java Duke18
+sn: Duke18
+userPassword: theduke
+mail: jduke18@email.com
+
+dn: uid=jduke19,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke19
+cn: Java Duke19
+sn: Duke19
+userPassword: theduke
+mail: jduke19@email.com
+
+dn: uid=jduke20,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke20
+cn: Java Duke20
+sn: Duke20
+userPassword: theduke
+mail: jduke20@email.com
+
+dn: uid=jduke21,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke21
+cn: Java Duke21
+sn: Duke21
+userPassword: theduke
+mail: jduke21@email.com
+
+dn: uid=jduke22,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke22
+cn: Java Duke22
+sn: Duke22
+userPassword: theduke
+mail: jduke22@email.com
+
+dn: uid=jduke23,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke23
+cn: Java Duke23
+sn: Duke23
+userPassword: theduke
+mail: jduke23@email.com
+
+dn: uid=jduke24,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke24
+cn: Java Duke24
+sn: Duke24
+userPassword: theduke
+mail: jduke24@email.com
+
+dn: uid=jduke25,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke25
+cn: Java Duke25
+sn: Duke25
+userPassword: theduke
+mail: jduke25@email.com
+
+dn: uid=jduke26,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke26
+cn: Java Duke26
+sn: Duke26
+userPassword: theduke
+mail: jduke26@email.com
+
+dn: uid=jduke27,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke27
+cn: Java Duke27
+sn: Duke27
+userPassword: theduke
+mail: jduke27@email.com
+
+dn: uid=jduke28,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke28
+cn: Java Duke28
+sn: Duke28
+userPassword: theduke
+mail: jduke28@email.com
+
+dn: uid=jduke29,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke29
+cn: Java Duke29
+sn: Duke29
+userPassword: theduke
+mail: jduke29@email.com
+
+dn: uid=jduke30,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke30
+cn: Java Duke30
+sn: Duke30
+userPassword: theduke
+mail: jduke30@email.com
+
+dn: uid=jduke31,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke31
+cn: Java Duke31
+sn: Duke31
+userPassword: theduke
+mail: jduke31@email.com
+
+dn: uid=jduke32,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke32
+cn: Java Duke32
+sn: Duke32
+userPassword: theduke
+mail: jduke32@email.com
+
+dn: uid=jduke33,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke33
+cn: Java Duke33
+sn: Duke33
+userPassword: theduke
+mail: jduke33@email.com
+
+dn: uid=jduke34,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke34
+cn: Java Duke34
+sn: Duke34
+userPassword: theduke
+mail: jduke34@email.com
+
+dn: uid=jduke35,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke35
+cn: Java Duke35
+sn: Duke35
+userPassword: theduke
+mail: jduke35@email.com
+
+dn: uid=jduke36,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke36
+cn: Java Duke36
+sn: Duke36
+userPassword: theduke
+mail: jduke36@email.com
+
+dn: uid=jduke37,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke37
+cn: Java Duke37
+sn: Duke37
+userPassword: theduke
+mail: jduke37@email.com
+
+dn: uid=jduke38,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke38
+cn: Java Duke38
+sn: Duke38
+userPassword: theduke
+mail: jduke38@email.com
+
+dn: uid=jduke39,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke39
+cn: Java Duke39
+sn: Duke39
+userPassword: theduke
+mail: jduke39@email.com
+
+dn: uid=jduke40,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke40
+cn: Java Duke40
+sn: Duke40
+userPassword: theduke
+mail: jduke40@email.com
+
+dn: uid=jduke41,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke41
+cn: Java Duke41
+sn: Duke41
+userPassword: theduke
+mail: jduke41@email.com
+
+dn: uid=jduke42,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke42
+cn: Java Duke42
+sn: Duke42
+userPassword: theduke
+mail: jduke42@email.com
+
+dn: uid=jduke43,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke43
+cn: Java Duke43
+sn: Duke43
+userPassword: theduke
+mail: jduke43@email.com
+
+dn: uid=jduke44,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke44
+cn: Java Duke44
+sn: Duke44
+userPassword: theduke
+mail: jduke44@email.com
+
+dn: uid=jduke45,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke45
+cn: Java Duke45
+sn: Duke45
+userPassword: theduke
+mail: jduke45@email.com
+
+dn: uid=jduke46,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke46
+cn: Java Duke46
+sn: Duke46
+userPassword: theduke
+mail: jduke46@email.com
+
+dn: uid=jduke47,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke47
+cn: Java Duke47
+sn: Duke47
+userPassword: theduke
+mail: jduke47@email.com
+
+dn: uid=jduke48,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke48
+cn: Java Duke48
+sn: Duke48
+userPassword: theduke
+mail: jduke48@email.com
+
+dn: uid=jduke49,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke49
+cn: Java Duke49
+sn: Duke49
+userPassword: theduke
+mail: jduke49@email.com
+
+dn: uid=jduke50,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke50
+cn: Java Duke50
+sn: Duke50
+userPassword: theduke
+mail: jduke50@email.com
+
+dn: uid=jduke51,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke51
+cn: Java Duke51
+sn: Duke51
+userPassword: theduke
+mail: jduke51@email.com
+
+dn: uid=jduke52,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke52
+cn: Java Duke52
+sn: Duke52
+userPassword: theduke
+mail: jduke52@email.com
+
+dn: uid=jduke53,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke53
+cn: Java Duke53
+sn: Duke53
+userPassword: theduke
+mail: jduke53@email.com
+
+dn: uid=jduke54,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke54
+cn: Java Duke54
+sn: Duke54
+userPassword: theduke
+mail: jduke54@email.com
+
+dn: uid=jduke55,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke55
+cn: Java Duke55
+sn: Duke55
+userPassword: theduke
+mail: jduke55@email.com
+
+dn: uid=jduke56,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke56
+cn: Java Duke56
+sn: Duke56
+userPassword: theduke
+mail: jduke56@email.com
+
+dn: uid=jduke57,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke57
+cn: Java Duke57
+sn: Duke57
+userPassword: theduke
+mail: jduke57@email.com
+
+dn: uid=jduke58,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke58
+cn: Java Duke58
+sn: Duke58
+userPassword: theduke
+mail: jduke58@email.com
+
+dn: uid=jduke59,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke59
+cn: Java Duke59
+sn: Duke59
+userPassword: theduke
+mail: jduke59@email.com
+
+dn: uid=jduke60,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke60
+cn: Java Duke60
+sn: Duke60
+userPassword: theduke
+mail: jduke60@email.com
+
+dn: uid=jduke61,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke61
+cn: Java Duke61
+sn: Duke61
+userPassword: theduke
+mail: jduke61@email.com
+
+dn: uid=jduke62,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke62
+cn: Java Duke62
+sn: Duke62
+userPassword: theduke
+mail: jduke62@email.com
+
+dn: uid=jduke63,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke63
+cn: Java Duke63
+sn: Duke63
+userPassword: theduke
+mail: jduke63@email.com
+
+dn: uid=jduke64,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke64
+cn: Java Duke64
+sn: Duke64
+userPassword: theduke
+mail: jduke64@email.com
+
+dn: uid=jduke65,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke65
+cn: Java Duke65
+sn: Duke65
+userPassword: theduke
+mail: jduke65@email.com
+
+dn: uid=jduke66,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke66
+cn: Java Duke66
+sn: Duke66
+userPassword: theduke
+mail: jduke66@email.com
+
+dn: uid=jduke67,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke67
+cn: Java Duke67
+sn: Duke67
+userPassword: theduke
+mail: jduke67@email.com
+
+dn: uid=jduke68,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke68
+cn: Java Duke68
+sn: Duke68
+userPassword: theduke
+mail: jduke68@email.com
+
+dn: uid=jduke69,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke69
+cn: Java Duke69
+sn: Duke69
+userPassword: theduke
+mail: jduke69@email.com
+
+dn: uid=jduke70,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke70
+cn: Java Duke70
+sn: Duke70
+userPassword: theduke
+mail: jduke70@email.com
+
+dn: uid=jduke71,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke71
+cn: Java Duke71
+sn: Duke71
+userPassword: theduke
+mail: jduke71@email.com
+
+dn: uid=jduke72,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke72
+cn: Java Duke72
+sn: Duke72
+userPassword: theduke
+mail: jduke72@email.com
+
+dn: uid=jduke73,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke73
+cn: Java Duke73
+sn: Duke73
+userPassword: theduke
+mail: jduke73@email.com
+
+dn: uid=jduke74,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke74
+cn: Java Duke74
+sn: Duke74
+userPassword: theduke
+mail: jduke74@email.com
+
+dn: uid=jduke75,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke75
+cn: Java Duke75
+sn: Duke75
+userPassword: theduke
+mail: jduke75@email.com
+
+dn: uid=jduke76,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke76
+cn: Java Duke76
+sn: Duke76
+userPassword: theduke
+mail: jduke76@email.com
+
+dn: uid=jduke77,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke77
+cn: Java Duke77
+sn: Duke77
+userPassword: theduke
+mail: jduke77@email.com
+
+dn: uid=jduke78,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke78
+cn: Java Duke78
+sn: Duke78
+userPassword: theduke
+mail: jduke78@email.com
+
+dn: uid=jduke79,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke79
+cn: Java Duke79
+sn: Duke79
+userPassword: theduke
+mail: jduke79@email.com
+
+dn: uid=jduke80,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke80
+cn: Java Duke80
+sn: Duke80
+userPassword: theduke
+mail: jduke80@email.com
+
+dn: uid=jduke81,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke81
+cn: Java Duke81
+sn: Duke81
+userPassword: theduke
+mail: jduke81@email.com
+
+dn: uid=jduke82,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke82
+cn: Java Duke82
+sn: Duke82
+userPassword: theduke
+mail: jduke82@email.com
+
+dn: uid=jduke83,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke83
+cn: Java Duke83
+sn: Duke83
+userPassword: theduke
+mail: jduke83@email.com
+
+dn: uid=jduke84,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke84
+cn: Java Duke84
+sn: Duke84
+userPassword: theduke
+mail: jduke84@email.com
+
+dn: uid=jduke85,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke85
+cn: Java Duke85
+sn: Duke85
+userPassword: theduke
+mail: jduke85@email.com
+
+dn: uid=jduke86,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke86
+cn: Java Duke86
+sn: Duke86
+userPassword: theduke
+mail: jduke86@email.com
+
+dn: uid=jduke87,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke87
+cn: Java Duke87
+sn: Duke87
+userPassword: theduke
+mail: jduke87@email.com
+
+dn: uid=jduke88,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke88
+cn: Java Duke88
+sn: Duke88
+userPassword: theduke
+mail: jduke88@email.com
+
+dn: uid=jduke89,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke89
+cn: Java Duke89
+sn: Duke89
+userPassword: theduke
+mail: jduke89@email.com
+
+dn: uid=jduke90,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke90
+cn: Java Duke90
+sn: Duke90
+userPassword: theduke
+mail: jduke90@email.com
+
+dn: uid=jduke91,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke91
+cn: Java Duke91
+sn: Duke91
+userPassword: theduke
+mail: jduke91@email.com
+
+dn: uid=jduke92,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke92
+cn: Java Duke92
+sn: Duke92
+userPassword: theduke
+mail: jduke92@email.com
+
+dn: uid=jduke93,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke93
+cn: Java Duke93
+sn: Duke93
+userPassword: theduke
+mail: jduke93@email.com
+
+dn: uid=jduke94,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke94
+cn: Java Duke94
+sn: Duke94
+userPassword: theduke
+mail: jduke94@email.com
+
+dn: uid=jduke95,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke95
+cn: Java Duke95
+sn: Duke95
+userPassword: theduke
+mail: jduke95@email.com
+
+dn: uid=jduke96,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke96
+cn: Java Duke96
+sn: Duke96
+userPassword: theduke
+mail: jduke96@email.com
+
+dn: uid=jduke97,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke97
+cn: Java Duke97
+sn: Duke97
+userPassword: theduke
+mail: jduke97@email.com
+
+dn: uid=jduke98,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke98
+cn: Java Duke98
+sn: Duke98
+userPassword: theduke
+mail: jduke98@email.com
+
+dn: uid=jduke99,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke99
+cn: Java Duke99
+sn: Duke99
+userPassword: theduke
+mail: jduke99@email.com
+
+dn: uid=jduke100,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke100
+cn: Java Duke100
+sn: Duke100
+userPassword: theduke
+mail: jduke100@email.com
+
+dn: uid=jduke101,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke101
+cn: Java Duke101
+sn: Duke101
+userPassword: theduke
+mail: jduke101@email.com
+
+dn: uid=jduke102,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke102
+cn: Java Duke102
+sn: Duke102
+userPassword: theduke
+mail: jduke102@email.com
+
+dn: uid=jduke103,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke103
+cn: Java Duke103
+sn: Duke103
+userPassword: theduke
+mail: jduke103@email.com
+
+dn: uid=jduke104,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke104
+cn: Java Duke104
+sn: Duke104
+userPassword: theduke
+mail: jduke104@email.com
+
+dn: uid=jduke105,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke105
+cn: Java Duke105
+sn: Duke105
+userPassword: theduke
+mail: jduke105@email.com
+
+dn: uid=jduke106,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke106
+cn: Java Duke106
+sn: Duke106
+userPassword: theduke
+mail: jduke106@email.com
+
+dn: uid=jduke107,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke107
+cn: Java Duke107
+sn: Duke107
+userPassword: theduke
+mail: jduke107@email.com
+
+dn: uid=jduke108,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke108
+cn: Java Duke108
+sn: Duke108
+userPassword: theduke
+mail: jduke108@email.com
+
+dn: uid=jduke109,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke109
+cn: Java Duke109
+sn: Duke109
+userPassword: theduke
+mail: jduke109@email.com
+
+dn: uid=jduke110,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jduke110
+cn: Java Duke110
+sn: Duke110
+userPassword: theduke
+mail: jduke110@email.com
+

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
@@ -315,6 +315,10 @@
             <name>pagedResultsExtensionSize</name>
             <value>${exo.ldap.search.resultlimit:1000}</value>
           </option>
+          <option>
+            <name>pagedResultsExtensionSupported</name>
+            <value>${exo.ldap.search.pagedResult.enabled:false}</value>
+          </option>
         </options>
       </identity-store>
     </identity-stores>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
@@ -317,7 +317,7 @@
           </option>
           <option>
             <name>pagedResultsExtensionSupported</name>
-            <value>${exo.ldap.search.pagedResult.enabled:false}</value>
+            <value>${exo.ldap.search.pagedResult.enabled:true}</value>
           </option>
         </options>
       </identity-store>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
@@ -334,7 +334,7 @@
           </option>
           <option>
             <name>pagedResultsExtensionSupported</name>
-            <value>${exo.ldap.search.pagedResult.enabled:false}</value>
+            <value>${exo.ldap.search.pagedResult.enabled:true}</value>
           </option>
         </options>
       </identity-store>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
@@ -332,6 +332,10 @@
             <name>pagedResultsExtensionSize</name>
             <value>${exo.ldap.search.resultlimit:1000}</value>
           </option>
+          <option>
+            <name>pagedResultsExtensionSupported</name>
+            <value>${exo.ldap.search.pagedResult.enabled:false}</value>
+          </option>
         </options>
       </identity-store>
     </identity-stores>


### PR DESCRIPTION
In synchronization, we need to get all LDAP users. If there are more user than the default limit, we should ne able to use pagination on results.
Currently, we cannot activate pagedResult.
This commit add the possibility to configure that point.