### PR TITLE
Task-42659 : Fix the bug of exo user not allowed to change password when property exo.portal.allow.change.external.password not displayed.

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
@@ -528,7 +528,7 @@ public class UserRestResourcesV1 implements ResourceContainer {
     if (user == null) {
       throw new WebApplicationException(Response.Status.BAD_REQUEST);
     }
-    boolean allowChangePassword = Boolean.valueOf(System.getProperty("exo.portal.allow.change.external.password").toString()) || user.isInternalStore();
+    boolean allowChangePassword = user.isInternalStore() || (System.getProperty("exo.portal.allow.change.external.password") != null && Boolean.valueOf(System.getProperty("exo.portal.allow.change.external.password").toString()));
     return Response.ok().entity("{\"isSynchronizedUserAllowedToChangePassword\":\"" + allowChangePassword + "\"}").build();
   }
 

--- a/component/portal/src/test/java/org/exoplatform/portal/rest/UserRestResourcesTest.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/rest/UserRestResourcesTest.java
@@ -205,6 +205,54 @@ public class UserRestResourcesTest extends BaseRestServicesTestCase {
     assertEquals(String.valueOf(resp.getEntity()), 204, resp.getStatus());
   }
 
+  public void testIsInternalUserAllowedToChangePassword() throws Exception {
+    // The property exo.portal.allow.change.external.password isn't displayed (null)
+    // Given
+    startUserSession(USER_1);
+
+    // When
+    ContainerResponse resp = launcher.service("GET",
+                                              "/v1/users/isSynchronizedUserAllowedToChangePassword",
+                                              "",
+                                              null,
+                                              null,
+                                              null);
+
+    // Then
+    assertEquals(String.valueOf(resp.getEntity()), 200, resp.getStatus());
+    assertTrue(String.valueOf(resp.getEntity()).contains("true"));
+    //Check the fail case
+    assertNull(System.getProperty("exo.portal.allow.change.external.password"));
+
+    // The property exo.portal.allow.change.external.password is true
+    //When
+    System.setProperty("exo.portal.allow.change.external.password", "true");
+    resp = launcher.service("GET",
+                            "/v1/users/isSynchronizedUserAllowedToChangePassword",
+                            "",
+                            null,
+                            null,
+                            null);
+
+    // Then
+    assertEquals(String.valueOf(resp.getEntity()), 200, resp.getStatus());
+    assertTrue(String.valueOf(resp.getEntity()).contains("true"));
+
+    // The property exo.portal.allow.change.external.password is false
+    //When
+    System.setProperty("exo.portal.allow.change.external.password", "false");
+    resp = launcher.service("GET",
+                            "/v1/users/isSynchronizedUserAllowedToChangePassword",
+                            "",
+                            null,
+                            null,
+                            null);
+
+    // Then
+    assertEquals(String.valueOf(resp.getEntity()), 200, resp.getStatus());
+    assertTrue(String.valueOf(resp.getEntity()).contains("true"));
+  }
+
   public void testCreateUser() throws Exception {
     when(userHandler.findUserByName(eq(USER_2), any())).thenReturn(null);
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
The problem is due to the property: exo.portal.allow.change.external.password is null in isSynchronizedUserAllowedToChangePassword, so I add a check to verify if the property is null or not.



