### PR TITLE
Task-58447: Add implicit refresh to save and abort listener when editing layout

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortalComposer.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortalComposer.java
@@ -708,6 +708,7 @@ public class UIPortalComposer extends UIContainer {
             uiWorkingWS.setRenderedChild(UIPortalApplication.UI_VIEWING_WS_ID);
             Util.getPortalRequestContext().ignoreAJAXUpdateOnPortlets(true);
 
+            Util.getPortalRequestContext().getJavascriptManager().getRequireJS().addScripts("location.reload(true);");
             UserNode currentNode = uiPortal.getSelectedUserNode();
             PageNodeEvent<UIPortalApplication> pnevent = new PageNodeEvent<UIPortalApplication>(uiPortalApp,
                     PageNodeEvent.CHANGE_NODE, currentNode.getNavigation().getKey(), currentNode.getURI());


### PR DESCRIPTION
ISSUE : When user opens the composer to edit layout and finish the action by clicking on save or cancel icon and go to open the news settings drawer, which will be opened but not canceled when the user want to cancel it by any action (save , cancel , click outside drawer )
FIX : Add implicit refresh to save and abort listener when editing layout.
FYI : this pr is a complement of the fix , the problem is fixed only on aboard button and this pr for the save button .