### PR TITLE
Task-52381: Token are not deleted after consumption.

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/externalRegistration/ExternalRegistrationHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/externalRegistration/ExternalRegistrationHandler.java
@@ -38,6 +38,7 @@ import org.exoplatform.web.WebRequestHandler;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.web.controller.QualifiedName;
 import org.exoplatform.web.login.recovery.PasswordRecoveryServiceImpl;
+import org.exoplatform.web.security.security.CookieTokenService;
 import org.exoplatform.web.security.security.RemindPasswordTokenService;
 
 import org.exoplatform.services.log.Log;
@@ -205,6 +206,7 @@ public class ExternalRegistrationHandler extends WebRequestHandler {
                             }
                             organizationService.getMembershipHandler().linkMembership(user, group, organizationService.getMembershipTypeHandler().findMembershipType(MEMBER), true);
                             service.sendExternalConfirmationAccountEmail(randomUserName, locale, url);
+                            remindPasswordTokenService.deleteTokensByUsernameAndType(email,CookieTokenService.EXTERNAL_REGISTRATION_TOKEN);
                         }
                     } catch (Exception e) {
                         errors.add(bundle.getString("external.registration.fail.create.user"));

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
@@ -115,6 +115,8 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
             this.changePasswordConnectorMap.get(this.changePasswordConnectorName).changePassword(username,password);
             try {
                 remindPasswordTokenService.deleteToken(tokenId, tokenType);
+                remindPasswordTokenService.deleteTokensByUsernameAndType(username, tokenType);
+                
             } catch (Exception ex) {
                 log.warn("Can not delete token: " + tokenId, ex);
             }

--- a/component/web/security/src/main/java/org/exoplatform/web/security/GateInTokenStore.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/GateInTokenStore.java
@@ -21,6 +21,8 @@ public interface GateInTokenStore {
     void cleanExpired();
 
     long size();
+    
+    void deleteTokensByUsernameAndType(String username, String tokenType);
 
     class TokenData {
         /** . */
@@ -34,12 +36,15 @@ public interface GateInTokenStore {
 
         /** . */
         public final Date expirationTime;
+        
+        public final String tokenType;
 
-        public TokenData(String tokenId, String hash, Credentials payload, Date expirationTime) {
+        public TokenData(String tokenId, String hash, Credentials payload, Date expirationTime, String tokenType) {
             this.tokenId = tokenId;
             this.hash = hash;
             this.expirationTime = expirationTime;
             this.payload = payload;
+            this.tokenType = tokenType;
         }
     }
 }

--- a/component/web/security/src/main/java/org/exoplatform/web/security/jpa/JPAGateInTokenStorage.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/jpa/JPAGateInTokenStorage.java
@@ -33,6 +33,7 @@ public class JPAGateInTokenStorage implements GateInTokenStore {
         entity.setUsername(data.payload.getUsername());
         entity.setPassword(data.payload.getPassword());
         entity.setExpirationTime(data.expirationTime);
+        entity.setTokenType(data.tokenType);
 
         this.tokenDAO.create(entity);
     }
@@ -43,11 +44,11 @@ public class JPAGateInTokenStorage implements GateInTokenStore {
         TokenEntity entity = this.tokenDAO.findByTokenId(tokenId);
         if (entity != null) {
             return new TokenData(entity.getTokenId(), entity.getTokenHash(),
-                    new Credentials(entity.getUsername(), entity.getPassword()), entity.getExpirationTime());
+                    new Credentials(entity.getUsername(), entity.getPassword()), entity.getExpirationTime(), entity.getTokenType());
         }
         return null;
     }
-
+    
     @Override
     @ExoTransactional
     public void deleteToken(String tokenId) {
@@ -82,5 +83,13 @@ public class JPAGateInTokenStorage implements GateInTokenStore {
     @ExoTransactional
     public long size() {
         return this.tokenDAO.count();
+    }
+
+    @Override
+    @ExoTransactional
+    public void deleteTokensByUsernameAndType(String username, String tokenType) {
+      
+      this.tokenDAO.deleteTokensByUsernameAndType(username, tokenType);
+      
     }
 }

--- a/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenDAO.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenDAO.java
@@ -7,5 +7,6 @@ import java.util.List;
 public interface TokenDAO extends GenericDAO<TokenEntity, Long> {
     TokenEntity findByTokenId(String tokenId);
     List<TokenEntity> findByUsername(String username);
+    void deleteTokensByUsernameAndType(String username, String tokenType);
     void cleanExpired();
 }

--- a/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenDAOImpl.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenDAOImpl.java
@@ -39,4 +39,13 @@ public class TokenDAOImpl extends GenericDAOJPAImpl<TokenEntity, Long> implement
             this.deleteAll(entities);
         }
     }
+
+    @Override
+    @ExoTransactional
+    public void deleteTokensByUsernameAndType(String username, String tokenType) {
+        Query query = getEntityManager().createNamedQuery("GateInToken.deleteTokensByUserAndType");
+        query.setParameter("username", username);
+        query.setParameter("tokenType", tokenType);
+        query.executeUpdate();
+    }
 }

