### PR TITLE
44284 : Build error for Meeds project

### DIFF
--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -42,6 +42,12 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.gatein.common</groupId>


### PR DESCRIPTION
Meeds fialed to build, we need to remove **javax.xml.stream:stax-api** from the dependencies list.