### PR TITLE
Task-54115 : No longer possible to create NEW customer spaces

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/jdbc/entity/NodeEntity.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/jdbc/entity/NodeEntity.java
@@ -71,7 +71,7 @@ public class NodeEntity implements Serializable {
   @Column(name = "NODE_INDEX")
   private int               index;
 
-  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, mappedBy = "parent", orphanRemoval = true)
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, mappedBy = "parent")
   @OrderBy("index ASC")
   private List<NodeEntity>  children         = new ArrayList<>();
 


### PR DESCRIPTION
ISSUES : error when creating customer space and an error displayed  (An error occured when creating the space)
FIX : the main cause of the bug is the deletion of a node. then in the creation of a space among the iteration there is a deletion of node children. at this level there an infinite loop is triggered because the deletion of node will remove data orphan of this node and in the same iteration this node there will be considered as an orphan and to solve this problem I removed the property 'orphanRemoval = true' at the level of the attribute children in 'NodeEntity