### PR TITLE
Task-54725 Analytics Page do not load on psql

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/jdbc/dao/WindowDAOImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/jdbc/dao/WindowDAOImpl.java
@@ -15,6 +15,12 @@ public class WindowDAOImpl extends AbstractDAO<WindowEntity> implements WindowDA
 
   @Override
   @ExoTransactional
+  public WindowEntity find(Long id) {
+    return super.find(id);
+  }
+
+  @Override
+  @ExoTransactional
   public List<Long> findIdsByContentIds(List<String> contentIds, Pagination pagination) {
     if (contentIds == null || contentIds.isEmpty()) {
       return Collections.emptyList();


### PR DESCRIPTION
Before this fix, analytics page to not load with psql database, because psql was unable to load blob without transaction
This fix add ExoTransactional annotation on find function for WindowDao, so that, there is a transaction when this function is called, and blob are correctly loaded