### PR TITLE
TASK-44539 : improved disabled user detection from AD

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/EntityMapperUtils.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/EntityMapperUtils.java
@@ -127,6 +127,8 @@ public class EntityMapperUtils {
 
       // used when populating User from the platform ; it return true or false
       // if it is from AD it always returns false since it is a number .
+      /* in AD , the (2) value represents a disabled user and  Many UserAccessControl values represent an enabled user like 65536 which represent an enabled user
+      whose password never expires : this user is detected as disabled if he has 65538 as UserAccessControl value   */
       Boolean enabled = Boolean.parseBoolean(attrs.get(USER_ENABLED).getValue().toString()) ;
 
       if (isInteger(status))
@@ -146,8 +148,8 @@ public class EntityMapperUtils {
     return changed;
   }
   private static Boolean isUserEnabled (int status) {
-    String BinaryStatus = Integer.toBinaryString(status);
-    if(BinaryStatus.charAt(BinaryStatus.length()-2) == '1') {
+    String binaryStatus = Integer.toBinaryString(status);
+    if(binaryStatus.charAt(binaryStatus.length()-2) == '1') {
       return false;
     }
     return true;

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/EntityMapperUtils.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/EntityMapperUtils.java
@@ -148,6 +148,7 @@ public class EntityMapperUtils {
     }
     return changed;
   }
+
   private static Boolean isUserEnabled (int status) {
     String binaryStatus = Integer.toBinaryString(status);
     if(binaryStatus.charAt(binaryStatus.length()-2) == '1') {
@@ -155,6 +156,7 @@ public class EntityMapperUtils {
     }
     return true;
   }
+
   private static boolean isInteger( String input ) {
     try {
       Integer.parseInt( input );

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/EntityMapperUtils.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/EntityMapperUtils.java
@@ -129,9 +129,9 @@ public class EntityMapperUtils {
       // if it is from AD it always returns false since it is a number .
       Boolean enabled = Boolean.parseBoolean(attrs.get(USER_ENABLED).getValue().toString()) ;
 
-      if (status.equals("512")  )
+      if (isInteger(status))
       {
-        enabled = true;
+        enabled = isUserEnabled(Integer.parseInt(status));
       }
       changed |= checkIfChanged && !Objects.equals(enabled, user.isEnabled());
 
@@ -145,5 +145,20 @@ public class EntityMapperUtils {
     }
     return changed;
   }
-
+  private static Boolean isUserEnabled (int status) {
+    String BinaryStatus = Integer.toBinaryString(status);
+    if(BinaryStatus.charAt(BinaryStatus.length()-2) == '1') {
+      return false;
+    }
+    return true;
+  }
+  private static boolean isInteger( String input ) {
+    try {
+      Integer.parseInt( input );
+      return true;
+    }
+    catch( Exception e ) {
+      return false;
+    }
+  }
 }

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/EntityMapperUtils.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/EntityMapperUtils.java
@@ -127,8 +127,9 @@ public class EntityMapperUtils {
 
       // used when populating User from the platform ; it return true or false
       // if it is from AD it always returns false since it is a number .
-      /* in AD , the (2) value represents a disabled user and  Many UserAccessControl values represent an enabled user like 65536 which represent an enabled user
-      whose password never expires : this user is detected as disabled if he has 65538 as UserAccessControl value   */
+      // in AD , the (2) value represents a disabled user and  Many UserAccessControl values represent an enabled user like 65536 which represent an enabled user .
+      //whose password never expires : this user is detected as disabled if he has 65538 as UserAccessControl value   */
+      // UserAccessControl Documentation Link : https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
       Boolean enabled = Boolean.parseBoolean(attrs.get(USER_ENABLED).getValue().toString()) ;
 
       if (isInteger(status))

--- a/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
@@ -142,11 +142,14 @@ public class TestLDAPOrganization extends TestOrganization {
     Attribute attr1 = new SimpleAttribute("enabled");
     Attribute attr2 = new SimpleAttribute("enabled");
     Attribute attr3 = new SimpleAttribute("enabled");
-
+    // 65536 represent an enabled user whose password never expires
     attr.addValue(65536);
+    // 65538 represent an disabled user whose password never expires
     attr1.addValue(65538);
-    attr1.addValue(8388608);
-    attr1.addValue(8388610);
+    // 8388608 represent an enabled user whose password expired
+    attr2.addValue(8388608);
+    // 83886010 represent an disabled user whose password expired
+    attr3.addValue(8388610);
 
     attrs.put("enabled",attr);
     assertFalse(EntityMapperUtils.populateUser(u,attrs,true));
@@ -155,10 +158,10 @@ public class TestLDAPOrganization extends TestOrganization {
     assertTrue(EntityMapperUtils.populateUser(u,attrs,true));
     attrs.remove("enabled",attr1);
     attrs.put("enabled",attr2);
-    assertFalse(EntityMapperUtils.populateUser(u,attrs,true));
+    assertTrue(EntityMapperUtils.populateUser(u,attrs,true));
     attrs.remove("enabled",attr2);
     attrs.put("enabled",attr3);
-    assertFalse(EntityMapperUtils.populateUser(u,attrs,true));
+    assertTrue(EntityMapperUtils.populateUser(u,attrs,true));
 
   }
 

--- a/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
@@ -10,15 +10,12 @@ import org.exoplatform.component.test.ContainerScope;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.idm.Config;
-import org.exoplatform.services.organization.idm.PicketLinkIDMOrganizationServiceImpl;
-import org.exoplatform.services.organization.idm.UserDAOImpl;
+import org.exoplatform.services.organization.idm.*;
 import org.exoplatform.services.organization.idm.cache.CacheableUserHandlerImpl;
+import org.picketlink.idm.api.Attribute;
+import org.picketlink.idm.impl.api.SimpleAttribute;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Created by exo on 5/5/16.
@@ -135,6 +132,34 @@ public class TestLDAPOrganization extends TestOrganization {
     test2 = organization.getUserHandler().findUserByName("admin");
     assertNull(test2);
     end();
+  }
+  public void testEnabledUserDetection() throws Exception{
+    User u = uHandler.createUserInstance("test");
+    ((UserImpl) u).setEnabled(true);
+
+    Map<String, Attribute> attrs = new HashMap<>();
+    Attribute attr = new SimpleAttribute("enabled");
+    Attribute attr1 = new SimpleAttribute("enabled");
+    Attribute attr2 = new SimpleAttribute("enabled");
+    Attribute attr3 = new SimpleAttribute("enabled");
+
+    attr.addValue(65536);
+    attr1.addValue(65538);
+    attr1.addValue(8388608);
+    attr1.addValue(8388610);
+
+    attrs.put("enabled",attr);
+    assertFalse(EntityMapperUtils.populateUser(u,attrs,true));
+    attrs.remove("enabled",attr);
+    attrs.put("enabled",attr1);
+    assertTrue(EntityMapperUtils.populateUser(u,attrs,true));
+    attrs.remove("enabled",attr1);
+    attrs.put("enabled",attr2);
+    assertFalse(EntityMapperUtils.populateUser(u,attrs,true));
+    attrs.remove("enabled",attr2);
+    attrs.put("enabled",attr3);
+    assertFalse(EntityMapperUtils.populateUser(u,attrs,true));
+
   }
 
   public void testFindEnabledUsers() throws Exception {

--- a/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
@@ -133,6 +133,7 @@ public class TestLDAPOrganization extends TestOrganization {
     assertNull(test2);
     end();
   }
+
   public void testEnabledUserDetection() throws Exception{
     User u = uHandler.createUserInstance("test");
     ((UserImpl) u).setEnabled(true);


### PR DESCRIPTION
Before this fix , disabled user from AD are detected only if the value of UserAccessControl attribute is equal to 514 , so i generalized the detection for all values and now the rule is:  an AD  user is disabled if UserAccessContral attribute is equal to ( (2 to the (power) n )+ 2) ) . this modification took place in EntityMapperUtils class.