### PR TITLE
Disable debug mode for Service worker

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/pwa/service-worker.js
+++ b/web/portal/src/main/webapp/WEB-INF/conf/pwa/service-worker.js
@@ -6,7 +6,6 @@ const siteName = '@site-name@';
 const development = @development@;
 
 workbox.setConfig({
-  debug: development,
   modulePathPrefix: '/eXoResources/javascript/workbox-5.1.4/'
 });
 

--- a/web/portal/src/main/webapp/WEB-INF/conf/pwa/service-worker.js
+++ b/web/portal/src/main/webapp/WEB-INF/conf/pwa/service-worker.js
@@ -6,6 +6,7 @@ const siteName = '@site-name@';
 const development = @development@;
 
 workbox.setConfig({
+  debug: false,
   modulePathPrefix: '/eXoResources/javascript/workbox-5.1.4/'
 });
 


### PR DESCRIPTION
Debug mode for Service worker is not needed event in development mode. It makes the browser console verbose.