### PR TITLE
Task-56238 Error on postgres when updating from 6.1.5

### DIFF
--- a/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
+++ b/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
@@ -378,7 +378,7 @@
   </changeSet>
 
   <changeSet author="idm" id="1.0.0-17" onValidationFail="MARK_RAN" runOnChange="false" dbms="oracle,postgresql">
-    <preConditions>
+    <preConditions onFail="MARK_RAN">
       <not>
         <sequenceExists sequenceName="hibernate_sequence" />
       </not>


### PR DESCRIPTION
Before this fix, when we make an update from 6.1.5 the preconditions for sequence hibernate_sequence fails, but is not marked as ran, which lead to an error in logs.
To fix this problem, we add the mark_ran on the preconditions tag, like for the other ones in this file