### PR TITLE
MAINT-48685: Catch CsrfException and reload the page when the csrf token has been lost or expired

### DIFF
--- a/webui/framework/src/main/java/org/exoplatform/webui/core/UIApplication.java
+++ b/webui/framework/src/main/java/org/exoplatform/webui/core/UIApplication.java
@@ -27,6 +27,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.web.application.AbstractApplicationMessage;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.webui.application.WebuiRequestContext;
+import org.exoplatform.webui.exception.CSRFException;
 import org.exoplatform.webui.exception.MessageException;
 
 /**
@@ -123,6 +124,8 @@ public abstract class UIApplication extends UIContainer {
             super.processAction(context);
         } catch (MessageException ex) {
             addMessage(ex.getDetailMessage());
+        } catch (CSRFException e) {
+            context.getJavascriptManager().getRequireJS().addScripts("location.reload();");
         } catch (Throwable t) {
             ApplicationMessage msg = new ApplicationMessage("UIApplication.msg.unknown-error", null, ApplicationMessage.ERROR);
             addMessage(msg);


### PR DESCRIPTION
…
ISSUE: When the csrf token is lost and expired in the session, and we have alread opened pages of the doc app, This lead to a blank page when execute any action that demands a csrf token check
FIX: Reload the page when a csrf token is expired or lost to avoid the display of blank page and to refresh the token in the page