### PR TITLE
MAINT-49963: Fix the ability of xss attacks on forgotpassord page

### DIFF
--- a/web/portal/src/main/webapp/forgotpassword/jsp/forgot_password.jsp
+++ b/web/portal/src/main/webapp/forgotpassword/jsp/forgot_password.jsp
@@ -63,7 +63,7 @@
 
 
     String initURL = (String)request.getAttribute("initURL");
-    if (initURL == null) {
+    if (initURL == null || !initURL.equals(contextPath + "/login")) {
         initURL = contextPath + "/login";
     }
 


### PR DESCRIPTION
**ISSUE**: The initialURL param could be an javascript function injects a dangerous code in the page
**FIX**: Add a check to allow only the right value for this param which is "/portal/login"