### PR TITLE
TASK-53648: Allow to choose the Swedish language from language settings

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/common/locales-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/locales-config.xml
@@ -191,5 +191,12 @@
     <description>Default configuration for the Romanian locale</description>
   </locale-config>
 
+  <locale-config>
+    <locale>sv_SE</locale>
+    <output-encoding>UTF-8</output-encoding>
+    <input-encoding>UTF-8</input-encoding>
+    <description>Default configuration for the Swedish locale</description>
+  </locale-config>
+
 </locales-config>
 


### PR DESCRIPTION
Prior to this change, it was not possible to navigate in the portal with Swedish language, after this change we add a new local config related for Swedish language in order to allow navigating with Swedish language.