### PR TITLE
MAINT-48685: Avoid the display of a blank page when the csrf token of webui request event is expired

### DIFF
--- a/webui/framework/src/main/java/org/exoplatform/webui/event/Event.java
+++ b/webui/framework/src/main/java/org/exoplatform/webui/event/Event.java
@@ -99,6 +99,8 @@ public class Event<T> {
                        this.getName(),
                        listener.getClass().getName());
             }
+            //Avoid the display of a blank page
+            context_.getJavascriptManager().getRequireJS().addScripts("location.reload();");
         } else {
             for (EventListener<T> listener : listeners_) {
                 listener.execute(this);


### PR DESCRIPTION
**ISSUE**: When open the documents app and leave it for a about 30 minutes, the csrf token of the session will be updated and all the webui event requests from the opened page in document app is using the already old bound csrf tokens in the page which causing a false alert because the sent token in the request is not equal to the session token and so the request will be rejected and a blank page will be shown.
**SOLUTION**: Automatically reload the page if this incident takes a place to avoid the blank page display