--- a/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenEntity.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenEntity.java
@@ -13,7 +13,8 @@ import java.util.Date;
         @NamedQuery(name = "GateInToken.findByTokenId", query = "SELECT t FROM GateInToken t WHERE t.tokenId = :tokenId"),
         @NamedQuery(name = "GateInToken.findByUser", query = "SELECT t FROM GateInToken t WHERE t.username = :username"),
         @NamedQuery(name = "GateInToken.findExpired", query = "SELECT t FROM GateInToken t WHERE t.expirationTime < :expireTime"),
-        @NamedQuery(name = "GateInToken.cleanTokens", query = "DELETE FROM GateInToken t WHERE t.expirationTime < :expireTime")
+        @NamedQuery(name = "GateInToken.cleanTokens", query = "DELETE FROM GateInToken t WHERE t.expirationTime < :expireTime"),
+        @NamedQuery(name = "GateInToken.deleteTokensByUserAndType", query="DELETE FROM GateInToken t WHERE t.username = :username AND t.tokenType = :tokenType")
 })
 public class TokenEntity implements Serializable {
     private static final long serialVersionUID = 6633792468705838255L;
@@ -38,6 +39,10 @@ public class TokenEntity implements Serializable {
 
     @Column(name="EXPIRATION_TIME", nullable = false)
     private Long expirationTime;
+    
+    @Column(name="TOKEN_TYPE", nullable = false)
+    private String tokenType;
+    
 
     public Long getId() {
         return id;
@@ -85,5 +90,13 @@ public class TokenEntity implements Serializable {
 
     public void setExpirationTime(Date expirationTime) {
         this.expirationTime = (expirationTime != null ? expirationTime.getTime() : -1);
+    }
+
+    public String getTokenType() {
+      return tokenType;
+    }
+
+    public void setTokenType(String tokenType) {
+      this.tokenType = tokenType;
     }
 }

--- a/component/web/security/src/main/java/org/exoplatform/web/security/security/CookieTokenService.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/security/CookieTokenService.java
@@ -160,8 +160,8 @@ public class CookieTokenService extends AbstractTokenService<GateInToken, String
             Credentials encodedCredentials = new Credentials(credentials.getUsername(), encryptedPassword);
 
             try {
-                this.tokenStore.saveToken(new GateInTokenStore.TokenData(id, hashedRandomString, encodedCredentials, new Date(expirationTimeMillis)));
-//                tokenContainer.saveToken(context.getSession(), id, hashedRandomString, encodedCredentials, new Date(expirationTimeMillis));
+                this.tokenStore.saveToken(new GateInTokenStore.TokenData(id, hashedRandomString, encodedCredentials, new Date(expirationTimeMillis), type));
+//                tokenContainer.saveToken(context.getSession(), id, hashedRandomString, encodedCredentials, new Date(expirationTimeMillis, tokenType));
             } catch (TokenExistsException e) {
                 cookieTokenString = null;
             }
@@ -232,7 +232,16 @@ public class CookieTokenService extends AbstractTokenService<GateInToken, String
     public void deleteTokensOfUser(final String user) {
         this.tokenStore.deleteTokenOfUser(user);
     }
-
+    
+    /**
+     * The UI should offer a way to delete all existing tokens of the current user.
+     *
+     * @param user
+     */
+    public void deleteTokensByUsernameAndType(final String username, final String tokenType) {
+        this.tokenStore.deleteTokensByUsernameAndType(username, tokenType);
+    }
+        
     /**
      * Removes all stored tokens
      */

--- a/component/web/security/src/main/resources/db/changelog/gatein-token.db.changelog-1.0.0.xml
+++ b/component/web/security/src/main/resources/db/changelog/gatein-token.db.changelog-1.0.0.xml
@@ -32,4 +32,9 @@
   <changeSet author="gatein-token" id="1.0.0-3" dbms="hsqldb">
     <createSequence sequenceName="SEQ_GATEIN_TOKEN_ID_GENERATOR" startValue="1"/>
   </changeSet>
+  <changeSet author="gatein-token" id="1.0.0-4">
+    <addColumn tableName="PORTAL_TOKENS">
+      <column name="TOKEN_TYPE" type="VARCHAR(250)"/>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Problem: When user forgot his password, he when to reset it by sending a link to his mail which gives him the hand to change his password. So the problem has happened when he send many links to mail to reset the password, all links kept available to change his password Even if he did it the first time. all this happened because every time a link is sent to his mail a token is generated and stored automatically in the database, so the recent tokens keep stored even if he consumes one of them that's why we could reset the password by every link sent.

Fix: The solution is to remove all tokens by type (forgot-token, onboarding,...) associate with this user after he succeeds to reset his password. I use the function deleteTokensByUsernameAndType(username, tokenType) of service RemindPasswordTokenService .this function is executed after every password is changed to delete all Tokens by type of the current user stored in DB then the recent links will be not available.