### PR TITLE
Task-53070 : Improve error message when record upload fail in webconferencing module

### DIFF
--- a/component/common/src/main/java/org/exoplatform/upload/UploadService.java
+++ b/component/common/src/main/java/org/exoplatform/upload/UploadService.java
@@ -357,7 +357,7 @@ public class UploadService {
         return upload;
     }
 
-    private boolean isLimited(UploadResource upResource, double contentLength) {
+    public boolean isLimited(UploadResource upResource, double contentLength) {
         // by default, use the limit set in the service
         UploadLimit limit = defaultUploadLimitMB_;
         // if the limit is set in the request (specific for this upload) then use
@@ -375,6 +375,17 @@ public class UploadService {
             return true;
         }
         return false;
+    }
+
+    public UploadLimit getLimitForResource(UploadResource upResource) {
+        // by default, use the limit set in the service
+        UploadLimit limit = defaultUploadLimitMB_;
+        // if the limit is set in the request (specific for this upload) then use
+        // this value instead of the default one
+        if (uploadLimits.containsKey(upResource.getUploadId())) {
+            limit = uploadLimits.get(upResource.getUploadId());
+        }
+        return limit;
     }
 
     public static class UploadLimit {


### PR DESCRIPTION
Before this fix, the function isLimited in uploadService is private
As we need it to make a clear error message in webconferencing, this commit make this function public.