### PR TITLE
Task-43584: Fix can't add apps to extra tabs on personal pages.

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UITabContainer.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UITabContainer.java
@@ -145,6 +145,8 @@ public class UITabContainer extends UIContainer {
                     child.setRendered(false);
                     newTabContainer.setRendered(true);
                     newTabContainer.setId(String.valueOf(Math.abs(newTabContainer.hashCode())));
+                    newTabContainer.setMoveAppsPermissions(container.getMoveAppsPermissions());
+                    newTabContainer.setMoveContainersPermissions(container.getMoveContainersPermissions());
                     pcontext.addUIComponentToUpdateByAjax(container);
                     pcontext.ignoreAJAXUpdateOnPortlets(true);
                     pcontext.getJavascriptManager().require("SHARED/portalComposer", "portalComposer")


### PR DESCRIPTION
Problem: can't move apps into the container of tab added by the "+" button. 
How it was solved: by setting the MoveAppsPermissions to "Everyone" in the AddTabActionListener class. 