### PR TITLE
41604 : Enable disabling users when removed from LDAP/AD

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
@@ -315,7 +315,7 @@ public class PicketLinkIDMExternalStoreService implements IDMExternalStoreServic
         return true;
       }
     } else {
-      if (idmUser == null) {
+      if (idmUser == null || !user.isEnabled()) { // user is present inside eXo DB but not on external store, or user is present in both stores and is disabled
         return true;
       }
     }

--- a/component/identity/src/test/resources/ldap/ldap/test-user-disable-opends.ldif
+++ b/component/identity/src/test/resources/ldap/ldap/test-user-disable-opends.ldif
@@ -1,0 +1,19 @@
+dn: uid=jdukeX,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jdukeX
+cn: Java DukeX
+sn: DukeX
+userPassword: theduke
+mail: jdukeX@email.com
+
+dn: uid=jdukeY,ou=People,o=test,dc=portal,dc=example,dc=com
+objectclass: top
+objectclass: inetOrgPerson
+objectclass: person
+uid: jdukeY
+cn: Java Duke
+sn: DukeY
+userPassword: thedukeY
+mail: jdukeY@email.com

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-externalstore-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-externalstore-configuration.xml
@@ -59,6 +59,11 @@
 				<description>Cron expression used to schedule the job that will process periodically data injected in queue (Default value = every minute)</description>
 				<value>${exo.idm.externalStore.queue.processing.cronExpression:0 */1 * ? * *}</value>
 			</value-param>
+			<value-param>
+				<name>exo.idm.externalStore.entries.missing.delete</name>
+				<description>If TRUE delete users if they are not present in external store, otherwise disable them (Default : delete users)</description>
+				<value>${exo.idm.externalStore.entries.missing.delete:true}</value>
+			</value-param>
 		</init-params>
 	</component>
 


### PR DESCRIPTION
When users are removed from LDAP/AD or are not retrievable for other reasons (Communication failure, LDAP Filter modified), they are removed from the internal store.
With this fix, we will be able to configure the Entity import service and define a default policy : 

- exo.idm.externalStore.entries.missing.delete = true -> Remove user if not present in external store
- exo.idm.externalStore.entries.missing.delete = false -> Disable user if not present in external store