### PR TITLE
TASK-47630 Cancel Differing Secondary JavaScript execution

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
@@ -7,10 +7,8 @@
    <% /* Include extensible templates configured by Kernel configuration to be imported in Page Header */ %>
    <% _ctx.includeTemplates("UIPortalApplication-End-Body") %>
 
-  <script type="text/javascript" defer="defer">
-    eXo.env.portal.addOnLoadCallback(() => {
-      <%=jsManager.getJavaScripts()%>
-    });
+  <script type="text/javascript">
+    <%=jsManager.getJavaScripts()%>
   </script>
 </body>
 </html>


### PR DESCRIPTION
Differing execution of Secondary Javascript (loaded and added in the bottom of the page) can deffer a lot the loading of Some JS when having a lot of Vue apps to load. This modification will ensure to execute Secondary Javascripts in sync way so that the display of the page isn't triggered only when loading of Secondary JS files is finished as well.