### PR TITLE
40139 : Load home node of current site when adding a page

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -27,13 +27,13 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <groupId>org.exoplatform.gatein.portal</groupId>
   <artifactId>gatein-portal-build-config</artifactId>
   <name>GateIn Portal: Build Configuration</name>
-  <version>6.2.x-SNAPSHOT</version>
+  <version>6.2.x-maintenance-SNAPSHOT</version>
 
   <licenses>
     <license>

--- a/cdi/contexts/pom.xml
+++ b/cdi/contexts/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.gatein.cdi</groupId>
     <artifactId>gatein-cdi-parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdi/injection/pom.xml
+++ b/cdi/injection/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.gatein.cdi</groupId>
     <artifactId>gatein-cdi-parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -28,14 +28,14 @@
 
   <groupId>org.gatein.cdi</groupId>
   <artifactId>gatein-cdi-parent</artifactId>
-  <version>6.2.x-SNAPSHOT</version>
+  <version>6.2.x-maintenance-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <description>GateIn CDI Enhancements parent</description>

--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>exo.portal.component.api</artifactId>

--- a/component/application-registry/pom.xml
+++ b/component/application-registry/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>exo.portal.component.common</artifactId>

--- a/component/file-storage/pom.xml
+++ b/component/file-storage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.portal.component.file-storage</artifactId>
   <packaging>jar</packaging>

--- a/component/identity/pom.xml
+++ b/component/identity/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/management/pom.xml
+++ b/component/management/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/pc/pom.xml
+++ b/component/pc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.component</artifactId>

--- a/component/portal/pom.xml
+++ b/component/portal/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/resources/pom.xml
+++ b/component/resources/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/scripting/pom.xml
+++ b/component/scripting/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/test/core/pom.xml
+++ b/component/test/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.test</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/test/pom.xml
+++ b/component/test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/test/web/pom.xml
+++ b/component/test/web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.test</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/api/pom.xml
+++ b/component/web/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/controller/pom.xml
+++ b/component/web/controller/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/oauth-common/pom.xml
+++ b/component/web/oauth-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>exo.portal.component.web</artifactId>
     <groupId>org.exoplatform.gatein.portal</groupId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/component/web/oauth-web/pom.xml
+++ b/component/web/oauth-web/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/pom.xml
+++ b/component/web/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/resources/pom.xml
+++ b/component/web/resources/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/security/pom.xml
+++ b/component/web/security/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/server/pom.xml
+++ b/component/web/server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/sso/pom.xml
+++ b/component/web/sso/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/sso/sso-agent-configs/pom.xml
+++ b/component/web/sso/sso-agent-configs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web.sso</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/sso/sso-integration-configs/pom.xml
+++ b/component/web/sso/sso-integration-configs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web.sso</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/examples/extension/config/pom.xml
+++ b/examples/extension/config/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/examples/extension/ear/pom.xml
+++ b/examples/extension/ear/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/examples/extension/jar/pom.xml
+++ b/examples/extension/jar/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/examples/extension/pom.xml
+++ b/examples/extension/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/examples/extension/war/pom.xml
+++ b/examples/extension/war/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.sample</artifactId>

--- a/examples/portal/config/pom.xml
+++ b/examples/portal/config/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/examples/portal/ear/pom.xml
+++ b/examples/portal/ear/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/examples/portal/jar/pom.xml
+++ b/examples/portal/jar/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/examples/portal/pom.xml
+++ b/examples/portal/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/examples/portal/rest-war/pom.xml
+++ b/examples/portal/rest-war/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/examples/portal/war/pom.xml
+++ b/examples/portal/war/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/examples/portlets/amd-js/pom.xml
+++ b/examples/portlets/amd-js/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>gatein-amd-js</artifactId>

--- a/examples/portlets/api/pom.xml
+++ b/examples/portlets/api/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>gatein-api</artifactId>

--- a/examples/portlets/ipc/consumer/pom.xml
+++ b/examples/portlets/ipc/consumer/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>ipc</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>consumer</artifactId>

--- a/examples/portlets/ipc/pom.xml
+++ b/examples/portlets/ipc/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>ipc</artifactId>

--- a/examples/portlets/ipc/producer/pom.xml
+++ b/examples/portlets/ipc/producer/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>ipc</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>producer</artifactId>

--- a/examples/portlets/jquery/pom.xml
+++ b/examples/portlets/jquery/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>gatein-jquery</artifactId>

--- a/examples/portlets/jsphellouser/pom.xml
+++ b/examples/portlets/jsphellouser/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>gatein-jsp-hellouser</artifactId>

