### PR TITLE
Task-40830 : When using initial account wizard, the user password is …

### DIFF
--- a/component/portal/pom.xml
+++ b/component/portal/pom.xml
@@ -57,7 +57,7 @@
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.resources</artifactId>
     </dependency>
-
+  
     <dependency>
       <groupId>org.exoplatform.ws</groupId>
       <artifactId>exo.ws.rest.core</artifactId>

--- a/component/portal/src/main/java/org/exoplatform/account/setup/rest/WelcomeScreenRestService.java
+++ b/component/portal/src/main/java/org/exoplatform/account/setup/rest/WelcomeScreenRestService.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2012 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.account.setup.rest;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.UserHandler;
+import org.exoplatform.services.rest.resource.ResourceContainer;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+
+/**
+ * @author <a href="hzekri@exoplatform.com">hzekri</a>
+ */
+@Path("/welcomeScreen")
+public class WelcomeScreenRestService implements ResourceContainer {
+
+  private static final Log LOG = ExoLogger.getLogger(WelcomeScreenRestService.class);
+
+  /**
+   * This method checks if username entered by user in Account Setup Screen
+   * already exists
+   */
+  @GET
+  @Path("/checkUsername")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Response checkUsername(@QueryParam("username") String username) {
+
+    CacheControl cacheControl = new CacheControl();
+    cacheControl.setNoCache(true);
+    cacheControl.setNoStore(true);
+
+    boolean userExists = false;
+    JSONObject jsonObject = new JSONObject();
+    OrganizationService orgService = (OrganizationService) PortalContainer.getInstance()
+                                                                          .getComponentInstanceOfType(OrganizationService.class);
+    UserHandler userHandler = orgService.getUserHandler();
+    try {
+      if (userHandler.findUserByName(username) != null) {
+        userExists = true;
+      }
+
+    } catch (Exception e) {
+      LOG.error("An error occurred while checking if username exists.", e);
+    }
+    try {
+      jsonObject.put("userExists", userExists);
+    } catch (JSONException e) {
+      LOG.error("An error occurred while creating JSONObject that will be returned to identify if username exists.", e);
+    }
+    return Response.ok(jsonObject.toString()).cacheControl(cacheControl).build();
+  }
+}

