### PR TITLE
Task-42855: Open onlyoffice editor from document explorer is not stable

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -812,21 +812,21 @@ public class UIPortalApplication extends UIApplication {
     @Override
     public void processAction(WebuiRequestContext context) throws Exception {
         PortalRequestContext pcontext = (PortalRequestContext) context;
-        // String requestURI = pcontext.getRequestURI();
         RequestNavigationData requestNavData = pcontext.getNavigationData();
 
         boolean isAjax = pcontext.useAjax();
 
         if (!isAjax) {
-            if (isAjaxInLastRequest) {
-                isAjaxInLastRequest = false;
-                if (requestNavData.equals(lastNonAjaxRequestNavData) && !requestNavData.equals(lastRequestNavData)) {
-                    NodeURL nodeURL = pcontext.createURL(NodeURL.TYPE).setNode(getCurrentSite().getSelectedUserNode());
-                    pcontext.sendRedirect(nodeURL.toString());
-                    return;
-                }
+          if (isAjaxInLastRequest) {
+            isAjaxInLastRequest = false;
+            if (requestNavData.equals(lastNonAjaxRequestNavData) && !requestNavData.equals(lastRequestNavData)
+                && pcontext.getPortletParameters().isEmpty()) {
+              NodeURL nodeURL = pcontext.createURL(NodeURL.TYPE).setNode(getCurrentSite().getSelectedUserNode());
+              pcontext.sendRedirect(nodeURL.toString());
+              return;
             }
-            lastNonAjaxRequestNavData = requestNavData;
+          }
+          lastNonAjaxRequestNavData = requestNavData;
         }
 
         isAjaxInLastRequest = isAjax;


### PR DESCRIPTION
Prior this change, there is a check if the requested node Path is equal to last non ajax request node Path and is not equal to the last node Path without taking into account the Portlet Parameters, and the server performs a 302 redirect on the last node Path.
Fix : Remove this check if the Portlet Parameters is not empty