### PR TITLE
TASK-40995:External user flag is still displayed next to the user fullname

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipDAOImpl.java
@@ -41,7 +41,7 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
 
     public MembershipDAOImpl(PicketLinkIDMOrganizationServiceImpl orgService, PicketLinkIDMService service) {
         super(orgService, service);
-        listeners_ = new ListenerStack(5);
+        listeners_ = new ListenerStack(6);
     }
 
     public void addMembershipEventListener(MembershipEventListener listener) {

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipTypeDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipTypeDAOImpl.java
@@ -60,7 +60,7 @@ public class MembershipTypeDAOImpl extends AbstractDAOImpl implements Membership
 
     public MembershipTypeDAOImpl(PicketLinkIDMOrganizationServiceImpl orgService, PicketLinkIDMService service) {
         super(orgService, service);
-        listeners_ = new ListenerStack(5);
+        listeners_ = new ListenerStack(6);
     }
 
     public void addMembershipTypeEventListener(MembershipTypeEventListener listener) {


### PR DESCRIPTION

when adding a user to 'External group ' an external flag must be displayed next to his name in the chat room and chat drawer: the External Flag isn't always displayed because in the actual behavior  setting user property is set when the user login  and not updated when removed from Group,fixed by adding a listener from MembershipEventListener to update the user enabled property one added or removed from 'External group'