--- a/component/portal/src/main/java/org/exoplatform/account/setup/web/AccountSetup.java
+++ b/component/portal/src/main/java/org/exoplatform/account/setup/web/AccountSetup.java
@@ -1,0 +1,97 @@
+package org.exoplatform.account.setup.web;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+
+import org.gatein.wci.ServletContainerFactory;
+import org.gatein.wci.security.Credentials;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+/**
+ * @author <a href="fbradai@exoplatform.com">Fbradai</a>
+ */
+public class AccountSetup extends HttpServlet {
+
+  private static final Log    LOG                   = ExoLogger.getLogger(AccountSetup.class);
+
+  private static final long   serialVersionUID      = 6467955354840693802L;
+
+  private final static String USER_NAME_ACCOUNT     = "username";
+
+  private final static String FIRST_NAME_ACCOUNT    = "firstNameAccount";
+
+  private final static String LAST_NAME_ACCOUNT     = "lastNameAccount";
+
+  private final static String EMAIL_ACCOUNT         = "emailAccount";
+
+  private final static String USER_PASSWORD_ACCOUNT = "password";
+
+  private final static String ADMIN_PASSWORD        = "adminPassword";
+
+  private final static String INITIAL_URI_PARAM     = "initialURI";
+
+  private final static String ACCOUNT_SETUP_BUTTON  = "setupbutton";
+
+  private final static String SETUP_SKIP_BUTTON     = "skipform";
+
+  private AccountSetupService accountSetupService;
+
+  public AccountSetup() {
+    accountSetupService = PortalContainer.getInstance().getComponentInstanceOfType(AccountSetupService.class);
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    String redirectURI;
+    String accountsetupbutton = request.getParameter(ACCOUNT_SETUP_BUTTON);
+
+    if (accountsetupbutton.equals(SETUP_SKIP_BUTTON) || accountSetupService.mustSkipAccountSetup()) {
+      if (LOG.isWarnEnabled()) {
+        LOG.warn("Direct access to Account Setup Form.");
+      }
+      accountSetupService.setSkipSetup(true);
+      redirectURI = "/" + PortalContainer.getCurrentPortalContainerName();
+    } else {
+      String userNameAccount = request.getParameter(USER_NAME_ACCOUNT);
+      String firstNameAccount = request.getParameter(FIRST_NAME_ACCOUNT);
+      String lastNameAccount = request.getParameter(LAST_NAME_ACCOUNT);
+      String emailAccount = request.getParameter(EMAIL_ACCOUNT);
+      String userPasswordAccount = request.getParameter(USER_PASSWORD_ACCOUNT);
+      String adminPassword = request.getParameter(ADMIN_PASSWORD);
+
+      accountSetupService.createAccount(userNameAccount,
+                                        firstNameAccount,
+                                        lastNameAccount,
+                                        emailAccount,
+                                        userPasswordAccount,
+                                        adminPassword);
+
+      // Redirect to requested page
+      HttpServletRequest wrappedRequest = new HttpServletRequestWrapper(request) {
+        @Override
+        public String getContextPath() {
+          return "/portal";
+        }
+      };
+      Credentials credentials = new Credentials(userNameAccount, userPasswordAccount);
+      ServletContainerFactory.getServletContainer().login(wrappedRequest, response, credentials);;
+      redirectURI = "/" + PortalContainer.getCurrentPortalContainerName();
+    }
+    response.setCharacterEncoding("UTF-8");
+    response.sendRedirect(redirectURI);
+  }
+
+  @Override
+  protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    doGet(request, response);
+  }
+
+}

