### PR TITLE
TASK-43200 Improve user navigations UX

### DIFF
--- a/portlet/web/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
+++ b/portlet/web/src/main/webapp/vue-apps/administration-navigation/components/ExoAdministrationHamburgerNavigation.vue
@@ -138,13 +138,12 @@ export default {
           <exo-administration-navigations :navigations="navigations" />
         `,
       });
-      const vuetify = this.vuetify;
       new VueHamburgerMenuItem({
         i18n: new VueI18n({
           locale: this.$i18n.locale,
           messages: this.$i18n.messages,
         }),
-        vuetify,
+        vuetify: this.vuetify,
       }).$mount(parentId);
     },
     openDrawer() {

--- a/portlet/web/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
+++ b/portlet/web/src/main/webapp/vue-apps/hamburger-menu/components/ExoHamburgerMenuNavigation.vue
@@ -91,6 +91,7 @@ export default {
   },
   created() {
     document.addEventListener('exo-hamburger-menu-navigation-refresh', this.refreshMenu);
+    document.addEventListener('closeAllDrawers', () => this.hamburgerMenu = false);
     $(document).on('keydown', (event) => {
       if (event.key === 'Escape') {
         this.hamburgerMenu = false;
@@ -161,6 +162,7 @@ export default {
       if (this.openedSecondLevel !== contentDetail.id && this.vueChildInstances[contentDetail.id].mountSecondLevel) {
         this.openedSecondLevel = contentDetail.id;
         this.vueChildInstances[contentDetail.id].mountSecondLevel('.HamburgerMenuSecondLevelParent > div');
+        document.dispatchEvent(new CustomEvent('drawerOpened'));
       }
     },
     hideSecondLevel() {

--- a/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -912,6 +912,20 @@
   </module>
 
   <module>
+    <name>inPageNavigation</name>
+    <load-group>baseGRP</load-group>
+    <script>
+      <path>/javascript/eXo/portal/InPageNavigation.js</path>
+    </script>
+    <depends>
+      <module>jquery</module>
+    </depends>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+  </module>
+
+  <module>
     <name>mobileSwipeContainer</name>
     <script>
       <path>/javascript/eXo/portal/MobileSwipeContainer.js</path>

--- a/web/eXoResources/src/main/webapp/javascript/eXo/core/TopbarLoading.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/core/TopbarLoading.js
@@ -1,17 +1,20 @@
-function() {
+(function($) {
   let operationsInProgress = 0;
+  return {
+    init: () => {
+      document.addEventListener('displayTopBarLoading', () => {
+        operationsInProgress++;
+        $('.TopbarLoadingContainer').removeClass('hidden');
+      });
 
-  document.addEventListener('displayTopBarLoading', () => {
-    operationsInProgress++;
-    $('.TopbarLoadingContainer').removeClass('hidden');
-  });
-
-  document.addEventListener('hideTopBarLoading', () => {
-    if (operationsInProgress > 0) {
-      operationsInProgress--;
-    }
-    if (operationsInProgress === 0) {
-      $('.TopbarLoadingContainer').addClass('hidden');
-    }
-  });
-}();
+      document.addEventListener('hideTopBarLoading', () => {
+        if (operationsInProgress > 0) {
+          operationsInProgress--;
+        }
+        if (operationsInProgress === 0) {
+          $('.TopbarLoadingContainer').addClass('hidden');
+        }
+      });
+    },
+  };
+})($);

--- a/web/eXoResources/src/main/webapp/javascript/eXo/core/extensionRegistry.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/core/extensionRegistry.js
@@ -61,10 +61,15 @@
   
   function registerExtension(app, extensionType, extensionContent) {
     var module = findModule(app, true);
-    
-    var extension = new Extension(extensionType, extensionContent);
-    module.extensions.push(extension);
 
+    const extension = new Extension(extensionType, extensionContent);
+    const extensionId = extensionContent.id || extensionContent.key;
+    const existingExtensionIndex = module.extensions.findIndex(ext => (ext.extensionContent.id || ext.extensionContent.key) === extensionId);
+    if (!extensionId || existingExtensionIndex < 0) {
+      module.extensions.push(extension);
+    } else {
+      module.extensions.splice(existingExtensionIndex, 1, extension);
+    }
     document.dispatchEvent(new CustomEvent(`extension-${app}-${extensionType}-updated`));
   }
   

--- a/web/eXoResources/src/main/webapp/javascript/eXo/portal/InPageNavigation.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/portal/InPageNavigation.js
@@ -1,0 +1,133 @@
+(function($) {
+  const inPageNavigation = {
+    installNewCSS: (newHead, newBody) => {
+      newHead.match(/<link.*id=".*".*>/g).forEach(link => {
+        const id = link.match(/id="([^"]*)"/i)[1];
+        if (!document.querySelector(`#${id}`)) {
+          const skinTypeResult = link.match(/skin-type="([a-z]*-skin)"/);
+          if (skinTypeResult && skinTypeResult.length === 2) {
+            const skinType = skinTypeResult[1];
+            const $lastSkinTypeDefinition = $(`[skin-type="${skinType}"]`).last();
+            if ($lastSkinTypeDefinition.length) {
+              // Install new CSS in the same skin files categories (portal, portlet or custom)
+              $lastSkinTypeDefinition.after(link);
+              return;
+            }
+          }
+          // Install new CSS from newly downloaded head
+          $(document.head).append(link);
+        }
+      });
+      newBody.match(/<link.*id=".*".*>/g).forEach(link => {
+        const id = link.match(/id="([^"]*)"/i)[1];
+        if (!document.querySelector(`#${id}`)) {
+          // Install new CSS from newly downloaded body
+          $(document.head).append(link);
+        }
+        newBody = newBody.replace(link, '');
+      });
+      return newBody;
+    },
+    installNewJS: (newHead) => {
+      const replacableScriptsIterator = newHead.matchAll(/<script[^>]*id="[^>]*"[^>]*>/g);
+      let scriptIteratorElement = replacableScriptsIterator.next().value;
+      while (scriptIteratorElement) {
+        const script = scriptIteratorElement[0];
+        const id = script.match(/id="([^"]*)"/i)[1];
+        const scriptContent = newHead.substring(scriptIteratorElement.index, newHead.indexOf('</script>', scriptIteratorElement.index));
+        const oldScriptElement = document.querySelector(`#${id}`);
+        if (oldScriptElement) {
+          oldScriptElement.remove();
+        }
+        const scriptElement = `${scriptContent}</script>`;
+        $(document.head).append(scriptElement);
+        scriptIteratorElement = replacableScriptsIterator.next().value;
+      }
+    },
+    handleDownloadedContent: (htmlContent) => {
+      const newDocument = $('<html />');
+      newDocument.html(htmlContent);
+
+      const newHead = htmlContent.substring(htmlContent.search('<head') + htmlContent.match(/<head.*>/g)[0].length, htmlContent.search('</head>'));
+      let newBody = htmlContent.substring(htmlContent.search('<body') + htmlContent.match(/<body.*>/g)[0].length, htmlContent.lastIndexOf('</body>'));
+
+      window.document.head.querySelector('title').innerHTML = $("<div/>").html(newHead.substring(newHead.search('<title>') + 7, newHead.search('</title>'))).text();
+      document.removeEventListeners();
+      document.body.innerHTML = '';
+
+      newBody = inPageNavigation.installNewCSS(newHead, newBody);
+      inPageNavigation.installNewJS(newHead);
+
+      $(document.body).html(newBody);
+
+      window.setTimeout(() => {
+        $('body').removeClass('hide-scroll');
+        $(window).trigger('resize');
+        document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
+      }, 1000);
+    },
+    displayLoadingEffect: () => {
+      document.dispatchEvent(new CustomEvent('closeAllDrawers'));
+      document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
+      $('#UISiteBody').remove();
+    },
+    handleLinks: () => {
+      const $linksToHandle = $('a[href]:not([href=""]):not([href="#"]):not([load-handled])');
+      $linksToHandle.attr('load-handled', 'true');
+
+      $linksToHandle.click(function(event) {
+        const newLocationHref = $(this).attr('href');
+        const newTarget = $(this).attr('target');
+        const sameTargetWindow = !newTarget || newTarget === '_self';
+        const sameSiteURI = newLocationHref && (newLocationHref.indexOf('/') === 0 || newLocationHref.indexOf(window.location.origin) === 0);
+
+        if (sameTargetWindow && sameSiteURI && !event.ctrlKey && !event.altKey && !event.shiftKey) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (window.handlingLink) {
+            return;
+          }
+          window.handlingLink = true;
+          window.history.replaceState('', newLocationHref, newLocationHref);
+
+          inPageNavigation.displayLoadingEffect();
+          const oldAssetVersion = eXo.env.client.assetsVersion;
+          fetch(newLocationHref, {
+            credentials: 'include',
+            method: 'GET'
+          })
+            .then(resp => {
+              if (resp && resp.status == 200) {
+                return resp.text();
+              }
+            })
+            .then(inPageNavigation.handleDownloadedContent)
+            .then(() => {
+              // If feature has been disabled or the assets versions has been modified, then reload page
+              if (!eXo.env.client.InPageNavigationEnabled || oldAssetVersion !== eXo.env.client.assetsVersion) {
+                window.location.reload();
+              }
+            })
+            .finally(() => {
+              window.handlingLink = false;
+            });
+        }
+      });
+    },
+    init: () => {
+      document.addEventListener('hideTopBarLoading', () => {
+        window.setTimeout(() => {
+          inPageNavigation.handleLinks();
+        }, 200);
+      });
+      document.addEventListener('drawerOpened', () => {
+        window.setTimeout(() => {
+          inPageNavigation.handleLinks();
+        }, 500);
+      });
+      inPageNavigation.handleLinks();
+    },
+  };
+  return inPageNavigation;
+})($);

