### PR TITLE
Task-41419: Allow creating file even if the file binary is quarantined fom FS by antimalware

### DIFF
--- a/component/file-storage/src/main/java/org/exoplatform/commons/file/resource/FileSystemResourceProvider.java
+++ b/component/file-storage/src/main/java/org/exoplatform/commons/file/resource/FileSystemResourceProvider.java
@@ -131,13 +131,17 @@ public class FileSystemResourceProvider implements BinaryProvider {
   public InputStream getStream(String name) {
     try {
       return new FileInputStream(getFile(name));
-    } catch (IOException e) {
+      
+    } catch (FileNotFoundException fileNotFoundException) {
       try {
-        log.error("Unable to read binary content from disk for file " + getFile(name).getPath() + ". The binary content is not "
-                      + "accessible, it was removed, or may have been quarantined by an antivirus.",e);
+        log.warn("Unable to read binary content from disk for file " + getFile(name).getPath() + ". The binary content is not "
+                      + "accessible, it was removed, or may have been quarantined by an antivirus.");
       } catch (IOException ioException) {
         log.error("Unable to get file object for name " + name, ioException);
       }
+    }
+    catch (IOException ioException) {
+      log.error("Unable to get file object for name " + name, ioException);
     }
     return null;
   }

--- a/component/file-storage/src/main/java/org/exoplatform/commons/file/services/impl/FileServiceImpl.java
+++ b/component/file-storage/src/main/java/org/exoplatform/commons/file/services/impl/FileServiceImpl.java
@@ -178,12 +178,8 @@ public class FileServiceImpl implements FileService {
             binaryProvider.put(fileInfo.getChecksum(), inputStream);
             created = true;
           }
-          if (binaryProvider.exists(fileInfo.getChecksum())) {
-            createdFileInfoEntity = dataStorage.create(fileInfo, nameSpace);
-            return createdFileInfoEntity;
-          } else {
-            throw new FileStorageException("Error while writing file " + fileInfo.getName());
-          }
+          createdFileInfoEntity = dataStorage.create(fileInfo, nameSpace);
+          return createdFileInfoEntity;
         } catch (Exception e) {
           try {
             if (created) {


### PR DESCRIPTION
- Before this fix, when we add an attachment on a wiki page and detected as a malware, the generated binary in FS is quarantined by the antimalware, the upload is not finished correctly and an exception is displayed.
- This fix will allow the upload even if the file binary is quarantined by the antimalware