--- a/examples/portlets/pom.xml
+++ b/examples/portlets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/examples/portlets/resourceserving/pom.xml
+++ b/examples/portlets/resourceserving/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>resource-serving</artifactId>

--- a/examples/portlets/simplesthelloworld/pom.xml
+++ b/examples/portlets/simplesthelloworld/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>gatein-simplest-helloworld</artifactId>

--- a/examples/portlets/struts-jpetstore/pom.xml
+++ b/examples/portlets/struts-jpetstore/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>struts-jpetstore</artifactId>

--- a/examples/portlets/todomvc/pom.xml
+++ b/examples/portlets/todomvc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>todomvc</artifactId>

--- a/examples/portlets/useridentity/pom.xml
+++ b/examples/portlets/useridentity/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.portlets</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>gatein-user-identity</artifactId>

--- a/examples/skins/pom.xml
+++ b/examples/skins/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/examples/skins/simpleskin/pom.xml
+++ b/examples/skins/simpleskin/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal.examples.skins</groupId>
     <artifactId>parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>gatein-sample-skin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>org.exoplatform.gatein.portal</groupId>
   <artifactId>exo.portal.parent</artifactId>
-  <version>6.2.x-SNAPSHOT</version>
+  <version>6.2.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>GateIn - Portal</name>
@@ -40,12 +40,12 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <org.exoplatform.depmgt.version>19.x-SNAPSHOT</org.exoplatform.depmgt.version>
-    <org.exoplatform.kernel.version>6.2.x-SNAPSHOT</org.exoplatform.kernel.version>
-    <org.exoplatform.core.version>6.2.x-SNAPSHOT</org.exoplatform.core.version>
-    <org.exoplatform.ws.version>6.2.x-SNAPSHOT</org.exoplatform.ws.version>
-    <org.exoplatform.gatein.sso.version>6.2.x-SNAPSHOT</org.exoplatform.gatein.sso.version>
-    <org.exoplatform.gatein.wci.version>6.2.x-SNAPSHOT</org.exoplatform.gatein.wci.version>
-    <org.exoplatform.gatein.pc.version>6.2.x-SNAPSHOT</org.exoplatform.gatein.pc.version>
+    <org.exoplatform.kernel.version>6.2.x-maintenance-SNAPSHOT</org.exoplatform.kernel.version>
+    <org.exoplatform.core.version>6.2.x-maintenance-SNAPSHOT</org.exoplatform.core.version>
+    <org.exoplatform.ws.version>6.2.x-maintenance-SNAPSHOT</org.exoplatform.ws.version>
+    <org.exoplatform.gatein.sso.version>6.2.x-maintenance-SNAPSHOT</org.exoplatform.gatein.sso.version>
+    <org.exoplatform.gatein.wci.version>6.2.x-maintenance-SNAPSHOT</org.exoplatform.gatein.wci.version>
+    <org.exoplatform.gatein.pc.version>6.2.x-maintenance-SNAPSHOT</org.exoplatform.gatein.pc.version>
     <org.exoplatform.gatein.dep.version>2.2.x-SNAPSHOT</org.exoplatform.gatein.dep.version>
     <org.exoplatform.framework.junit.version>1.2.4-GA</org.exoplatform.framework.junit.version>
     <nl.captcha.simplecaptcha.version>1.1.1.Final-gatein-4</nl.captcha.simplecaptcha.version>

--- a/portlet/exoadmin/pom.xml
+++ b/portlet/exoadmin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.portlet</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/portlet/pom.xml
+++ b/portlet/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.portlet</artifactId>

--- a/portlet/web/pom.xml
+++ b/portlet/web/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.portlet</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/starter/ear/pom.xml
+++ b/starter/ear/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.starter.root</artifactId>

--- a/starter/war/pom.xml
+++ b/starter/war/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/web/eXoResources/pom.xml
+++ b/web/eXoResources/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.web</artifactId>

--- a/web/portal/pom.xml
+++ b/web/portal/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/web/rest/pom.xml
+++ b/web/rest/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.web</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/core/pom.xml
+++ b/webui/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/eXo/pom.xml
+++ b/webui/eXo/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/framework/pom.xml
+++ b/webui/framework/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.webui</artifactId>

--- a/webui/portal/pom.xml
+++ b/webui/portal/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/portlet/pom.xml
+++ b/webui/portlet/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.2.x-SNAPSHOT</version>
+    <version>6.2.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
When adding a new page from a page included in global site, the new page will be added to the Global site.
This PR makes sure to select the current site if the navigation belongs to the Global site 