### PR TITLE
EXO-59192 : openId authentication, locate user with its email instead of username

### DIFF
--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/data/SocialNetworkServiceImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/data/SocialNetworkServiceImpl.java
@@ -158,7 +158,7 @@ public class SocialNetworkServiceImpl implements SocialNetworkService, OAuthCode
       Query queryByEmail = new Query();
       queryByEmail.setEmail(email);
       ListAccess<User> users = userHandler.findUsersByQuery(queryByEmail);
-      if(users == null || users.getSize() == 0 || users.getSize() > 0) {
+      if(users == null || users.getSize() == 0 || users.getSize() > 1) {
         return null;
       } else if(users.getSize() == 1) {
         return users.load(0, 1)[0];

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/data/SocialNetworkServiceImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/data/SocialNetworkServiceImpl.java
@@ -26,7 +26,6 @@ package org.gatein.security.oauth.data;
 import java.lang.reflect.Method;
 
 import org.exoplatform.commons.utils.ListAccess;
-import org.exoplatform.commons.utils.ListAccessImpl;
 import org.exoplatform.container.component.ComponentRequestLifecycle;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.organization.*;

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/data/SocialNetworkServiceImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/data/SocialNetworkServiceImpl.java
@@ -25,14 +25,11 @@ package org.gatein.security.oauth.data;
 
 import java.lang.reflect.Method;
 
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.commons.utils.ListAccessImpl;
 import org.exoplatform.container.component.ComponentRequestLifecycle;
 import org.exoplatform.container.component.RequestLifeCycle;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.User;
-import org.exoplatform.services.organization.UserHandler;
-import org.exoplatform.services.organization.UserProfile;
-import org.exoplatform.services.organization.UserProfileHandler;
-import org.exoplatform.services.organization.UserStatus;
+import org.exoplatform.services.organization.*;
 import org.exoplatform.web.security.codec.AbstractCodec;
 import org.exoplatform.web.security.codec.CodecInitializer;
 import org.exoplatform.web.security.security.TokenServiceInitializationException;
@@ -153,7 +150,30 @@ public class SocialNetworkServiceImpl implements SocialNetworkService, OAuthCode
         }
     }
 
