### PR TITLE
MAINT-53372 : External-registration - user added to the users as default group and then removed and added to the externals group during the registration phase

### DIFF
--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>exo.portal.component.api</artifactId>

--- a/component/application-registry/pom.xml
+++ b/component/application-registry/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>exo.portal.component.common</artifactId>

--- a/component/file-storage/pom.xml
+++ b/component/file-storage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.portal.component.file-storage</artifactId>
   <packaging>jar</packaging>

--- a/component/identity/pom.xml
+++ b/component/identity/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/management/pom.xml
+++ b/component/management/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/pc/pom.xml
+++ b/component/pc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.component</artifactId>

--- a/component/portal/pom.xml
+++ b/component/portal/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/resources/pom.xml
+++ b/component/resources/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/scripting/pom.xml
+++ b/component/scripting/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/test/core/pom.xml
+++ b/component/test/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.test</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/test/pom.xml
+++ b/component/test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/test/web/pom.xml
+++ b/component/test/web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.test</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/api/pom.xml
+++ b/component/web/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/controller/pom.xml
+++ b/component/web/controller/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/oauth-common/pom.xml
+++ b/component/web/oauth-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>exo.portal.component.web</artifactId>
     <groupId>org.exoplatform.gatein.portal</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/component/web/oauth-web/pom.xml
+++ b/component/web/oauth-web/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/pom.xml
+++ b/component/web/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/resources/pom.xml
+++ b/component/web/resources/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/security/pom.xml
+++ b/component/web/security/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/security/src/main/java/org/exoplatform/web/login/externalRegistration/ExternalRegistrationHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/externalRegistration/ExternalRegistrationHandler.java
@@ -197,13 +197,9 @@ public class ExternalRegistrationHandler extends WebRequestHandler {
                       user.setEmail(email);
                     }
                     try {
-                        organizationService.getUserHandler().createUser(user, true);// Broadcast user creation event
+                        organizationService.getUserHandler().createUser(user, false);
                         Group group = organizationService.getGroupHandler().findGroupById(EXTERNALS_GROUP);
                         if (organizationService.getMembershipTypeHandler() != null) {
-                            Collection<Membership>  usersMemberhips = organizationService.getMembershipHandler().findMembershipsByUserAndGroup(user.getUserName(), USERS_GROUP);
-                            for (Membership usersMemberhip : usersMemberhips) {
-                              organizationService.getMembershipHandler().removeMembership(usersMemberhip.getId(), true);
-                            }
                             organizationService.getMembershipHandler().linkMembership(user, group, organizationService.getMembershipTypeHandler().findMembershipType(MEMBER), true);
                             service.sendExternalConfirmationAccountEmail(randomUserName, locale, url);
                             remindPasswordTokenService.deleteTokensByUsernameAndType(email,CookieTokenService.EXTERNAL_REGISTRATION_TOKEN);

--- a/component/web/server/pom.xml
+++ b/component/web/server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/sso/pom.xml
+++ b/component/web/sso/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/sso/sso-agent-configs/pom.xml
+++ b/component/web/sso/sso-agent-configs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web.sso</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/sso/sso-integration-configs/pom.xml
+++ b/component/web/sso/sso-integration-configs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web.sso</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -33,14 +33,14 @@
   
   <groupId>org.exoplatform.gatein.portal</groupId>
   <artifactId>exo.portal.parent</artifactId>
-  <version>6.3.x-SNAPSHOT</version>
+  <version>6.3.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   
   <name>GateIn - Portal</name>
   
   <properties>
-    <org.exoplatform.gatein.sso.version>6.3.x-SNAPSHOT</org.exoplatform.gatein.sso.version>
-    <org.exoplatform.gatein.pc.version>6.3.x-SNAPSHOT</org.exoplatform.gatein.pc.version>
+    <org.exoplatform.gatein.sso.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.gatein.sso.version>
+    <org.exoplatform.gatein.pc.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.gatein.pc.version>
     
     <!-- Default eXo profiles -->
     <surefire.exo.profiles>hsqldb</surefire.exo.profiles>

--- a/portlet/exoadmin/pom.xml
+++ b/portlet/exoadmin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.portlet</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/portlet/pom.xml
+++ b/portlet/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.portlet</artifactId>

--- a/portlet/web/pom.xml
+++ b/portlet/web/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.portlet</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/web/eXoResources/pom.xml
+++ b/web/eXoResources/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.web</artifactId>

--- a/web/portal/pom.xml
+++ b/web/portal/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/web/rest/pom.xml
+++ b/web/rest/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.web</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/core/pom.xml
+++ b/webui/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/eXo/pom.xml
+++ b/webui/eXo/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/framework/pom.xml
+++ b/webui/framework/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.webui</artifactId>

--- a/webui/portal/pom.xml
+++ b/webui/portal/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/portlet/pom.xml
+++ b/webui/portlet/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
…
ISSUE: When bind the users a group to a given space and create an external user the binding report will contain the external user as it's added to the users group and then removed, This because of broadcasting the `creation_event` to the `NewUserEventListener` which adds the user to the default `users` group.
Fix: This fix should disable the broadcast event option when creation the external user also remove the unneeded removing from the users group, So it will not be added only to the external group