### PR TITLE
Task-58447: Add implicit refresh to save and abort listener when editing layout.

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortalComposer.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortalComposer.java
@@ -360,6 +360,7 @@ public class UIPortalComposer extends UIContainer {
             uiWorkingWS.setRenderedChild(UIPortalApplication.UI_VIEWING_WS_ID);
             PortalRequestContext prContext = Util.getPortalRequestContext();
             prContext.ignoreAJAXUpdateOnPortlets(true);
+            prContext.getJavascriptManager().getRequireJS().addScripts("location.reload(true);");
 
             UIEditInlineWorkspace uiEditWS = uiWorkingWS.getChild(UIEditInlineWorkspace.class);
             uiEditWS.getComposer().setEditted(false);
@@ -434,6 +435,7 @@ public class UIPortalComposer extends UIContainer {
             uiPortalApp.setModeState(UIPortalApplication.NORMAL_MODE);
             uiWorkingWS.setRenderedChild(UIPortalApplication.UI_VIEWING_WS_ID);
             prContext.ignoreAJAXUpdateOnPortlets(true);
+            prContext.getJavascriptManager().getRequireJS().addScripts("location.reload(true);");
 
             if (uiComposer.isPortalExist(editPortal)) {
                 PortalConfig pConfig = prContext.getDynamicPortalConfig();


### PR DESCRIPTION
ISSUE : When user opens the composer  to edit layout and finish the action by clicking on save or cancel icon and go to open the news settings drawer, which will be opened but not canceled when the user want to cancel it by any action (save , cancel , click outside drawer )
FIX : Add implicit refresh to save and abort listener when editing layout.