### PR TITLE
MAINT-45289: Avoid having a null portalowner value in PortalRequestContext

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -511,10 +511,10 @@ public class PortalRequestContext extends WebuiRequestContext {
 
     public String getPortalOwner() {
         UserPortalConfig userPortalConfig = getUserPortalConfig();
-        if (userPortalConfig != null) {
+        if (userPortalConfig != null && userPortalConfig.getPortalName() != null) {
             return userPortalConfig.getPortalName();
         } else {
-            return null;
+            return portalConfigService.getDefaultPortal();
         }
     }
 


### PR DESCRIPTION
**ISSUE**: Sometimes the notification of activities redirects to 404 error page, because of a null value of `portalOwner` in the URL.
**FIX**: THis fix should maintain the `getPortalOwner` function to avoid having such null value in the `portalOwner` by add a check and sending the default `portalOnwer` if the value is null