--- a/component/portal/src/main/java/org/exoplatform/account/setup/web/AccountSetupService.java
+++ b/component/portal/src/main/java/org/exoplatform/account/setup/web/AccountSetupService.java
@@ -1,0 +1,142 @@
+package org.exoplatform.account.setup.web;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.container.component.ComponentRequestLifecycle;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.MembershipType;
+import org.exoplatform.services.organization.MembershipTypeHandler;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserHandler;
+
+public class AccountSetupService {
+
+  private static final Log    LOG                             = ExoLogger.getLogger(AccountSetup.class);
+
+  public final static String  ACCOUNT_SETUP_NODE              = "accountSetup";
+
+  public final static String  ACCOUNT_SETUP_SKIP_PROPERTY     = "accountsetup.skip";
+
+  private final static String ADMIN_FIRST_NAME                = "root";
+
+  private final static String PLATFORM_USERS_GROUP            = "/platform/administrators";
+
+  private final static String PLATFORM_WEB_CONTRIBUTORS_GROUP = "/platform/web-contributors";
+
+  private final static String PLATFORM_DEVELOPERS_GROUP       = "/developers";
+
+  private final static String PLATFORM_PLATFORM_USERS_GROUP   = "/platform/users";
+
+  private final static String MEMBERSHIP_TYPE_MANAGER         = "*";
+
+  private SettingService      settingService;
+
+  private OrganizationService organizationService;
+
+  private Boolean             skipSetup                       = null;
+
+  public AccountSetupService(SettingService settingService, OrganizationService organizationService) {
+    this.settingService = settingService;
+    this.organizationService = organizationService;
+  }
+
+  public void setSkipSetup(boolean skipSetup) {
+    this.skipSetup = skipSetup;
+    settingService.set(Context.GLOBAL, Scope.GLOBAL, ACCOUNT_SETUP_NODE, SettingValue.create("true"));
+  }
+
+  public boolean mustSkipAccountSetup() {
+    if (skipSetup == null) {
+      SettingValue accountSetupNode = settingService.get(Context.GLOBAL, Scope.GLOBAL, ACCOUNT_SETUP_NODE);
+
+      String propertySetupSkip = PropertyManager.getProperty(ACCOUNT_SETUP_SKIP_PROPERTY);
+      if (propertySetupSkip == null) {
+        LOG.debug("Property accountsetup.skip not found in configuration.properties");
+        propertySetupSkip = "false";
+      }
+
+      skipSetup = accountSetupNode != null || propertySetupSkip.equals("true") || PropertyManager.isDevelopping();
+    }
+
+    return skipSetup;
+  }
+
+  public void createAccount(String userNameAccount,
+                            String firstNameAccount,
+                            String lastNameAccount,
+                            String emailAccount,
+                            String userPasswordAccount,
+                            String adminPassword) {
+    MembershipTypeHandler membershipTypeHandler = organizationService.getMembershipTypeHandler();
+    UserHandler userHandler = organizationService.getUserHandler();
+
+    RequestLifeCycle.begin((ComponentRequestLifecycle) organizationService);
+    try {
+      // Set password for admin user
+      try {
+        User adminUser = userHandler.findUserByName(ADMIN_FIRST_NAME);
+        adminUser.setPassword(adminPassword);
+        organizationService.getUserHandler().saveUser(adminUser, false);
+      } catch (Exception e) {
+        LOG.error("Can not set password to the created user", e);
+      }
+
+      // Create user account
+      User user = userHandler.createUserInstance(userNameAccount);
+      user.setPassword(userPasswordAccount);
+      user.setFirstName(firstNameAccount);
+      user.setLastName(lastNameAccount);
+      user.setEmail(emailAccount);
+
+      try {
+        userHandler.createUser(user, true);
+      } catch (Exception e) {
+        LOG.error("Can not create User", e);
+      }
+
+      MembershipType membershipType;
+      // Assign the membership "*:/platform/users" to the created user
+      try {
+        Group group = organizationService.getGroupHandler().findGroupById(PLATFORM_PLATFORM_USERS_GROUP);
+        membershipType = membershipTypeHandler.findMembershipType(MEMBERSHIP_TYPE_MANAGER);
+        organizationService.getMembershipHandler().linkMembership(user, group, membershipType, true);
+      } catch (Exception e) {
+        LOG.error("Can not assign *:/platform/users membership to the created user", e);
+      }
+
+      // Assign the membership "*:/platform/administrators" to the created user
+      try {
+        Group group = organizationService.getGroupHandler().findGroupById(PLATFORM_USERS_GROUP);
+        if (group != null) {
+          membershipType = membershipTypeHandler.findMembershipType(MEMBERSHIP_TYPE_MANAGER);
+          organizationService.getMembershipHandler().linkMembership(user, group, membershipType, true);
+        }
+      } catch (Exception e) {
+        LOG.error("Can not assign *:/platform/administrators membership to the created user", e);
+      }
+
+      // Assign the membership "*:/platform/web-contributors" to the created
+      // user
+      try {
+        Group group = organizationService.getGroupHandler().findGroupById(PLATFORM_WEB_CONTRIBUTORS_GROUP);
+        if (group != null) {
+          membershipType = membershipTypeHandler.findMembershipType(MEMBERSHIP_TYPE_MANAGER);
+          organizationService.getMembershipHandler().linkMembership(user, group, membershipType, true);
+        }
+      } catch (Exception e) {
+        LOG.error("Can not assign *:/platform/web-contributors membership to the created user", e);
+      }
+
+      setSkipSetup(true);
+    } finally {
+      RequestLifeCycle.end();
+    }
+  }
+}

