### PR TITLE
TASK-57293 Fix Administration Menu Categorization when using same Page order

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/NavigationCategoryService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/NavigationCategoryService.java
@@ -87,11 +87,10 @@ public class NavigationCategoryService {
     String cat1 = navigationCategories.get(key1);
     String cat2 = navigationCategories.get(key2);
     if (StringUtils.equals(cat1, cat2)) {
-      if (navigationUriOrder.containsKey(key1) && navigationUriOrder.containsKey(key2)) {
-        return navigationUriOrder.get(key1) - navigationUriOrder.get(key2);
-      } else {
-        return 0;
-      }
+      int key1Order = navigationUriOrder.containsKey(key1) ? navigationUriOrder.get(key1) : 0;
+      int key2Order = navigationUriOrder.containsKey(key2) ? navigationUriOrder.get(key2) : 0;
+      int order = key1Order - key2Order;
+      return order == 0 ? key1.compareTo(key2) : order;
     } else if (StringUtils.isBlank(cat1)) {
       return -1;
     } else if (StringUtils.isBlank(cat2)) {

--- a/component/portal/src/test/java/org/exoplatform/portal/config/NavigationCategoryServiceTest.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/NavigationCategoryServiceTest.java
@@ -59,12 +59,12 @@ public class NavigationCategoryServiceTest {
   public void testAddSortedCategories() {
     NavigationCategoryService navigationCategoryService = new NavigationCategoryService();
 
-    addNavigationPlugin(navigationCategoryService, "cat1", "6", "uri1-2");
-    addNavigationPlugin(navigationCategoryService, "cat1", "6", "uri1-3");
-    addNavigationPlugin(navigationCategoryService, "cat1", "6", "uri1-1");
-    addNavigationPlugin(navigationCategoryService, "cat2", "4", "uri2-2");
-    addNavigationPlugin(navigationCategoryService, "cat2", "4", "uri2-2");
-    addNavigationPlugin(navigationCategoryService, "cat2", "4", "uri2-1");
+    addNavigationPlugin(navigationCategoryService, "cat1", "6", "uri1-2", "10");
+    addNavigationPlugin(navigationCategoryService, "cat1", "6", "uri1-3", "20");
+    addNavigationPlugin(navigationCategoryService, "cat1", "6", "uri1-1", "30");
+    addNavigationPlugin(navigationCategoryService, "cat2", "4", "uri2-2", "30");
+    addNavigationPlugin(navigationCategoryService, "cat2", "4", "uri2-2", "20");
+    addNavigationPlugin(navigationCategoryService, "cat2", "4", "uri2-1", "20");
 
     assertNotNull(navigationCategoryService.getNavigationCategories());
     assertEquals("URI must be injected only oncve in one single category",
@@ -83,8 +83,8 @@ public class NavigationCategoryServiceTest {
     assertEquals("cat1", fourthEntry.getValue());
     assertEquals("cat1", fifthEntry.getValue());
 
-    assertEquals("uri2-2", firstEntry.getKey());
-    assertEquals("uri2-1", secondEntry.getKey());
+    assertEquals("uri2-1", firstEntry.getKey());
+    assertEquals("uri2-2", secondEntry.getKey());
     assertEquals("uri1-2", thirdEntry.getKey());
     assertEquals("uri1-3", fourthEntry.getKey());
     assertEquals("uri1-1", fifthEntry.getKey());
@@ -93,11 +93,13 @@ public class NavigationCategoryServiceTest {
   private void addNavigationPlugin(NavigationCategoryService navigationCategoryService,
                                    String categoryName,
                                    String categoryOrder,
-                                   String uriValue) {
+                                   String uriValue,
+                                   String uriOrder) {
     InitParams params = new InitParams();
     addParam(params, NavigationCategoryPlugin.CATEGORY_PARAM_NAME, categoryName);
     addParam(params, NavigationCategoryPlugin.CATEGORY_ORDER_PARAM_NAME, categoryOrder);
     addParam(params, NavigationCategoryPlugin.URI_PARAM_NAME, uriValue);
+    addParam(params, NavigationCategoryPlugin.URI_ORDER_PARAM_NAME, uriOrder);
     NavigationCategoryPlugin plugin = new NavigationCategoryPlugin(params);
     navigationCategoryService.addPlugin(plugin);
   }


### PR DESCRIPTION
Prior to this change, when adding two pages using the same URI.ORDER parameter, the TreeMap hides the second entry having the same order using the specific sorting algorithm. This change will ensure to avoid such a case by adding in comparaison, if the same order is adopted, the URI names comparaison.