### PR TITLE
50124 : Configure remember me token expiration

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/common/autologin-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/autologin-configuration.xml
@@ -46,8 +46,8 @@
       <values-param>
         <name>service.configuration</name>
         <value>cookie-token</value>
-        <value>7</value>
-        <value>DAY</value>
+        <value>${exo.token.rememberme.expiration.value:7}</value>
+        <value>${exo.token.rememberme.expiration.unit:DAY}</value>
         <value>autologin</value>
       </values-param>
     </init-params>


### PR DESCRIPTION
This PR allows to set the value of the expiration time of the remember-me token with two parameters :
* **exo.token.rememberme.expiration.unit** : Defines the unit of the expiration time for the remember me token. its value could be : DAY, HOUR, MINUTE, SECOND. Default value : DAY
* **exo.token.rememberme.expiration.value** : Defines the value of the expiration time  for the remember me token. Default value : 7