--- a/component/portal/src/main/java/org/exoplatform/account/setup/web/AccountSetupViewServlet.java
+++ b/component/portal/src/main/java/org/exoplatform/account/setup/web/AccountSetupViewServlet.java
@@ -1,0 +1,37 @@
+package org.exoplatform.account.setup.web;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.exoplatform.container.PortalContainer;
+
+/**
+ * @author <a href="fbradai@exoplatform.com">Fbradai</a>
+ */
+public class AccountSetupViewServlet extends HttpServlet {
+
+  private final static String AS_JSP_RESOURCE    = "/WEB-INF/jsp/welcome-screens/accountSetup.jsp";
+
+  private AccountSetupService accountSetupService;
+
+  @Override
+  protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    accountSetupService = PortalContainer.getInstance().getComponentInstanceOfType(AccountSetupService.class);
+
+    if (accountSetupService.mustSkipAccountSetup()) {
+      response.sendRedirect("/");
+    } else {
+      getServletContext().getRequestDispatcher(AS_JSP_RESOURCE).forward(request, response);
+    }
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    doPost(request, response);
+  }
+
+}

--- a/component/portal/src/test/java/org/exoplatform/account/setup/web/AccountSetupServiceTest.java
+++ b/component/portal/src/test/java/org/exoplatform/account/setup/web/AccountSetupServiceTest.java
@@ -1,0 +1,109 @@
+package org.exoplatform.account.setup.web;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.exoplatform.account.setup.web.AccountSetupService;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.commons.utils.PropertyManager;
+import org.exoplatform.services.organization.OrganizationService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AccountSetupServiceTest {
+
+  @Mock
+  private SettingService      settingService;
+
+  @Mock
+  private OrganizationService organizationService;
+
+  @Test
+  public void shouldNotSkipAccountSetupWhenNothingSet() {
+    // Given
+    PropertyManager.setProperty(AccountSetupService.ACCOUNT_SETUP_SKIP_PROPERTY, "");
+    PropertyManager.setProperty(PropertyManager.DEVELOPING, "");
+    when(settingService.get(any(Context.class), any(Scope.class), eq(AccountSetupService.ACCOUNT_SETUP_NODE))).thenReturn(null);
+
+    AccountSetupService accountSetupService = new AccountSetupService(settingService, organizationService);
+
+    // When
+    boolean mustSkip = accountSetupService.mustSkipAccountSetup();
+
+    // Then
+    assertFalse(mustSkip);
+  }
+
+  @Test
+  public void shouldSkipAccountSetupWhenPropertyIsSet() {
+    // Given
+    PropertyManager.setProperty(AccountSetupService.ACCOUNT_SETUP_SKIP_PROPERTY, "true");
+
+    AccountSetupService accountSetupService = new AccountSetupService(settingService, organizationService);
+
+    // When
+    boolean mustSkip = accountSetupService.mustSkipAccountSetup();
+
+    // Then
+    assertTrue(mustSkip);
+
+    PropertyManager.setProperty(AccountSetupService.ACCOUNT_SETUP_SKIP_PROPERTY, "");
+  }
+
+  @Test
+  public void shouldSkipAccountSetupWhenAlreadyDoneOrSkipped() {
+    // Given
+    when(settingService.get(any(Context.class),
+                            any(Scope.class),
+                            eq(AccountSetupService.ACCOUNT_SETUP_NODE))).thenReturn(new SettingValue("true"));
+
+    AccountSetupService accountSetupService = new AccountSetupService(settingService, organizationService);
+
+    // When
+    boolean mustSkip = accountSetupService.mustSkipAccountSetup();
+
+    // Then
+    assertTrue(mustSkip);
+  }
+
+  @Test
+  public void shouldSkipAccountSetupWhenDevelopingModeIsSet() {
+    // Given
+    PropertyManager.setProperty(PropertyManager.DEVELOPING, "true");
+
+    AccountSetupService accountSetupService = new AccountSetupService(settingService, organizationService);
+
+    // When
+    boolean mustSkip = accountSetupService.mustSkipAccountSetup();
+
+    // Then
+    assertTrue(mustSkip);
+
+    PropertyManager.setProperty(PropertyManager.DEVELOPING, "");
+  }
+
+  @Test
+  public void shouldSkipAccountSetupWhenSkipSetup() {
+    // Given
+    AccountSetupService accountSetupService = new AccountSetupService(settingService, organizationService);
+
+    // When
+    boolean mustSkipBefore = accountSetupService.mustSkipAccountSetup();
+    accountSetupService.setSkipSetup(true);
+    boolean mustSkipAfter = accountSetupService.mustSkipAccountSetup();
+
+    // Then
+    assertFalse(mustSkipBefore);
+    assertTrue(mustSkipAfter);
+  }
+}

