### PR TITLE
TASK-53709: The new changed username isn't considered in chat application.

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
@@ -310,6 +310,7 @@ public class UserRestResourcesV1 implements ResourceContainer {
       user.setFirstName(firstName);
       user.setLastName(lastName);
       user.setPassword(password);
+      user.setDisplayName(firstName+" "+lastName);
       organizationService.getUserHandler().saveUser(user, true);
     }
 

--- a/component/portal/src/test/java/org/exoplatform/portal/rest/UserRestResourcesTest.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/rest/UserRestResourcesTest.java
@@ -461,6 +461,20 @@ public class UserRestResourcesTest extends BaseRestServicesTestCase {
     assertEquals(400, response.getStatus());
     assertNotNull(response.getEntity());
     assertEquals("DisableSuperUser", response.getEntity().toString());
+
+    data.put("userName", USER_2);
+    data.put("lastName", USER_2);
+    data.put("firstName", USER_2);
+    data.put("password", "");
+    data.put("enabled", true);
+    data.put("email", email2);
+    response = getResponse("PUT", "/v1/users", data.toString());
+    assertNotNull(response);
+    assertNull(response.getEntity());
+    assertEquals(204, response.getStatus());
+    user2.setDisplayName(USER_2+" "+USER_2);
+    verify(userHandler, atMost(1)).saveUser(eq(user2), eq(true));
+
   }
 
   public void testDeleteUser() throws Exception {


### PR DESCRIPTION
ISSUES : When editing username, The new changed username isn't considered in chat application.
FIX : The problem is that when editing the firstname or the last name ,the new changes does not considered in chat application and it solved by adding the new displayname to the user object that will be updated in the mongo database.