### PR TITLE
EXO-59193/59192 : OIDC authentication fix and On the fly registration rework

### DIFF
--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/data/SocialNetworkServiceImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/data/SocialNetworkServiceImpl.java
@@ -25,14 +25,10 @@ package org.gatein.security.oauth.data;
 
 import java.lang.reflect.Method;
 
+import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.component.ComponentRequestLifecycle;
 import org.exoplatform.container.component.RequestLifeCycle;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.User;
-import org.exoplatform.services.organization.UserHandler;
-import org.exoplatform.services.organization.UserProfile;
-import org.exoplatform.services.organization.UserProfileHandler;
-import org.exoplatform.services.organization.UserStatus;
+import org.exoplatform.services.organization.*;
 import org.exoplatform.web.security.codec.AbstractCodec;
 import org.exoplatform.web.security.codec.CodecInitializer;
 import org.exoplatform.web.security.security.TokenServiceInitializationException;
@@ -153,7 +149,30 @@ public class SocialNetworkServiceImpl implements SocialNetworkService, OAuthCode
         }
     }
 
-    @Override
+  @Override
+  public User findUserByEmail(String email) {
+    try {
+      begin();
+      UserHandler userHandler = orgService.getUserHandler();
+      Query queryByEmail = new Query();
+      queryByEmail.setEmail(email);
+      ListAccess<User> users = userHandler.findUsersByQuery(queryByEmail);
+      if(users == null || users.getSize() == 0 || users.getSize() > 1) {
+        return null;
+      } else if(users.getSize() == 1) {
+        return users.load(0, 1)[0];
+      }
+    } catch (OAuthException oauthEx) {
+      throw oauthEx;
+    } catch (Exception e) {
+      throw new OAuthException(OAuthExceptionCode.PERSISTENCE_ERROR, e);
+    } finally {
+      end();
+    }
+    return null;
+  }
+
+  @Override
     public <T extends AccessTokenContext> void updateOAuthInfo(OAuthProviderType<T> oauthProviderType, String username, String oauthUsername, T accessToken) {
         try {
             begin();

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdPrincipalProcessor.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdPrincipalProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.gatein.security.oauth.openid;
 
+import org.apache.commons.lang3.StringUtils;
 import org.gatein.security.oauth.spi.OAuthPrincipal;
 import org.gatein.security.oauth.spi.OAuthPrincipalProcessor;
 import org.gatein.security.oauth.utils.OAuthUtils;
@@ -30,18 +31,16 @@ public class OpenIdPrincipalProcessor implements OAuthPrincipalProcessor {
     public User convertToGateInUser(OAuthPrincipal principal) {
         String email = principal.getEmail();
         String username = principal.getUserName();
-        if(email != null) {
-            int index = email.indexOf('@');
-            if(index > 0) {
-                username = email.substring(0, index);
-            }
+        UserImpl gateinUser = new UserImpl();
+        if(StringUtils.isNotBlank(username)) {
+          gateinUser.setUserName(OAuthUtils.refineUserName(username));
         }
-
-        User gateinUser = new UserImpl(OAuthUtils.refineUserName(username));
         gateinUser.setFirstName(principal.getFirstName());
         gateinUser.setLastName(principal.getLastName());
         gateinUser.setEmail(email);
-        gateinUser.setDisplayName(principal.getDisplayName());
+        if(StringUtils.isNotBlank(principal.getDisplayName())) {
+          gateinUser.setDisplayName(principal.getDisplayName());
+        }
 
         return gateinUser;
     }

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/spi/SocialNetworkService.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/spi/SocialNetworkService.java
@@ -62,4 +62,11 @@ public interface SocialNetworkService {
      */
     <T extends AccessTokenContext> void removeOAuthAccessToken(OAuthProviderType<T> oauthProviderType, String username);
 
+    /**
+     * Locates a user by its email address. If no user is found or more than one user
+     * has that email, it returns null
+     * @param email
+     * @return User having provided email
+     */
+    User findUserByEmail(String email);
 }

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/utils/OAuthUtils.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/utils/OAuthUtils.java
@@ -107,16 +107,16 @@ public class OAuthUtils {
         try {
             // Assume that username is first part of email
             String email = userInfo.getString(OAuthConstants.EMAIL_ATTRIBUTE);
-            String username = email != null ? email.substring(0, email.indexOf('@')) : userInfo.getString("given_name");
-            return new OAuthPrincipal<OpenIdAccessTokenContext>(username,
-                                                                userInfo.getString(OAuthConstants.GIVEN_NAME_ATTRIBUTE),
-                                                                userInfo.getString(OAuthConstants.FAMILY_NAME_ATTRIBUTE),
-                                                                userInfo.getString(OAuthConstants.NAME_ATTRIBUTE),
-                                                                userInfo.getString(OAuthConstants.EMAIL_ATTRIBUTE),
-                                                                userInfo.has(OAuthConstants.PICTURE_ATTRIBUTE) ?
-                                                                userInfo.getString(OAuthConstants.PICTURE_ATTRIBUTE) : null,
-                                                                accessToken,
-                                                                openIdProviderType);
+
+            return new OAuthPrincipal<>(null,
+                                        userInfo.getString(OAuthConstants.GIVEN_NAME_ATTRIBUTE),
+                                        userInfo.getString(OAuthConstants.FAMILY_NAME_ATTRIBUTE),
+                                        userInfo.getString(OAuthConstants.NAME_ATTRIBUTE),
+                                        userInfo.getString(OAuthConstants.EMAIL_ATTRIBUTE),
+                                        userInfo.has(OAuthConstants.PICTURE_ATTRIBUTE) ? userInfo.getString(OAuthConstants.PICTURE_ATTRIBUTE)
+                                                                                       : null,
+                                        accessToken,
+                                        openIdProviderType);
         } catch (JSONException jsonException) {
             throw new OAuthException(OAuthExceptionCode.ACCESS_TOKEN_ERROR,
                                      "Error during user info reading: response format is ko");

--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -235,8 +235,10 @@ public class LoginHandler extends JspBasedWebHandler {
       if (meetDisabledUser) {
         status = LoginStatus.DISABLED_USER;
       }
-
-      response.setContentType(TEXT_HTML_CONTENT_TYPE);
+      Object ssoStatus = request.getAttribute("SSO.Login.Status");
+      if(ssoStatus != null) {
+        status = LoginStatus.valueOf((String) ssoStatus);
+      }
       dispatch(context, loginPath.toString(), status);
     }
   }

--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginStatus.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginStatus.java
@@ -22,7 +22,9 @@ public enum LoginStatus {
   AUTHENTICATED,
   FAILED("SigninFail"),
   DISABLED_USER("DisabledUserSignin"),
-  MANY_USERS_WITH_SAME_EMAIL("ManyUsersWithSameEmail");
+  MANY_USERS_WITH_SAME_EMAIL("ManyUsersWithSameEmail"),
+
+  USER_ACCOUNT_NOT_FOUND("UserAccountNotFound");
 
   private final String errorCode;
 


### PR DESCRIPTION
When we use OpenID authentication, if a user does not have an account, an accountg is created with his username as his email's username. If the user has already an account with that email in the platform, the user account won't be loaded and we will get a page requesting to input the password (unknown since it is generated on first login)
The current commit fixes the problem by :
- Retrieve the user from eXo database using its email, and generate a correct username following pattern firstname.lastname (lowercase) when the username is not provided by the Oauth
- Adding a function to load the user with its email instead of its username when the latter is null
(cherry picked from commit f1cd4c2216491dd5122cf4092ffcb68a02baa751)

Add possibility to share Login error from SSO filter with the Login Handler to display login failure resons for end users.
(cherry picked from commit 5c44e28542e9adae6cdfafdb3ddce93a6a394c0f)