--- a/component/web/security/pom.xml
+++ b/component/web/security/pom.xml
@@ -50,6 +50,10 @@
       <artifactId>exo.portal.component.web.controller</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.web.api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.gatein.common</groupId>
       <artifactId>common-common</artifactId>
     </dependency>

--- a/component/web/security/src/main/java/org/exoplatform/account/setup/web/AccountSetupFilter.java
+++ b/component/web/security/src/main/java/org/exoplatform/account/setup/web/AccountSetupFilter.java
@@ -1,0 +1,49 @@
+package org.exoplatform.account.setup.web;
+
+import java.io.IOException;
+
+import org.exoplatform.web.filter.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.PortalContainer;
+
+/**
+ * @author <a href="fbradai@exoplatform.com">Fbradai</a>
+ */
+public class AccountSetupFilter implements Filter {
+  private static final String PLF_PLATFORM_EXTENSION_SERVLET_CTX = "/portal";
+
+  private static final String ACCOUNT_SETUP_SERVLET              = "/accountSetup";
+  private static final String ACCOUNT_SETUP_ACTION              = "/accountSetupAction";
+  
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+    HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+
+    ExoContainer container = PortalContainer.getInstance();
+    AccountSetupService accountSetupService = container.getComponentInstanceOfType(AccountSetupService.class);
+
+    boolean setupDone = accountSetupService.mustSkipAccountSetup();
+
+    String requestUri = httpServletRequest.getRequestURI();
+    boolean isRestUri = requestUri.contains(container.getContext().getRestContextName());
+    boolean isAccountSetupUri = requestUri.equals(PLF_PLATFORM_EXTENSION_SERVLET_CTX+ACCOUNT_SETUP_SERVLET) ||
+        requestUri.equals(PLF_PLATFORM_EXTENSION_SERVLET_CTX+ACCOUNT_SETUP_ACTION);
+    if (!isAccountSetupUri && !setupDone && !isRestUri) {
+      ServletContext platformExtensionContext = httpServletRequest.getSession()
+                                                                  .getServletContext()
+                                                                  .getContext(PLF_PLATFORM_EXTENSION_SERVLET_CTX);
+      platformExtensionContext.getRequestDispatcher(ACCOUNT_SETUP_SERVLET).forward(httpServletRequest, httpServletResponse);
+      return;
+    }
+    chain.doFilter(request, response);
+  }
+}

--- a/web/portal/src/main/webapp/WEB-INF/conf/common/account-setup-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/account-setup-configuration.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+               xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <component>
+    <type>org.exoplatform.account.setup.web.AccountSetupService</type>
+  </component>
+
+  <component>
+    <type>org.exoplatform.account.setup.rest.WelcomeScreenRestService</type>
+  </component>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.web.filter.ExtensibleFilter</target-component>
+    <component-plugin>
+      <name>Account Setup Filter</name>
+      <set-method>addFilterDefinitions</set-method>
+      <type>org.exoplatform.web.filter.FilterDefinitionPlugin</type>
+      <priority>3</priority>
+      <init-params>
+        <object-param>
+          <name>Account Setup Filter</name>
+          <object type="org.exoplatform.web.filter.FilterDefinition">
+            <field name="filter">
+              <object type="org.exoplatform.account.setup.web.AccountSetupFilter" />
+            </field>
+            <field name="patterns">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>.*</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>

