### PR TITLE
Task-52379 : Fixed changed new password which is identical to the old one

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
@@ -43,6 +43,8 @@ public class UserRestResourcesV1 implements ResourceContainer {
 
   private static final String            DELEGATED_GROUP                = "/platform/delegated";
 
+    public static final String           UNCHANGED_NEW_PASSWORD_ERROR_CODE = "UNCHANGED_NEW_PASSWORD";
+
   public static final UserFieldValidator USERNAME_VALIDATOR             = new UserFieldValidator("userName", true, false);
 
   public static final UserFieldValidator EMAIL_VALIDATOR                = new UserFieldValidator("emailAddress", false, false);
@@ -435,6 +437,10 @@ public class UserRestResourcesV1 implements ResourceContainer {
   
       if (isSameUser && !userHandler.authenticate(username, currentPassword)) {
         return Response.serverError().entity(WRONG_USER_PASSWORD_ERROR_CODE).build();
+      }
+
+      if (isSameUser && userHandler.authenticate(username, newPassword))  {
+        return Response.serverError().entity(UNCHANGED_NEW_PASSWORD_ERROR_CODE).build();
       }
   
       Locale locale = request.getLocale();


### PR DESCRIPTION
ISSUE : Password can be change to the same one
FIXED: when changing password, check if we are able to authenticate the user with the new password. If yes, it means that the user didn't change his password, so we refuse the modification