### PR TITLE
TASK-42595 Allow to access a public site and pages

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/portal/portal/sharedlayout.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/portal/portal/sharedlayout.xml
@@ -26,7 +26,6 @@
     id="ParentSiteContainer"
     template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
 
-  <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
   <container id="UITopBarContainer" template="system:/groovy/portal/webui/container/UITopBarContainer.gtmpl">
     <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
     <container id="left-topNavigation-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl" attribute="">


### PR DESCRIPTION
Prior to this change, the global sharedlayout.xml has a global permission into it that avoids delegating permissions check to sites & pages API.
With this fix, the sites & pages permission will be applied to allow or not displaying pages contents.