### PR TITLE
Task-56311 : Exception in logs related to antibrute force feature

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -1036,7 +1036,7 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
                           profile.getAttribute(AUTHENTICATION_ATTEMPTS) != null ? Integer.parseInt(profile.getAttribute(AUTHENTICATION_ATTEMPTS))
                                                                                 : 0;
         Instant latestAuthFailureTime =
-                                      Instant.ofEpochMilli(profile.getAttribute(AUTHENTICATION_ATTEMPTS) != null ? Long.parseLong(profile.getAttribute(LATEST_AUTH_TIME))
+                                      Instant.ofEpochMilli(profile.getAttribute(LATEST_AUTH_TIME) != null ? Long.parseLong(profile.getAttribute(LATEST_AUTH_TIME))
                                                                                                                  : Instant.EPOCH.toEpochMilli());
         if (currentNbFail >= orgService.getConfiguration().getMaxAuthenticationAttempts()
             && latestAuthFailureTime.plus(orgService.getConfiguration().getBlockingTime(), ChronoUnit.MINUTES)


### PR DESCRIPTION
Before this fix, when the user try to log the first time after deployment the antibrute force feature, there is an error in log
this issue is due to the fact we get an attribute in the profile without checking correclty the nullity.
The nullity check is done on another attribute.
This fix change the nullity check to make it correctly.