### PR TITLE
Task-53093: Allow to import new applications to an existing category

### DIFF
--- a/component/api/src/main/java/org/exoplatform/application/registry/ApplicationCategoriesPlugins.java
+++ b/component/api/src/main/java/org/exoplatform/application/registry/ApplicationCategoriesPlugins.java
@@ -28,75 +28,78 @@ import org.exoplatform.container.configuration.ConfigurationManager;
 import org.exoplatform.container.xml.InitParams;
 
 /**
- * Created by The eXo Platform SARL Author : Le Bien Thuy lebienthuy@gmail.com 9 Oct 2007
+ * Created by The eXo Platform SARL Author : Le Bien Thuy lebienthuy@gmail.com 9
+ * Oct 2007
  */
 
 public class ApplicationCategoriesPlugins extends BaseComponentPlugin {
-    private ConfigurationManager cmanager_;
+  private ConfigurationManager       cmanager_;
 
-    private ApplicationRegistryService pdcService_;
+  private ApplicationRegistryService pdcService_;
 
-    private List<ApplicationCategory> categories;
+  private List<ApplicationCategory>  categories;
 
-    private boolean merge;
-    
-    private boolean system;
+  private boolean                    merge;
 
-    public ApplicationCategoriesPlugins(ApplicationRegistryService pdcService, ConfigurationManager cmanager, InitParams params)
-            throws Exception {
-        categories = params.getObjectParamValues(ApplicationCategory.class);
-        if (params.containsKey("merge")) {
-          merge = StringUtils.equalsIgnoreCase("true", params.getValueParam("merge").getValue());
+  private boolean                    system;
+
+  public ApplicationCategoriesPlugins(ApplicationRegistryService pdcService, ConfigurationManager cmanager, InitParams params)
+      throws Exception {
+    categories = params.getObjectParamValues(ApplicationCategory.class);
+    if (params.containsKey("merge")) {
+      merge = StringUtils.equalsIgnoreCase("true", params.getValueParam("merge").getValue());
+    }
+    if (params.containsKey("system")) {
+      system = StringUtils.equalsIgnoreCase("true", params.getValueParam("system").getValue());
+    }
+    cmanager_ = cmanager;
+    pdcService_ = pdcService;
+  }
+
+  public boolean isMerge() {
+    return merge;
+  }
+
+  public void setMerge(boolean merge) {
+    this.merge = merge;
+  }
+
+  public void run() throws Exception {
+    run(false);
+  }
+
+  public List<ApplicationCategory> getCategories() {
+    return categories;
+  }
+
+  public void run(boolean firstStartup) throws Exception {
+    if (categories == null || (!firstStartup && !merge && !system))
+      return;
+    for (ApplicationCategory category : categories) {
+      ApplicationCategory storedCategory = pdcService_.getApplicationCategory(category.getName());
+      List<Application> apps = category.getApplications();
+      // Recreate category when starting server if deleted by UI for categories
+      // of type 'merge = true'
+      if (storedCategory == null) {
+        pdcService_.save(category);
+      }
+
+      // Avoid to reimport applications when deleted by UI in case of 'merge =
+      // true'
+      if (firstStartup || storedCategory == null) {
+        for (Application app : apps) {
+          pdcService_.save(category, app);
         }
-        if (params.containsKey("system")) {
-          system = StringUtils.equalsIgnoreCase("true", params.getValueParam("system").getValue());
+      } else if (system) {
+        for (Application app : apps) {
+          Application storedApplication = pdcService_.getApplication(category.getName() + "/" + app.getApplicationName());
+          // Avoid to reimport application when modified by UI in case of
+          // 'system = true', it will be imported only when not existing
+          if (storedApplication == null) {
+            pdcService_.save(category, app);
+          }
         }
-        cmanager_ = cmanager;
-        pdcService_ = pdcService;
+      }
     }
-
-    public boolean isMerge() {
-      return merge;
-    }
-
-    public void setMerge(boolean merge) {
-      this.merge = merge;
-    }
-
-    public void run() throws Exception {
-      run(false);
-    }
-
-    public List<ApplicationCategory> getCategories() {
-      return categories;
-    }
-
-    public void run(boolean firstStartup) throws Exception {
-        if (categories == null || (!firstStartup && !merge && !system))
-            return;
-        for (ApplicationCategory category : categories) {
-            ApplicationCategory storedCategory = pdcService_.getApplicationCategory(category.getName());
-            List<Application> apps = category.getApplications();
-            // Recreate category when starting server if deleted by UI for categories of type 'merge = true'
-            if (storedCategory == null) {
-              pdcService_.save(category);
-            }
-
-            // Avoid to reimport applications when deleted by UI in case of 'merge = true'
-            if (firstStartup || storedCategory == null) {
-              for (Application app : apps) {
-                pdcService_.save(category, app);
-              }
-            }
-            else if (system) {
-              for (Application app : apps) {
-                Application storedApplication = pdcService_.getApplication(category.getName() + "/" + app.getApplicationName());
-                // Avoid to reimport application when modified by UI in case of 'system = true', it will be imported only when not existing
-                if (storedApplication == null) {
-                  pdcService_.save(category, app);
-                }
-              }
-            }
-        }
-    }
+  }
 }


### PR DESCRIPTION
Prior to this change, it was not possible to import new applications to an existing category. After this change, we have added a new "system" value param for ApplicationCategoriesPlugins component plugin in order to allow importing only new applications to an existing category and avoid reimporting already existing applications (when modified by interface).