### PR TITLE
Task 58776 : Update service parameter to use only one parameter wellKnowUrl

### DIFF
--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
@@ -476,7 +476,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
                 this.tokenInfoURL = json.getString("token_endpoint");
             }
         } catch (JSONException e) {
-            log.error("error at read Url wellnown Configuration Content : " + e.getMessage());
+            log.error("Unable to read webKnownUrl content.", e.getMessage());
         }
     }
 

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
@@ -467,15 +467,17 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
             return;
         }
         try {
-            String wellnownConfigurationContent = readUrl(this.wellKnownConfigurationUrl);
-            if (wellnownConfigurationContent != null) {
-                JSONObject json = new JSONObject(wellnownConfigurationContent);
+            String wellKnownConfigurationContent = readUrl(new URL(this.wellKnownConfigurationUrl));
+            if (wellKnownConfigurationContent != null) {
+                JSONObject json = new JSONObject(wellKnownConfigurationContent);
                 this.authenticationURL = json.getString("authorization_endpoint");
                 this.accessTokenURL = json.getString("token_endpoint");
                 this.userInfoURL = json.getString("userinfo_endpoint");
             }
         } catch (JSONException e) {
-            log.error("Unable to read webKnownUrl content.", e.getMessage());
+            log.error("Unable to read webKnownUrl content : " + this.wellKnownConfigurationUrl);
+        } catch (MalformedURLException e) {
+            log.error("WellKnowConfigurationUrl malformed : url" + this.wellKnownConfigurationUrl);
         }
     }
 
@@ -484,22 +486,17 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
         // Nothing to stop
     }
 
-    private static String readUrl(String urlString) {
-        try {
-            URL url = new URL(urlString);
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
-                StringBuilder buffer = new StringBuilder();
-                int read;
-                char[] chars = new char[1024];
-                while ((read = reader.read(chars)) != -1)
-                    buffer.append(chars, 0, read);
+    private static String readUrl(URL url) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+            StringBuilder buffer = new StringBuilder();
+            int read;
+            char[] chars = new char[1024];
+            while ((read = reader.read(chars)) != -1)
+                buffer.append(chars, 0, read);
 
-                return buffer.toString();
-            } catch (IOException e) {
-                log.error(e.getMessage());
-            }
-        } catch (MalformedURLException e) {
-            log.error("Mal formed URL Exception");
+            return buffer.toString();
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
         return null;
     }

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
@@ -473,7 +473,6 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
                 this.authenticationURL = json.getString("authorization_endpoint");
                 this.accessTokenURL = json.getString("token_endpoint");
                 this.userInfoURL = json.getString("userinfo_endpoint");
-                this.tokenInfoURL = json.getString("token_endpoint");
             }
         } catch (JSONException e) {
             log.error("Unable to read webKnownUrl content.", e.getMessage());

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
@@ -64,7 +64,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
     return getKey(header.getKeyId());
   }
 
-  public Key getKey(String keyId) {
+  private Key getKey(String keyId) {
 
     // check non synchronized to avoid a lock
     Key result = keyMap.get(keyId);
@@ -86,7 +86,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
     }
   }
 
-  public void updateKeys() {
+  private void updateKeys() {
 
     JsonObject configuration = getJson(issuer + "/.well-known/openid-configuration");
     String jwksUrl = configuration.getString("jwks_uri");
@@ -113,7 +113,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
 
   }
 
-  public JsonObject getJson(String url) {
+  private JsonObject getJson(String url) {
     StringBuilder content = new StringBuilder();
     try {
       URL wellKnownUrl = new URL(url); // creating a url object
@@ -134,8 +134,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
       return reader.readObject();
     }
   }
-
-  public BigInteger base64ToBigInteger(String value) {
+  private BigInteger base64ToBigInteger(String value) {
     return new BigInteger(1, Decoders.BASE64URL.decode(value));
   }
 }

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
@@ -64,7 +64,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
     return getKey(header.getKeyId());
   }
 
-  private Key getKey(String keyId) {
+  public Key getKey(String keyId) {
 
     // check non synchronized to avoid a lock
     Key result = keyMap.get(keyId);
@@ -86,7 +86,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
     }
   }
 
-  private void updateKeys() {
+  public void updateKeys() {
 
     JsonObject configuration = getJson(issuer + "/.well-known/openid-configuration");
     String jwksUrl = configuration.getString("jwks_uri");
@@ -113,7 +113,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
 
   }
 
-  private JsonObject getJson(String url) {
+  public JsonObject getJson(String url) {
     StringBuilder content = new StringBuilder();
     try {
       URL wellKnownUrl = new URL(url); // creating a url object
@@ -135,7 +135,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
     }
   }
 
-  private BigInteger base64ToBigInteger(String value) {
+  public BigInteger base64ToBigInteger(String value) {
     return new BigInteger(1, Decoders.BASE64URL.decode(value));
   }
 }

--- a/web/portal/src/main/webapp/WEB-INF/conf/sso/oauth-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/sso/oauth-configuration.xml
@@ -156,20 +156,8 @@
         <value>${exo.oauth.openid.accessType}</value>
       </value-param>
       <value-param>
-        <name>authenticationURL</name>
-        <value>${exo.oauth.openid.authenticationURL}</value>
-      </value-param>
-      <value-param>
-        <name>accessTokenURL</name>
-        <value>${exo.oauth.openid.accessTokenURL}</value>
-      </value-param>
-      <value-param>
-        <name>tokenInfoURL</name>
-        <value>${exo.oauth.openid.tokenInfoURL}</value>
-      </value-param>
-      <value-param>
-        <name>userInfoURL</name>
-        <value>${exo.oauth.openid.userInfoURL}</value>
+        <name>wellKnownConfigurationUrl</name>
+        <value>${exo.oauth.openid.wellKnownConfigurationUrl}</value>
       </value-param>
     </init-params>
   </component>


### PR DESCRIPTION
**Prior to this change**, We need to validate the jwt token. For this we need information (keys) which are in the wellKnownUrl configuration , so we have rationalized and reduced the number of parameters.
**This change** , wellKnownUrl contains parameters userInfoUrl, TokenInfoUrl and authenticationURL  . By adding parameter wellKnowUrl, we are able to read other parameters, so we can remove them for cofnigruation.