### PR TITLE
Task 48683: Disable Service worker by default

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/pwa/pwa-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/pwa/pwa-configuration.xml
@@ -8,7 +8,7 @@
       <properties-param>
         <name>PWAServiceWorker</name>
         <description>PWA Service Worker Feature enablement flag</description>
-        <property name="exo.feature.PWAServiceWorker.enabled" value="${exo.feature.PWAServiceWorker.enabled:true}" />
+        <property name="exo.feature.PWAServiceWorker.enabled" value="${exo.feature.PWAServiceWorker.enabled:false}" />
       </properties-param>
     </init-params>
   </component>


### PR DESCRIPTION
After several weeks of performance testing by disabling Service Worker Caching on Beta Testing production and after enhancing Resources Caching Strategy, the Service Worker will be disabled by default on product because it becomes useless.