### PR TITLE
TASK-53535 Fix Database model generation for PostgreSQL using Liquibase 4.7

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/jdbc/entity/WindowEntity.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/jdbc/entity/WindowEntity.java
@@ -83,7 +83,7 @@ public class WindowEntity extends ComponentEntity implements Serializable {
   private String            contentId;
 
   @Lob
-  @Type(type = "org.hibernate.type.BinaryType")
+  @Type(type = "org.hibernate.type.MaterializedBlobType")
   @Column(name = "CUSTOMIZATION", length = 10000)
   @Basic(fetch = FetchType.LAZY)
   private byte[]            customization;

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/jdbc/dao/WindowDAOImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/jdbc/dao/WindowDAOImpl.java
@@ -14,6 +14,7 @@ import org.exoplatform.portal.jdbc.entity.WindowEntity;
 public class WindowDAOImpl extends AbstractDAO<WindowEntity> implements WindowDAO {
 
   @Override
+  @ExoTransactional
   public List<Long> findIdsByContentIds(List<String> contentIds, Pagination pagination) {
     if (contentIds == null || contentIds.isEmpty()) {
       return Collections.emptyList();
@@ -46,6 +47,7 @@ public class WindowDAOImpl extends AbstractDAO<WindowEntity> implements WindowDA
   }
 
   @Override
+  @ExoTransactional
   public List<WindowEntity> findByIds(List<Long> ids) {
     if (ids == null || ids.isEmpty()) {
       return Collections.emptyList();
@@ -56,6 +58,7 @@ public class WindowDAOImpl extends AbstractDAO<WindowEntity> implements WindowDA
   }
   
   @Override
+  @ExoTransactional
   public void deleteById(Long id) {
     WindowEntity window = find(id);
     if (window != null) {

--- a/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
+++ b/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
@@ -91,6 +91,7 @@
 
   <!-- Page -->
   <changeSet author="portal" id="1.0.0-9">
+    <validCheckSum>ANY</validCheckSum>
     <createTable tableName="PORTAL_PAGES">
       <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_PAGE"/>
@@ -98,7 +99,7 @@
       <column name="SITE_ID" type="BIGINT">
         <constraints nullable="false"/>
       </column>
-      <column name="SHOW_MAX_WINDOW" type="BIT" />
+      <column name="SHOW_MAX_WINDOW" type="BOOLEAN" defaultValueBoolean="false" />
       <column name="DISPLAY_NAME" type="NVARCHAR(200)"/>
       <column name="NAME" type="NVARCHAR(200)"/>
       <column name="DESCRIPTION" type="LONGTEXT" />
@@ -254,6 +255,7 @@
   </changeSet>
   
   <changeSet author="portal" id="1.0.0-23">
+    <validCheckSum>ANY</validCheckSum>
     <createTable tableName="PORTAL_WINDOWS">
       <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_WINDOW"/>
@@ -261,9 +263,9 @@
       <column name="TITLE" type="NVARCHAR(200)"/>
       <column name="ICON" type="NVARCHAR(200)"/>
       <column name="DESCRIPTION" type="LONGTEXT" />
-      <column name="SHOW_INFO_BAR" type="BIT" />
-      <column name="SHOW_APP_STATE" type="BIT" />
-      <column name="SHOW_APP_MODE" type="BIT" />
+      <column name="SHOW_INFO_BAR" type="BOOLEAN" defaultValueBoolean="false" />
+      <column name="SHOW_APP_STATE" type="BOOLEAN" defaultValueBoolean="false" />
+      <column name="SHOW_APP_MODE" type="BOOLEAN" defaultValueBoolean="false" />
       <column name="THEME" type="NVARCHAR(200)"/>
       <column name="WIDTH" type="VARCHAR(20)"/>
       <column name="HEIGHT" type="VARCHAR(20)"/>


### PR DESCRIPTION
Prior to this change, using Lisuibase 4.7 on an empty PostgreSQL Server, some errors are raised while generating Tables for 'BIT' column types. The column type has been changed to 'BOOLEAN' to make it compliant with Liquibase 4.7. In addition, a modification has been made on Window Entity mapping to be compliant with new version of Hibernate 5.6.