### PR TITLE
TASK-54200:Logout : going back open the last active page (#339)

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestHandler.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestHandler.java
@@ -131,7 +131,9 @@ public class PortalRequestHandler extends WebRequestHandler {
         log.debug("Session ID = " + req.getSession().getId());
 
         // watch out: this might get overriden later, if the portal itself has a configuration for this value
-        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Cache-Control","no-cache, no-store, must-revalidate");
+        res.setHeader("Pragma","no-cache");
+        res.setHeader("Expires","0");
 
         //
         String requestPath = controllerContext.getParameter(REQUEST_PATH);


### PR DESCRIPTION
ISSUES : When we click on the back button after logout, the last active page is displayed, while the login page should be displayed.
FIX : the problem is that after logout, the last active page reloads from the cache. It fixed by adding a code that does not allow the cache of the page.