--- a/web/portal/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -26,6 +26,7 @@
     xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
   <import>war:/conf/common/common-configuration.xml</import>
   <import>war:/conf/common/resource-compressor-configuration.xml</import>
+  <import>war:/conf/common/account-setup-configuration.xml</import>
   <import>war:/conf/common/portlet-container-configuration.xml</import>
   <import>war:/conf/common/autologin-configuration.xml</import>
   <import>war:/conf/common/remindpwd-configuration.xml</import>

--- a/web/portal/src/main/webapp/WEB-INF/jsp/welcome-screens/accountSetup.jsp
+++ b/web/portal/src/main/webapp/WEB-INF/jsp/welcome-screens/accountSetup.jsp
@@ -1,0 +1,144 @@
+<%@ page import="java.util.ResourceBundle" %>
+<%@ page import="org.exoplatform.container.PortalContainer"%>
+<%@ page import="org.exoplatform.services.resources.ResourceBundleService"%>
+<%@ page import="org.exoplatform.portal.config.UserPortalConfigService" %>
+<%@ page import="org.exoplatform.portal.resource.SkinService"%>
+<%@ page import="org.gatein.portal.controller.resource.ResourceRequestHandler" %>
+<%@ page import="org.exoplatform.portal.resource.SkinConfig" %>
+
+<%
+    /**
+     * Copyright ( C ) 2012 eXo Platform SAS.
+     *
+     * This is free software; you can redistribute it and/or modify it
+     * under the terms of the GNU Lesser General Public License as
+     * published by the Free Software Foundation; either version 2.1 of
+     * the License, or (at your option) any later version.
+     *
+     * This software is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+     * Lesser General Public License for more details.
+     *
+     * You should have received a copy of the GNU Lesser General Public
+     * License along with this software; if not, write to the Free
+     * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+     * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+     */
+%>
+<%@ page language="java" %>
+<%
+    String usernameRegExp = System.getProperty("gatein.validators.username.regexp");
+    if(usernameRegExp==null) usernameRegExp="";
+    String formatMsg = System.getProperty("gatein.validators.username.format.message");
+    String usernameMinLength = System.getProperty("gatein.validators.username.length.min");
+    String usernameMaxLength = System.getProperty("gatein.validators.username.length.max");
+    int max=0;
+    int min=0;
+    if(usernameMaxLength!=null) {
+        max = Integer.parseInt(usernameMaxLength);
+    }
+    if(usernameMinLength!=null) {
+        min = Integer.parseInt(usernameMinLength);
+    }
+    String contextPath = request.getContextPath() ;
+    String lang = request.getLocale().getLanguage();
+    response.setCharacterEncoding("UTF-8");
+    response.setContentType("text/html; charset=UTF-8");
+
+  PortalContainer portalContainer = PortalContainer.getCurrentInstance(session.getServletContext());
+  ResourceBundleService service = (ResourceBundleService) portalContainer.getComponentInstanceOfType(ResourceBundleService.class);
+  ResourceBundle rb = service.getResourceBundle(service.getSharedResourceBundleNames(), request.getLocale());
+
+  UserPortalConfigService userPortalConfigService = portalContainer.getComponentInstanceOfType(UserPortalConfigService.class);
+  String skinName = userPortalConfigService.getDefaultPortalSkinName();
+  SkinService skinService = portalContainer.getComponentInstanceOfType(SkinService.class);
+  SkinConfig skin = skinService.getSkin("portal/AccountSetup", skinName);
+  String cssPath = "";
+  if(skin != null) {
+    cssPath = skin.getCSSPath()+"?v="+ResourceRequestHandler.VERSION;
+  } else {
+    cssPath = skinService.getSkin("portal/AccountSetup", "Enterprise").getCSSPath()+"?v="+ResourceRequestHandler.VERSION;
+  }
+%>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%=lang%>" lang="<%=lang%>">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <link rel="shortcut icon" type="image/x-icon"  href="/portal/favicon.ico" />
+    <link id="brandingSkin" rel="stylesheet" type="text/css" href="/rest/v1/platform/branding/css">
+    <link href="/commons-extension/css/welcome-screens/jquery.qtip.min.css" rel="stylesheet" type="text/css" />
+    <link href="<%=cssPath%>" rel="stylesheet" type="text/css" />
+
+    <script type="text/javascript" src="/eXoResources/javascript/jquery-3.2.1.js"></script>
+    <script type="text/javascript" src="/commons-extension/javascript/ie-placeholder.js"></script>
+    <script type="text/javascript" src="/commons-extension/javascript/welcome-screens/accountSetup.js"></script>
+
+</head>
+<div class="backLight"></div>
+<div class="uiWelcomeBox" id="AccountSetup1"  >
+    <div class="header"><%=rb.getString("AccountSetupViewServlet.label.header1")%></div>
+    <div class="content form-horizontal" id="AccountSetup">
+        <h5><%=rb.getString("AccountSetupViewServlet.label.create_account")%></h5>
+        <p class="desc"><%=rb.getString("AccountSetupViewServlet.label.primary_user")%></p>
+        <form name="tcForm" action="<%= contextPath + "/accountSetupAction"%>" method="post">
+            <div class="control-group" id ="usernameId">
+                <label class="control-label"><%=rb.getString("AccountSetupViewServlet.label.userName")%>:</label>
+                <div class="controls">
+                    <input type="text" name="username" id="userNameAccount" placeholder="<%=rb.getString("AccountSetupViewServlet.label.user_Name")%>" class="inputFieldLarge"/>
+                    <input type="hidden" id="usernameRegExpid" value="<%=usernameRegExp%>"/>
+                    <input type="hidden" id="formatMsgid" value="<%=formatMsg%>"/>
+                    <input type="hidden" id="usernameMaxLengthid" value="<%=max%>"/>
+                    <input type="hidden" id="usernameMinLengthid" value="<%=min%>"/>
+                </div>
+            </div>
+            <div class="control-group" id="fullnameId">
+                <label class="control-label"><%=rb.getString("AccountSetupViewServlet.label.full_Name")%>:</label>
+                <div class="controls"><input type="text" name="firstNameAccount" id="firstNameAccount" placeholder="<%=rb.getString("AccountSetupViewServlet.label.first_Name")%>" class="inputFieldMedium"/><input type="text" name="lastNameAccount" id="lastNameAccount" placeholder="<%=rb.getString("AccountSetupViewServlet.label.last_Name")%>" class="inputFieldMedium" /></div>
+            </div>
+            <div class="control-group" id="emailId">
+                <label class="control-label"><%=rb.getString("AccountSetupViewServlet.label.email")%>:</label>
+                <div class="controls"><input type="text" name="emailAccount" id="emailAccount" class="inputFieldLarge" /></div>
+            </div>
+            <div class="control-group" id="passwordId">
+                <label class="control-label"><%=rb.getString("AccountSetupViewServlet.label.password")%>:</label>
+                <div class="controls"><input type="password" name="password" id="userPasswordAccount" class="inputFieldMini" /><span class="confirmLabel"><%=rb.getString("AccountSetupViewServlet.label.confirm")%>:</span><input type="password" name="confirmUserPasswordAccount" id="confirmUserPasswordAccount" class="inputFieldMini" />
+                </div>
+            </div>
+
+            <h5><%=rb.getString("AccountSetupViewServlet.label.addmin_password")%></h5>
+            <p class="desc"><%=rb.getString("AccountSetupViewServlet.label.login_root")%></p>
+            <div class="control-group" id="adminUsernameId">
+                <label class="control-label"><%=rb.getString("AccountSetupViewServlet.label.userName")%>:</label>
+                <div class="controls"><input type="text" name="adminFirstName" id="adminFirstName" placeholder="root" readonly="readonly" class="inputFieldLarge disable" /></div>
+            </div>
+            <div class="control-group" id="adminPasswordId">
+                <label class="control-label"><%=rb.getString("AccountSetupViewServlet.label.password")%>:</label>
+                <div class="controls">
+                    <input type="password" name="adminPassword" id="adminPassword" class="inputFieldMini" /><span class="confirmLabel"><%=rb.getString("AccountSetupViewServlet.label.confirm")%>:</span><input type="password" name="confirmAdminPassword" id="confirmAdminPassword" class="inputFieldMini" />
+                </div>
+            </div>
+    </div>
+    <!-- Please do not make it Button it may cause blocker problem -->
+    <div class="bottom">
+        <button class="btn btn-primary" id="continueButton" onclick="WelcomeScreens.exit();return false;"><%=rb.getString("AccountSetupViewServlet.label.submit")%></button>
+        <button class="btn" name="setupbutton" value="skipform"><%=rb.getString("AccountSetupViewServlet.label.skip")%></button>
+    </div>
+</div>
+</div>
+<div>
+    <!--	<div class="backLight"></div>    -->
+    <div class="uiWelcomeBox" id="Greetings" style="display: none">
+        <div class="header"><%=rb.getString("AccountSetupViewServlet.label.greetings")%></div>
+        <div class="content form-horizontal" id="AccountSetup">
+            <p>
+                <strong><%=rb.getString("AccountSetupViewServlet.label.almost_done")%></strong>, <%=rb.getString("AccountSetupViewServlet.label.add_your_colleagues")%>.
+            </p>
+            <div class="screenShot"><a href="javascript:void(0);"></a></div>
+        </div>
+        <div class="bottom"><button name="setupbutton" value="submitform" class="btn btn-primary"><%=rb.getString("AccountSetupViewServlet.label.start")%></button></div>
+    </div>
+</div>
+</form>
+</html>