-    @Override
+  @Override
+  public User findUserByEmail(String email) {
+    try {
+      begin();
+      UserHandler userHandler = orgService.getUserHandler();
+      Query queryByEmail = new Query();
+      queryByEmail.setEmail(email);
+      ListAccess<User> users = userHandler.findUsersByQuery(queryByEmail);
+      if(users == null || users.getSize() == 0 || users.getSize() > 0) {
+        return null;
+      } else if(users.getSize() == 1) {
+        return users.load(0, 1)[0];
+      }
+    } catch (OAuthException oauthEx) {
+      throw oauthEx;
+    } catch (Exception e) {
+      throw new OAuthException(OAuthExceptionCode.PERSISTENCE_ERROR, e);
+    } finally {
+      end();
+    }
+    return null;
+  }
+
+  @Override
     public <T extends AccessTokenContext> void updateOAuthInfo(OAuthProviderType<T> oauthProviderType, String username, String oauthUsername, T accessToken) {
         try {
             begin();

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdPrincipalProcessor.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdPrincipalProcessor.java
@@ -31,14 +31,16 @@ public class OpenIdPrincipalProcessor implements OAuthPrincipalProcessor {
     public User convertToGateInUser(OAuthPrincipal principal) {
         String email = principal.getEmail();
         String username = principal.getUserName();
-        UserImpl gateinUser = new UserImpl(OAuthUtils.refineUserName(username));
-        if(StringUtils.isNoneBlank(username)) {
-            gateinUser.setUserName(OAuthUtils.refineUserName(username));
+        UserImpl gateinUser = new UserImpl();
+        if(StringUtils.isNotBlank(username)) {
+          gateinUser.setUserName(OAuthUtils.refineUserName(username));
         }
         gateinUser.setFirstName(principal.getFirstName());
         gateinUser.setLastName(principal.getLastName());
         gateinUser.setEmail(email);
-        gateinUser.setDisplayName(principal.getDisplayName());
+        if(StringUtils.isNotBlank(principal.getDisplayName())) {
+          gateinUser.setDisplayName(principal.getDisplayName());
+        }
 
         return gateinUser;
     }

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdPrincipalProcessor.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdPrincipalProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.gatein.security.oauth.openid;
 
+import org.apache.commons.lang3.StringUtils;
 import org.gatein.security.oauth.spi.OAuthPrincipal;
 import org.gatein.security.oauth.spi.OAuthPrincipalProcessor;
 import org.gatein.security.oauth.utils.OAuthUtils;
@@ -30,14 +31,10 @@ public class OpenIdPrincipalProcessor implements OAuthPrincipalProcessor {
     public User convertToGateInUser(OAuthPrincipal principal) {
         String email = principal.getEmail();
         String username = principal.getUserName();
-        if(email != null) {
-            int index = email.indexOf('@');
-            if(index > 0) {
-                username = email.substring(0, index);
-            }
+        UserImpl gateinUser = new UserImpl(OAuthUtils.refineUserName(username));
+        if(StringUtils.isNoneBlank(username)) {
+            gateinUser.setUserName(OAuthUtils.refineUserName(username));
         }
-
-        User gateinUser = new UserImpl(OAuthUtils.refineUserName(username));
         gateinUser.setFirstName(principal.getFirstName());
         gateinUser.setLastName(principal.getLastName());
         gateinUser.setEmail(email);

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/spi/SocialNetworkService.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/spi/SocialNetworkService.java
@@ -62,4 +62,11 @@ public interface SocialNetworkService {
      */
     <T extends AccessTokenContext> void removeOAuthAccessToken(OAuthProviderType<T> oauthProviderType, String username);
 
+    /**
+     * Locates a user by its email address. If no user is found or more than one user
+     * has that email, it returns null
+     * @param email
+     * @return User having provided email
+     */
+    User findUserByEmail(String email);
 }

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/utils/OAuthUtils.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/utils/OAuthUtils.java
@@ -107,16 +107,16 @@ public class OAuthUtils {
         try {
             // Assume that username is first part of email
             String email = userInfo.getString(OAuthConstants.EMAIL_ATTRIBUTE);
-            String username = email != null ? email.substring(0, email.indexOf('@')) : userInfo.getString("given_name");
-            return new OAuthPrincipal<OpenIdAccessTokenContext>(username,
-                                                                userInfo.getString(OAuthConstants.GIVEN_NAME_ATTRIBUTE),
-                                                                userInfo.getString(OAuthConstants.FAMILY_NAME_ATTRIBUTE),
-                                                                userInfo.getString(OAuthConstants.NAME_ATTRIBUTE),
-                                                                userInfo.getString(OAuthConstants.EMAIL_ATTRIBUTE),
-                                                                userInfo.has(OAuthConstants.PICTURE_ATTRIBUTE) ?
-                                                                userInfo.getString(OAuthConstants.PICTURE_ATTRIBUTE) : null,
-                                                                accessToken,
-                                                                openIdProviderType);
+
+            return new OAuthPrincipal<>(null,
+                                        userInfo.getString(OAuthConstants.GIVEN_NAME_ATTRIBUTE),
+                                        userInfo.getString(OAuthConstants.FAMILY_NAME_ATTRIBUTE),
+                                        userInfo.getString(OAuthConstants.NAME_ATTRIBUTE),
+                                        userInfo.getString(OAuthConstants.EMAIL_ATTRIBUTE),
+                                        userInfo.has(OAuthConstants.PICTURE_ATTRIBUTE) ? userInfo.getString(OAuthConstants.PICTURE_ATTRIBUTE)
+                                                                                       : null,
+                                        accessToken,
+                                        openIdProviderType);
         } catch (JSONException jsonException) {
             throw new OAuthException(OAuthExceptionCode.ACCESS_TOKEN_ERROR,
                                      "Error during user info reading: response format is ko");

--- a/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/OAuthAuthenticationFilter.java
+++ b/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/OAuthAuthenticationFilter.java
@@ -139,18 +139,26 @@ public class OAuthAuthenticationFilter extends AbstractSSOInterceptor {
 
     protected void handleRedirectToRegistrationForm(HttpServletRequest httpRequest, HttpServletResponse httpResponse, OAuthPrincipal principal)
             throws IOException {
-        if (log.isTraceEnabled()) {
-            log.trace("Not found portalUser with username " + principal.getUserName() + ". Redirecting to registration form");
-        }
+      if (log.isTraceEnabled()) {
+        log.trace("Not found portalUser with username " + principal.getUserName() + ". Redirecting to registration form");
+      }
 
-        //User gateInUser = OAuthUtils.convertOAuthPrincipalToGateInUser(principal);
-        OAuthPrincipalProcessor principalProcessor = principal.getOauthProviderType().getOauthPrincipalProcessor();
-        User gateInUser =
-        authenticationRegistry.setAttributeOfClient(httpRequest, OAuthConstants.ATTRIBUTE_AUTHENTICATED_PORTAL_USER, gateInUser);
+      //User gateInUser = OAuthUtils.convertOAuthPrincipalToGateInUser(principal);
+      User gateInUser; 
+      OAuthPrincipalProcessor principalProcessor = principal.getOauthProviderType().getOauthPrincipalProcessor();
+      if(StringUtils.isNotBlank(principal.getUserName())) {
+        gateInUser = socialNetworkService.findUserByEmail(principal.getEmail());
+      } else {
+        gateInUser = socialNetworkService.findUserByEmail(principal.getEmail());
+      }
+      if(gateInUser == null) {
+        gateInUser = principalProcessor.convertToGateInUser(principal);
+      }
+      authenticationRegistry.setAttributeOfClient(httpRequest, OAuthConstants.ATTRIBUTE_AUTHENTICATED_PORTAL_USER, gateInUser);
 
-        String registrationRedirectUrl = getRegistrationRedirectURL(httpRequest);
-        registrationRedirectUrl = httpResponse.encodeRedirectURL(registrationRedirectUrl);
-        httpResponse.sendRedirect(registrationRedirectUrl);
+      String registrationRedirectUrl = getRegistrationRedirectURL(httpRequest);
+      registrationRedirectUrl = httpResponse.encodeRedirectURL(registrationRedirectUrl);
+      httpResponse.sendRedirect(registrationRedirectUrl);
     }
 
 

--- a/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/OAuthAuthenticationFilter.java
+++ b/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/OAuthAuthenticationFilter.java
@@ -143,11 +143,10 @@ public class OAuthAuthenticationFilter extends AbstractSSOInterceptor {
         log.trace("Not found portalUser with username " + principal.getUserName() + ". Redirecting to registration form");
       }
 
-      //User gateInUser = OAuthUtils.convertOAuthPrincipalToGateInUser(principal);
-      User gateInUser; 
+      User gateInUser;
       OAuthPrincipalProcessor principalProcessor = principal.getOauthProviderType().getOauthPrincipalProcessor();
       if(StringUtils.isNotBlank(principal.getUserName())) {
-        gateInUser = socialNetworkService.findUserByEmail(principal.getEmail());
+        gateInUser = socialNetworkService.findUserByEmail(principal.getUserName());
       } else {
         gateInUser = socialNetworkService.findUserByEmail(principal.getEmail());
       }

--- a/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/OAuthAuthenticationFilter.java
+++ b/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/OAuthAuthenticationFilter.java
@@ -32,6 +32,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.web.security.AuthenticationRegistry;
 import org.exoplatform.services.log.Log;
@@ -116,7 +117,12 @@ public class OAuthAuthenticationFilter extends AbstractSSOInterceptor {
 
 
     protected void processPrincipal(HttpServletRequest httpRequest, HttpServletResponse httpResponse, OAuthPrincipal principal) throws IOException {
-        User portalUser = socialNetworkService.findUserByOAuthProviderUsername(principal.getOauthProviderType(), principal.getUserName());
+      User portalUser;
+      if(StringUtils.isNotBlank(principal.getUserName())) {
+        portalUser = socialNetworkService.findUserByOAuthProviderUsername(principal.getOauthProviderType(), principal.getUserName());
+      } else {
+        portalUser = socialNetworkService.findUserByEmail(principal.getEmail());
+      }
 
         if (portalUser == null) {
             // This means that user has been successfully authenticated via OAuth, but doesn't exist in GateIn. So we need to establish context
@@ -139,7 +145,7 @@ public class OAuthAuthenticationFilter extends AbstractSSOInterceptor {
 
         //User gateInUser = OAuthUtils.convertOAuthPrincipalToGateInUser(principal);
         OAuthPrincipalProcessor principalProcessor = principal.getOauthProviderType().getOauthPrincipalProcessor();
-        User gateInUser = principalProcessor.convertToGateInUser(principal);
+        User gateInUser =
         authenticationRegistry.setAttributeOfClient(httpRequest, OAuthConstants.ATTRIBUTE_AUTHENTICATED_PORTAL_USER, gateInUser);
 
         String registrationRedirectUrl = getRegistrationRedirectURL(httpRequest);


### PR DESCRIPTION
When we use OpenID authentication, if a user does not have an account, an accountg is created with his username as his email's username. If the user has already an account with that email in the platform, the user account won't be loaded and we will get a page requesting to input the password (unknown since it is generated on first login)
The current commit fixes the problem by : 
- Retrieve the user from eXo database using its email, and generate a correct username following pattern firstname.lastname (lowercase) when the username is not provided by the Oauth
- add a function to load the user with its email instead of its username when the latter is null

