### PR TITLE
Task-50856 : [Active directory sycnhronization] AD group users aren't synchronized with the eXo group

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
@@ -152,6 +152,79 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
 
     }
 
+    @Override
+    public void moveGroup(Group parentOriginGroup, Group parentTargetGroup,Group groupToMove) throws Exception {
+        //find ParentOriginGroup
+        if (log.isTraceEnabled()) {
+            Tools.logMethodIn(log, LogLevel.TRACE, "moveGroup", new Object[] { "parentOriginGroup", parentOriginGroup,"parentTargetGroup", parentTargetGroup,
+                "groupToMove", groupToMove });
+        }
+
+        org.picketlink.idm.api.Group jbidParentOriginGroup = null;
+        String plParentOriginGroupName = getPLIDMGroupName(parentOriginGroup.getGroupName());
+        try {
+            jbidParentOriginGroup = getIdentitySession().getPersistenceManager()
+                                                  .findGroup(plParentOriginGroupName,
+                                                             orgService.getConfiguration().getGroupType(parentOriginGroup.getParentId()));
+        } catch (Exception e) {
+            handleException("Identity operation error: ", e);
+        }
+
+        //find ParentTargetGroup
+        org.picketlink.idm.api.Group jbidParentTargetGroup = null;
+        String plParentTargetGroupName = getPLIDMGroupName(parentTargetGroup.getGroupName());
+        try {
+            jbidParentTargetGroup = getIdentitySession().getPersistenceManager()
+                                                        .findGroup(plParentTargetGroupName,
+                                                                   orgService.getConfiguration().getGroupType(parentTargetGroup.getParentId()));
+        } catch (Exception e) {
+            handleException("Identity operation error: ", e);
+        }
+
+        //find groupToMove
+        org.picketlink.idm.api.Group jbidGroupToMove = null;
+        String plGroupToMoveName = getPLIDMGroupName(groupToMove.getGroupName());
+        try {
+            jbidGroupToMove = getIdentitySession().getPersistenceManager()
+                                                        .findGroup(plGroupToMoveName,
+                                                                   orgService.getConfiguration().getGroupType(groupToMove.getParentId()));
+        } catch (Exception e) {
+            handleException("Identity operation error: ", e);
+        }
+
+        //if one is missing => error
+        if (jbidParentOriginGroup == null) {
+            throw new Exception("Group " + jbidParentOriginGroup + " does not exist");
+        }
+        if (jbidParentTargetGroup == null) {
+            throw new Exception("Group " + jbidParentOriginGroup + " does not exist");
+        }
+        if (jbidGroupToMove == null) {
+            throw new Exception("Group " + jbidGroupToMove + " does not exist");
+        }
+
+
+
+
+
+
+        //use RelationshiManager.disassociated
+        try {
+            getIdentitySession().getRelationshipManager()
+                                                 .disassociateGroups(jbidParentOriginGroup, List.of(jbidGroupToMove));
+        } catch (Exception e) {
+            handleException("Cannot dissociate: " + plGroupToMoveName + " to "+plParentOriginGroupName+"; ", e);
+        }
+        //use RelationshiManager.associate
+        try {
+            getIdentitySession().getRelationshipManager()
+                                .associateGroups(jbidParentTargetGroup,jbidGroupToMove);
+        } catch (Exception e) {
+            handleException("Cannot associate: " + plGroupToMoveName + " to "+plParentTargetGroupName+"; ", e);
+        }
+
+    }
+
     public void saveGroup(Group group, boolean broadcast) throws Exception {
         if (log.isTraceEnabled()) {
             Tools.logMethodIn(log, LogLevel.TRACE, "saveGroup", new Object[] { "group", group, "broadcast", broadcast });

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableGroupHandlerImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableGroupHandlerImpl.java
@@ -213,6 +213,20 @@ public class CacheableGroupHandlerImpl extends GroupDAOImpl {
     }
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void moveGroup(Group parentOriginGroup, Group parentTargetGroup,Group groupToMove) throws Exception {
+    disableCacheInThread.set(true);
+    try {
+      clearCache();
+      super.moveGroup(parentOriginGroup,parentTargetGroup,groupToMove);
+    } finally {
+      disableCacheInThread.set(false);
+    }
+  }
+
   public void clearCache() {
     groupCache.clearCache();
   }

--- a/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/TestLDAPOrganization.java
@@ -111,6 +111,26 @@ public class TestLDAPOrganization extends TestOrganization {
       Assert.assertTrue(childGoups.size() > 0);
   }
 
+  public void testMoveGroup() throws Exception {
+    GroupHandler handler = organizationService.getGroupHandler();
+    Group group = handler.findGroupById("/organization/communication/press-and-media");
+    assertNotNull(group);
+    Group communication = handler.findGroupById("/organization/communication");
+    int communitcationChildren = handler.findGroups(communication).size();
+
+
+    Group parentOrigin = handler.findGroupById("/organization/communication");
+    Group parentTarget = handler.findGroupById("/organization/operations");
+
+
+    handler.moveGroup(parentOrigin,parentTarget,group);
+
+    assertEquals(communitcationChildren - 1, handler.findGroups(communication).size());
+    assertNotNull(handler.findGroupById("/organization/operations/press-and-media"));
+
+
+  }
+
   public void testFindFilteredGroup() throws Exception {
     GroupHandler handler = organizationService.getGroupHandler();
     Group filteredGroup = handler.findGroupById("/organization_hierarchy/filteredSubOrganizationC");


### PR DESCRIPTION
Before this fix, when an AD group is member of more than one group, he is synchronized at root group level. When a parent of this group is removed (he now have only one parent), he is sync ad children of his parent. But the  information is not propagated to idm database. So, when a user, member of a group like this connect, he is ejected from this group.
This fix allow to detect that a group moves from the root level to a non root level, and propagate the information to the IDM database