--- a/web/portal/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -67,6 +67,7 @@
   <import>war:/conf/portal/module-configuration.xml</import>
   <import>war:/conf/portal/dynamic-container-configuration.xml</import>
   <import>war:/conf/portal/page-template-configuration.xml</import>
+  <import>war:/conf/portal/inpage-navigation-configuration.xml</import>
 
   <import>war:/conf/branding/branding-configuration.xml</import>
 

--- a/web/portal/src/main/webapp/WEB-INF/conf/portal/inpage-navigation-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/portal/inpage-navigation-configuration.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2021 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 2.1 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<configuration
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+    xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+  <external-component-plugins>
+    <target-component>org.exoplatform.groovyscript.text.TemplateService</target-component>
+    <component-plugin>
+      <name>UIPortalApplication-Start-head</name>
+      <set-method>addTemplateExtension</set-method>
+      <type>org.exoplatform.groovyscript.text.TemplateExtensionPlugin</type>
+      <init-params>
+        <values-param>
+          <name>templates</name>
+          <description>Scripts to declare in page head element for InPageNavigation feature</description>
+          <value>war:/groovy/portal/webui/workspace/UIInPageNavigationPolyfill.gtmpl</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>UIPortalApplication-head</name>
+      <set-method>addTemplateExtension</set-method>
+      <type>org.exoplatform.groovyscript.text.TemplateExtensionPlugin</type>
+      <init-params>
+        <values-param>
+          <name>templates</name>
+          <description>Scripts to declare in page head element for InPageNavigation feature</description>
+          <value>war:/groovy/portal/webui/workspace/UIInPageNavigation.gtmpl</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>

