### PR TITLE
MEED-429 Add content-type HTTP Header to register page

### DIFF
--- a/component/web/resources/src/main/java/org/exoplatform/web/application/JspBasedWebHandler.java
+++ b/component/web/resources/src/main/java/org/exoplatform/web/application/JspBasedWebHandler.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -46,7 +47,9 @@ public abstract class JspBasedWebHandler extends WebRequestHandler {
 
   private static final Log          LOG            = ExoLogger.getLogger(JspBasedWebHandler.class);
 
-  protected static final String     JS_PATHS_PARAM = "paths";
+  protected static final String     TEXT_HTML_CONTENT_TYPE = "text/html; charset=UTF-8";
+
+  protected static final String     JS_PATHS_PARAM         = "paths";
 
   protected LocaleConfigService     localeConfigService;
 
@@ -87,6 +90,9 @@ public abstract class JspBasedWebHandler extends WebRequestHandler {
                               List<String> additionalCSSModules,
                               Consumer<JSONObject> extendUIParameters) throws Exception {
     HttpServletRequest request = context.getRequest();
+
+    HttpServletResponse response = context.getResponse();
+    response.setContentType(TEXT_HTML_CONTENT_TYPE);
 
     LocaleConfig localeConfig = request.getLocale() == null ? localeConfigService.getDefaultLocaleConfig()
                                                             : localeConfigService.getLocaleConfig(request.getLocale()

--- a/component/web/resources/src/test/java/org/exoplatform/web/application/TestJspBasedWebHandler.java
+++ b/component/web/resources/src/test/java/org/exoplatform/web/application/TestJspBasedWebHandler.java
@@ -16,22 +16,24 @@
  */
 package org.exoplatform.web.application;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import org.exoplatform.portal.branding.BrandingService;
 import org.exoplatform.portal.resource.SkinService;
@@ -39,6 +41,12 @@ import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.resources.impl.LocaleConfigImpl;
 import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.application.javascript.JavascriptConfigService;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestJspBasedWebHandler {
@@ -138,5 +146,6 @@ public class TestJspBasedWebHandler {
     assertTrue(inlineScripts.contains("brandingLogo"));
     assertTrue(attributes.get("brandingThemeUrl").toString().contains(String.valueOf(brandingLastModifiedTime)));
     assertEquals(attributes.get("brandingPrimaryColor").toString(), primarycolor);
+    verify(response, times(1)).setContentType(JspBasedWebHandler.TEXT_HTML_CONTENT_TYPE);
   }
 }

--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -60,8 +60,6 @@ public class LoginHandler extends JspBasedWebHandler {
 
   private static final Log        LOG                        = ExoLogger.getLogger(LoginHandler.class);
 
-  private static final String     TEXT_HTML_CONTENT_TYPE     = "text/html; charset=UTF-8";
-
   private static final String     JS_PATHS_PARAM             = "paths";
 
   private static final String     LOGIN_JSP_PATH_PARAM       = "login.jsp.path";
@@ -236,7 +234,6 @@ public class LoginHandler extends JspBasedWebHandler {
         status = LoginStatus.DISABLED_USER;
       }
 
-      response.setContentType(TEXT_HTML_CONTENT_TYPE);
       dispatch(context, loginPath.toString(), status);
     }
   }


### PR DESCRIPTION
Issue : Meeds-io/meeds#228

Prior tot his change, there was no content-type HTTP Header that was defined for register page which leads to have a plain text page when introducing HTTP Header  in front-end server (for better client side protection purpose).

This change will introduce explicitly the missing content-type header.