### PR TITLE
52391 : Fix Locale code in Javascript

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -31,7 +31,7 @@
   String language = rcontext.getLocale().getLanguage();
   String country = rcontext.getLocale().getCountry();
   if (country != null && country.length() > 0) {
-    language += "_" + country;
+    language += "-" + country;
   }
   String docBase =  rcontext.getRequestContextPath() ;
   String skin = uicomponent.getSkin();


### PR DESCRIPTION
in Java composite Locales uses underscore character ( _ )  between language and country, in Java it uses hyphen ( - )