### PR TITLE
EXO-59193 : Allow getting login errors from Session attributes

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -233,7 +233,10 @@ public class LoginHandler extends JspBasedWebHandler {
       if (meetDisabledUser) {
         status = LoginStatus.DISABLED_USER;
       }
-
+      Object ssoStatus = request.getAttribute("SSO.Login.Status");
+      if(ssoStatus != null) {
+        status = LoginStatus.valueOf((String) ssoStatus);
+      }
       dispatch(context, loginPath.toString(), status);
     }
   }

--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginStatus.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginStatus.java
@@ -22,7 +22,9 @@ public enum LoginStatus {
   AUTHENTICATED,
   FAILED("SigninFail"),
   DISABLED_USER("DisabledUserSignin"),
-  MANY_USERS_WITH_SAME_EMAIL("ManyUsersWithSameEmail");
+  MANY_USERS_WITH_SAME_EMAIL("ManyUsersWithSameEmail"),
+
+  USER_ACCOUNT_NOT_FOUND("UserAccountNotFound");
 
   private final String errorCode;
 


### PR DESCRIPTION
This fix will add possibility to share Login error from SSO filter with the Login Handler to display login failure resons for end users.