### PR TITLE
 38509 : Fix LDAP configuration to solve groups upgrade issue  (#166)

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
@@ -160,9 +160,17 @@
                 <key><string>/</string></key>
                 <value><string>root_type</string></value>
               </entry>
+              <!-- exo.group.platform.identity.type will define the identity type of groups under /platform group.
+                Before meeds 1.0 , the value was '.platform' , starting meeds 1.0 the value is GROUP -->
               <entry>
-                <key><string>${exo.ldap.groups.rootGroup:/platform/*}</string></key>
-                <value><string>GROUP</string></value>
+                <key><string>/platform/*</string></key>
+                <value><string>${exo.group.platform.identity.type:GROUP}</string></value>
+              </entry>
+              <!-- exo.ldap.groups.rootGroup is the group under which all LDAP/AD groups will be imported
+                   exo.ldap.groups.identity.type is the identity type for groups imported from LDAP/AD-->
+              <entry>
+                <key><string>${exo.ldap.groups.rootGroup:/ldap-groups/*}</string></key>
+                <value><string>${exo.ldap.groups.identity.type:LDAP_MAPPED_GROUP}</string></value>
               </entry>
             </map>
           </field>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
@@ -62,7 +62,7 @@
           <identity-store-id>PortalLDAPStore</identity-store-id>
           <identity-object-types>
             <identity-object-type>USER</identity-object-type>
-            <identity-object-type>GROUP</identity-object-type>
+            <identity-object-type>LDAP_MAPPED_GROUP</identity-object-type>
           </identity-object-types>
           <options>
             <option>
@@ -224,7 +224,7 @@
             </options>
           </identity-object-type>
           <identity-object-type>
-            <name>GROUP</name>
+            <name>LDAP_MAPPED_GROUP</name>
             <relationships>
               <relationship>
                 <relationship-type-ref>JBOSS_IDENTITY_MEMBERSHIP</relationship-type-ref>
@@ -232,7 +232,7 @@
               </relationship>
               <relationship>
                 <relationship-type-ref>JBOSS_IDENTITY_MEMBERSHIP</relationship-type-ref>
-                <identity-object-type-ref>GROUP</identity-object-type-ref>
+                <identity-object-type-ref>LDAP_MAPPED_GROUP</identity-object-type-ref>
               </relationship>
             </relationships>
             <credentials/>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
@@ -62,7 +62,7 @@
           <identity-store-id>PortalLDAPStore</identity-store-id>
           <identity-object-types>
             <identity-object-type>USER</identity-object-type>
-            <identity-object-type>GROUP</identity-object-type>
+            <identity-object-type>LDAP_MAPPED_GROUP</identity-object-type>
           </identity-object-types>
           <options>
             <option>
@@ -236,7 +236,7 @@
             </options>
           </identity-object-type>
           <identity-object-type>
-            <name>GROUP</name>
+            <name>LDAP_MAPPED_GROUP</name>
             <relationships>
               <relationship>
                 <relationship-type-ref>JBOSS_IDENTITY_MEMBERSHIP</relationship-type-ref>
@@ -244,7 +244,7 @@
               </relationship>
               <relationship>
                 <relationship-type-ref>JBOSS_IDENTITY_MEMBERSHIP</relationship-type-ref>
-                <identity-object-type-ref>GROUP</identity-object-type-ref>
+                <identity-object-type-ref>LDAP_MAPPED_GROUP</identity-object-type-ref>
               </relationship>
             </relationships>
             <credentials/>


### PR DESCRIPTION
The identity type of all groups under /platform were mistakenly changed from .platform to GROUP with configuration added to enable configuring LDAP using exo.properties file
In thi sPR we add some properties to make it possible to define values for all IDM identity types, to help old installations use previous values which makes it possible to retrieve correctly users by groups.
The new properties are :

    exo.group.platform.identity.type : it defines the identity type of groups under /platform group.Before meeds 1.0 , the value was '.platform' , starting meeds 1.0 the value is GROUP. Default value : GROUP
    exo.ldap.groups.rootGroup is the group under which all LDAP/AD groups will be imported. Default value was changed to /ldap-groups/* instead of /platform/*
    exo.ldap.groups.identity.type : it defines the identity type for groups imported from LDAP/AD. Default value is LDAP_MAPPED_GROUP