### PR TITLE
Task-58590 : Register link is not present on login form

### DIFF
--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>exo.portal.component.api</artifactId>

--- a/component/application-registry/pom.xml
+++ b/component/application-registry/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>exo.portal.component.common</artifactId>

--- a/component/file-storage/pom.xml
+++ b/component/file-storage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>exo.portal.component.file-storage</artifactId>
   <packaging>jar</packaging>

--- a/component/identity/pom.xml
+++ b/component/identity/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/management/pom.xml
+++ b/component/management/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/pc/pom.xml
+++ b/component/pc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.component</artifactId>

--- a/component/portal/pom.xml
+++ b/component/portal/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/resources/pom.xml
+++ b/component/resources/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/scripting/pom.xml
+++ b/component/scripting/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/test/core/pom.xml
+++ b/component/test/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.test</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/test/pom.xml
+++ b/component/test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/test/web/pom.xml
+++ b/component/test/web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.test</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/api/pom.xml
+++ b/component/web/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/controller/pom.xml
+++ b/component/web/controller/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/oauth-common/pom.xml
+++ b/component/web/oauth-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>exo.portal.component.web</artifactId>
     <groupId>org.exoplatform.gatein.portal</groupId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/component/web/oauth-web/pom.xml
+++ b/component/web/oauth-web/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/pom.xml
+++ b/component/web/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/resources/pom.xml
+++ b/component/web/resources/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/security/pom.xml
+++ b/component/web/security/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/security/src/main/java/org/exoplatform/web/login/onboarding/OnboardingUIParamsForRegister.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/onboarding/OnboardingUIParamsForRegister.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpSession;
 
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.web.ControllerContext;
+import org.exoplatform.web.login.LoginHandler;
 import org.exoplatform.web.login.UIParamsExtension;
 import org.exoplatform.web.register.RegisterHandler;
 import org.exoplatform.web.security.security.SecureRandomService;
@@ -35,7 +36,8 @@ public class OnboardingUIParamsForRegister implements UIParamsExtension {
 
   public static final String        ONBOARDING_REGISTER_TOKEN   = "onboardingRegisterToken";
 
-  private static final List<String> EXTENSION_NAMES             = Arrays.asList(RegisterHandler.REGISTER_EXTENSION_NAME);
+  private static final List<String> EXTENSION_NAMES             = Arrays.asList(RegisterHandler.REGISTER_EXTENSION_NAME,
+                                                                                LoginHandler.LOGIN_EXTENSION_NAME);
 
   private SecureRandomService       secureRandomService;
 

--- a/component/web/server/pom.xml
+++ b/component/web/server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/sso/pom.xml
+++ b/component/web/sso/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/sso/sso-agent-configs/pom.xml
+++ b/component/web/sso/sso-agent-configs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web.sso</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/component/web/sso/sso-integration-configs/pom.xml
+++ b/component/web/sso/sso-integration-configs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.component.web.sso</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -33,14 +33,14 @@
   
   <groupId>org.exoplatform.gatein.portal</groupId>
   <artifactId>exo.portal.parent</artifactId>
-  <version>6.4.x-SNAPSHOT</version>
+  <version>6.4.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   
   <name>GateIn - Portal</name>
   
   <properties>
-    <org.exoplatform.gatein.sso.version>6.4.x-SNAPSHOT</org.exoplatform.gatein.sso.version>
-    <org.exoplatform.gatein.pc.version>6.4.x-SNAPSHOT</org.exoplatform.gatein.pc.version>
+    <org.exoplatform.gatein.sso.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.gatein.sso.version>
+    <org.exoplatform.gatein.pc.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.gatein.pc.version>
     
     <!-- Default eXo profiles -->
     <surefire.exo.profiles>hsqldb</surefire.exo.profiles>

--- a/portlet/exoadmin/pom.xml
+++ b/portlet/exoadmin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.portlet</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/portlet/pom.xml
+++ b/portlet/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.portlet</artifactId>

--- a/portlet/web/pom.xml
+++ b/portlet/web/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.portlet</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/web/eXoResources/pom.xml
+++ b/web/eXoResources/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.web</artifactId>

--- a/web/portal/pom.xml
+++ b/web/portal/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/web/rest/pom.xml
+++ b/web/rest/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.web</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/core/pom.xml
+++ b/webui/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/eXo/pom.xml
+++ b/webui/eXo/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/framework/pom.xml
+++ b/webui/framework/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo.portal.webui</artifactId>

--- a/webui/portal/pom.xml
+++ b/webui/portal/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/webui/portlet/pom.xml
+++ b/webui/portlet/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.exoplatform.gatein.portal</groupId>
     <artifactId>exo.portal.webui</artifactId>
-    <version>6.4.x-SNAPSHOT</version>
+    <version>6.4.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Before this fix, when we activate the property  meeds.register.onboarding.enabled=true, the link to access to the register form is not displayed on login form
This commit activate the extension to display to register link on login form