### PR TITLE
fix/TASK-25736: Unbind on click event before assigning the new one

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIRightClickPopupMenu.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIRightClickPopupMenu.js
@@ -38,7 +38,7 @@
 	     */
 	    this.disableContextMenu(menu.parent());
 	
-	    menu.find('.UIRightPopupMenuContainer, .uiRightPopupMenuContainer').on('click', 'div.MenuItem a, .menuItem a', eXo.webui.UIRightClickPopupMenu.prepareObjectIdEvt);
+	    menu.find('.UIRightPopupMenuContainer, .uiRightPopupMenuContainer').unbind('click').on('click', 'div.MenuItem a, .menuItem a', eXo.webui.UIRightClickPopupMenu.prepareObjectIdEvt);
 	  },
 	  /**
 	   * Hide and disable mouse down event of context menu object


### PR DESCRIPTION
Every node in the navigation menu is bound twice the `onClick` event. When you click on copy, paste or any action, it will be fired twice.
This fix will make sure that every menu action has only one listener for the click event.