### PR TITLE
52391 : Fix Locale code in Javascript 

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -31,7 +31,7 @@
   String language = rcontext.getLocale().getLanguage();
   String country = rcontext.getLocale().getCountry();
   if (country != null && country.length() > 0) {
-    language += "_" + country;
+    language += "-" + country;
   }
   String docBase =  rcontext.getRequestContextPath() ;
   String skin = uicomponent.getSkin();


### PR DESCRIPTION
in Java composite Locales uses underscore character ( _ )  between language and country, in Java it uses hyphen ( - )
Before, we used underscore character which was wrong, this will fix it to make sure no error is raised when using locale for converting dates in Javascript

(cherry picked from commit 504ef80d3f632488b51a1abeca4d6f48078317fe)