### PR TITLE
39280 : Fix resize effect when opening the Drawer

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/portal/BodyScrollListener.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/portal/BodyScrollListener.js
@@ -1,6 +1,10 @@
 $(document).ready(() => {
+  // Avoid applying margin on Mobile view
+  if (window.innerWidth <= 768) {
+    return;
+  }
   function controlBodyScrollClass() {
-    if ($('body').height() > $(window).height()) {
+    if ($('body').height() > ($(window).height() + 1)) {
       $('body').addClass('with-scroll');
       $('body').removeClass('no-scroll');
     } else {
@@ -10,4 +14,14 @@ $(document).ready(() => {
   }
   $(window).resize(controlBodyScrollClass);
   controlBodyScrollClass();
+
+  // Add a style to define scrollbar width
+  const scrollbarWidth = parseInt(window.innerWidth - document.body.offsetWidth);
+  const styleElement = document.createElement('style');
+  styleElement.textContent = `
+  .hide-scroll.with-scroll {
+    margin-right: ${scrollbarWidth}px !important;
+  }`;
+  styleElement.setAttribute('type', 'text/css');
+  document.head.append(styleElement);
 })


### PR DESCRIPTION
When the page doesn't have a scrollbar, the DOM elements gets resized when opening a Drawer.
This PR will fix this effect. In fact, this is due to the fact that the returned body width is sometimes more than the window width by 0.03 pixels. Thus to fix it, we will test on (.height() + 1) instead of .height().
In addition, the scrollbar width is different from a browser to another (FF VS Firefox), thus here a style is computed at page display time and injected in Body Head