--- a/web/portal/src/main/webapp/WEB-INF/conf/pwa/service-worker.js
+++ b/web/portal/src/main/webapp/WEB-INF/conf/pwa/service-worker.js
@@ -177,3 +177,6 @@ this.addEventListener('activate', function(event) {
     })
   );
 });
+
+workbox.core.skipWaiting();
+workbox.core.clientsClaim();

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIInPageNavigation.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIInPageNavigation.gtmpl
@@ -1,0 +1,11 @@
+<%
+  def userName = _ctx.getRequestContext().getRemoteUser();
+  def featureService = uicomponent.getApplicationComponent(org.exoplatform.commons.api.settings.ExoFeatureService.class);
+  def InPageNavigationEnabled = featureService.isFeatureActiveForUser("InPageNavigation", userName);
+%>
+<script type="text/javascript" id="portalInPageScript">
+  eXo.env.client.InPageNavigationEnabled = <%=InPageNavigationEnabled%>;
+  <% if (InPageNavigationEnabled) { %>
+    require(["SHARED/inPageNavigation"], inPageNavigation => inPageNavigation.init());
+  <% } %>
+</script>

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIInPageNavigationPolyfill.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIInPageNavigationPolyfill.gtmpl
@@ -1,0 +1,40 @@
+<%
+  def userName = _ctx.getRequestContext().getRemoteUser();
+  def featureService = uicomponent.getApplicationComponent(org.exoplatform.commons.api.settings.ExoFeatureService.class);
+  def InPageNavigationEnabled = featureService.isFeatureActiveForUser("InPageNavigation", userName);
+%>
+<% if (InPageNavigationEnabled) { %>
+  <script type="text/javascript">
+    function installDocumentEventListenersPolyFill() {
+      document.originalAddEventListener = document.addEventListener;
+      document.addEventListener = (type, listener, useCapture) => {
+        document.originalAddEventListener(type, listener, useCapture);
+
+        if (document.head.eventsHandler) {
+          document.head.eventsHandler.setAttribute(type, 'true');
+          return document.head.eventsHandler.addEventListener(type, listener, useCapture);
+        }
+      };
+      document.originalDispatchEvent = document.dispatchEvent;
+      document.dispatchEvent = (event, target) => {
+        if (document.head.eventsHandler) {
+          if (document.head.eventsHandler.getAttribute(event.type)) {
+            return document.head.eventsHandler.dispatchEvent(event, target);
+          } else {
+            document.originalDispatchEvent(event, target);
+          }
+        } else {
+          document.originalDispatchEvent(event, target);
+        }
+      };
+      document.removeEventListeners = () => {
+        if (document.head.eventsHandler) {
+          document.head.eventsHandler.remove();
+        }
+        document.head.eventsHandler = document.createElement("events-handler");
+      };
+      document.removeEventListeners();
+    }
+    installDocumentEventListenersPolyFill();
+  </script>
+<% } %>

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -84,17 +84,17 @@
     <% for (skinConfig in portalSkins) {
          def url = skinConfig.createURL(rcontext.controllerContext);
          url.setOrientation(orientation); %>
-      <link id="${skinConfig.id}" rel="stylesheet" type="text/css" href="$url" />
+      <link id="${skinConfig.id}" rel="stylesheet" type="text/css" href="$url" skin-type="portal-skin" />
     <% } %>
     <% for (portletSkin in portletSkins) {
          def url = portletSkin.createURL(rcontext.controllerContext);
          url.setOrientation(orientation); %>
-      <link id="${portletSkin.id}" rel="stylesheet" type="text/css" href= "$url" />
+      <link id="${portletSkin.id}" rel="stylesheet" type="text/css" href= "$url" skin-type="portlet-skin" />
     <% } %>
     <% for (customSkin in customSkins) {
          def url = customSkin.createURL(rcontext.controllerContext);
          url.setOrientation(orientation); %>
-      <link id="${customSkin.id}" rel="stylesheet" type="text/css" href= "$url" />
+      <link id="${customSkin.id}" rel="stylesheet" type="text/css" href= "$url" skin-type="custom-skin" />
     <% } %>
 
     <!-- Scripts -->
