### PR TITLE
MAINT-48685: Avoid the display of a blank page when the csrf token of webui request event is expired

### DIFF
--- a/webui/framework/src/main/java/org/exoplatform/webui/event/Event.java
+++ b/webui/framework/src/main/java/org/exoplatform/webui/event/Event.java
@@ -25,6 +25,7 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.web.security.csrf.CSRFTokenUtil;
 import org.exoplatform.webui.application.WebuiRequestContext;
+import org.exoplatform.webui.exception.CSRFException;
 
 import javax.portlet.PortletRequest;
 import javax.servlet.http.HttpServletRequest;
@@ -99,8 +100,7 @@ public class Event<T> {
                        this.getName(),
                        listener.getClass().getName());
             }
-            //Avoid the display of a blank page
-            context_.getJavascriptManager().getRequireJS().addScripts("location.reload();");
+            throw new CSRFException("CSRF token expired or lost, please reload the page");
         } else {
             for (EventListener<T> listener : listeners_) {
                 listener.execute(this);

--- a/webui/framework/src/main/java/org/exoplatform/webui/exception/CSRFException.java
+++ b/webui/framework/src/main/java/org/exoplatform/webui/exception/CSRFException.java
@@ -1,0 +1,11 @@
+package org.exoplatform.webui.exception;
+
+public class CSRFException extends Exception{
+
+    public CSRFException(String errorMessage, Throwable err) {
+        super(errorMessage, err);
+    }
+    public CSRFException(String errorMessage) {
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
… 
**ISSUE**: When open the documents app and leave it for a about 30 minutes, the csrf token of the session will be updated and all the webui event requests from the opened page in document app is using the already old bound csrf tokens in the page which causing a false alert because the sent token in the request is not equal to the session token and so the request will be rejected and a blank page will be shown.
**SOLUTION**: Throw an exception to reload the page if this incident takes a place to avoid the blank page display