--- a/web/portal/src/main/webapp/WEB-INF/web.xml
+++ b/web/portal/src/main/webapp/WEB-INF/web.xml
@@ -263,9 +263,31 @@
     <servlet-name>ServiceWorkerServlet</servlet-name>
     <servlet-class>org.exoplatform.web.pwa.ServiceWorkerServlet</servlet-class>
   </servlet>
-
+  
+  <servlet>
+    <servlet-name>accountSetup</servlet-name>
+    <servlet-class>org.exoplatform.account.setup.web.AccountSetup</servlet-class>
+  </servlet>
+  
+  <servlet>
+    <servlet-name>accountSetupViewServlet</servlet-name>
+    <servlet-class>org.exoplatform.account.setup.web.AccountSetupViewServlet</servlet-class>
+  </servlet>
+  
+  
   <!--  =================================================================  -->
-
+  
+  <servlet-mapping>
+    <servlet-name>accountSetup</servlet-name>
+    <url-pattern>/accountSetupAction</url-pattern>
+  </servlet-mapping>
+  
+  <servlet-mapping>
+    <servlet-name>accountSetupViewServlet</servlet-name>
+    <url-pattern>/accountSetup</url-pattern>
+  </servlet-mapping>
+  
+  
   <servlet-mapping>
     <servlet-name>LoginServlet</servlet-name>
     <url-pattern>/login</url-pattern>


### PR DESCRIPTION
…exposed in a GET request

Before this fix, when we use the initial account wizard, we make a GET request on /portal/login to automatically log the user. The password is added as query String of this request and so exposed in access log.
This fix moves the AccountSetup servlet from commons to portal, and logs the user directly after form submit without any additionnal request, so that the password is not exposed.