@@ -111,6 +111,8 @@
      <% if (org.exoplatform.commons.utils.PropertyManager.isDevelopping()) { %>
           eXo.developing = true ;
      <% } %>
+   </script>
+   <script type="text/javascript" id="portalHeadScripts">
      eXo.env.portal.context = "<%=docBase%>";
      eXo.env.portal.accessMode = "<%= rcontext.getAccessPath() == 0 ? "public" : "private" %>";
      eXo.env.portal.portalName = "<%=rcontext.getPortalOwner()%>";
@@ -138,6 +140,8 @@
      eXo.session.canKeepState = $canKeepState;
      eXo.session.isOpen = <%=uicomponent.isSessionOpen()%> ;
      eXo.session.itvTime = ${session.getMaxInactiveInterval()} ;
+
+     require(['SHARED/topbarLoading'], topbarLoading => topbarLoading.init());
    </script>
    <%
      def headerElements = rcontext.getExtraMarkupHeadersAsStrings();

--- a/webui/framework/src/main/java/org/exoplatform/webui/core/lifecycle/WebuiBindingContext.java
+++ b/webui/framework/src/main/java/org/exoplatform/webui/core/lifecycle/WebuiBindingContext.java
@@ -148,6 +148,17 @@ public class WebuiBindingContext extends BindingContext {
     }
 
     public void include(String name, ResourceResolver resourceResolver) throws Exception {
+        if (PropertyManager.isDevelopping()) {
+          WebuiRequestContext context = getRequestContext();
+          WebuiRequestContext rootContext = (WebuiRequestContext) context.getParentAppRequestContext();
+          if (rootContext == null)
+            rootContext = context;
+          long lastAccess = rootContext.getUIApplication().getLastAccessApplication();
+          if (resourceResolver.isModified(name, lastAccess)) {
+            log.debug("Invalidate the template: {}", name);
+            service_.invalidateTemplate(name, resourceResolver);
+          }
+        }
         service_.include(name, clone(), resourceResolver);
     }
 


### PR DESCRIPTION
Prior to this change, when clicking on any site link to access a page, the whole page is loaded with almost the same CSS & JS resources.
This new feature (when enabled by a Feature Switch) allows to override the default browser behavior that will load the whole page, by fetching the DOM of the new page only and add new CSS & JS resources only if it's missing in currently loaded page.

In order to intercept links clicking event, a script will be executed to inject an "onclick" event that will prevent page loading if the link doesn't have a target window (different from `_self`) and the link accesses a page of current site. (no `navigateTo` method should be used ;-) )

The new requested page is loaded by replacing the whole `body` element by the new one, but the `head` elements are processed one by one to avoid reloading CSS & JS, thus adding a blinking effect.

Knowing that the page isn't reloaded entirely, the document events will remain between pages, thus a `polyfill` has been added to override `document.addEventListener` & `document.dispatchEvent`, so that the list of registered events can be cleared between page displays (No standard JS method to clear document events).

Note: a `skin-type` attribute has been added in CSS links to preserve CSS loading order when dynamically adding CSS links when switching from a page to another.