### PR TITLE
fix: OpenId Connect does not working with ADFS - EXO-59388 - meeds-io/meeds#260

### DIFF
--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdAccessTokenContext.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdAccessTokenContext.java
@@ -1,6 +1,8 @@
 package org.gatein.security.oauth.openid;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import org.gatein.security.oauth.spi.AccessTokenContext;
@@ -15,11 +17,14 @@ public class OpenIdAccessTokenContext extends AccessTokenContext implements Seri
     
     public final OAuth2AccessToken accessToken;
 
+    private Map<String, String>  customClaims;
+
     public OpenIdAccessTokenContext(OAuth2AccessToken tokenData, String... scopes) {
         super(scopes);
         if (tokenData == null) {
             throw new IllegalArgumentException("tokenData can't be null");
         }
+        customClaims = new HashMap<>();
         this.accessToken = tokenData;
     }
 
@@ -28,6 +33,7 @@ public class OpenIdAccessTokenContext extends AccessTokenContext implements Seri
         if (tokenData == null) {
             throw new IllegalArgumentException("tokenData can't be null");
         }
+        customClaims = new HashMap<>();
         this.accessToken = tokenData;
     }
     
@@ -40,4 +46,11 @@ public class OpenIdAccessTokenContext extends AccessTokenContext implements Seri
         return accessToken;
     }
 
+    public void addCustomClaims(Map<String, String> newCustomClaims) {
+      this.customClaims.putAll(newCustomClaims);
+    }
+
+    public Map<String, String> getCustomClaims() {
+      return this.customClaims;
+    }
 }

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
@@ -145,7 +145,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
     // Very initial request to portal
     if (state == null || state.isEmpty()) {
 
-      return initialInteraction(request, response, scopes);
+      return initialInteraction(request, response);
     } else if (state.equals(InteractionState.State.AUTH.name())) {
       OAuth2AccessToken tokenResponse = obtainAccessToken(request);
       OpenIdAccessTokenContext accessTokenContext = validateTokenAndUpdateScopes(new OpenIdAccessTokenContext(tokenResponse));
@@ -162,8 +162,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
 
   //
   protected InteractionState<OpenIdAccessTokenContext> initialInteraction(HttpServletRequest request,
-                                                                          HttpServletResponse response,
-                                                                          Set<String> scopes) throws IOException {
+                                                                          HttpServletResponse response) throws IOException {
     String verificationState = String.valueOf(secureRandomService.getSecureRandom().nextLong());
     String authorizeUrl = this.authenticationURL + "?" + "response_type=code" + "&client_id=" + this.clientID + "&scope="
         + this.scopes.stream().collect(Collectors.joining(" ")) + "&redirect_uri=" + this.redirectURL + "&state="

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
@@ -41,398 +41,432 @@ import org.picocontainer.Startable;
  */
 public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
 
-    private static Log log = ExoLogger.getLogger(OpenIdProcessorImpl.class);
+  private static Log                  log    = ExoLogger.getLogger(OpenIdProcessorImpl.class);
 
-    private final String redirectURL;
-    private String authenticationURL;
-    private String accessTokenURL;
-    private String userInfoURL;
-    private final String clientID;
-    private final String clientSecret;
-    private final Set<String> scopes = new HashSet<String>();
-    private final String accessType;
-    private final String wellKnownConfigurationUrl;
-    private final String applicationName;
-    private String issuer;
-    private final int chunkLength;
+  private final String                redirectURL;
 
+  private String                      authenticationURL;
 
-    private RemoteJwkSigningKeyResolver remoteJwkSigningKeyResolver;
-    private final SecureRandomService secureRandomService;
+  private String                      accessTokenURL;
 
-    public OpenIdProcessorImpl(ExoContainerContext context, InitParams params, SecureRandomService secureRandomService) {
-        this.clientID = params.getValueParam("clientId").getValue();
-        this.clientSecret = params.getValueParam("clientSecret").getValue();
-        String redirectURLParam = params.getValueParam("redirectURL").getValue();
-        this.wellKnownConfigurationUrl = params.getValueParam("wellKnownConfigurationUrl").getValue();
-        String scope = params.getValueParam("scope").getValue();
-        this.accessType = params.getValueParam("accessType").getValue();
-        ValueParam appNameParam = params.getValueParam("applicationName");
-        if (appNameParam != null && appNameParam.getValue() != null) {
-            applicationName = appNameParam.getValue();
-        } else {
-            applicationName = "GateIn portal";
-        }
-        if (clientID == null || clientID.length() == 0 || clientID.trim().equals("<<to be replaced>>")) {
-            throw new IllegalArgumentException("Property 'clientId' needs to be provided. The value should be " +
-                    "clientId of your OpenId application");
-        }
+  private String                      userInfoURL;
 
-        if (clientSecret == null || clientSecret.length() == 0 || clientSecret.trim().equals("<<to be replaced>>")) {
-            throw new IllegalArgumentException("Property 'clientSecret' needs to be provided. The value should be " +
-                    "clientSecret of your OpenId application");
-        }
+  private final String                clientID;
+
+  private final String                clientSecret;
+
+  private final Set<String>           scopes = new HashSet<String>();
+
+  private final String                accessType;
+
+  private final String                wellKnownConfigurationUrl;
+
+  private final String                applicationName;
+
+  private String                      issuer;
+
+  private final int                   chunkLength;
 
 
-        if (redirectURLParam == null || redirectURLParam.length() == 0) {
-            this.redirectURL = "http://localhost:8080/" + context.getName() + OAuthConstants.OPEN_ID_AUTHENTICATION_URL_PATH;
-        } else {
-            this.redirectURL = redirectURLParam.replaceAll("@@portal.container.name@@", context.getName());
-        }
+  private RemoteJwkSigningKeyResolver remoteJwkSigningKeyResolver;
 
-        addScopesFromString(scope, this.scopes);
+  private final SecureRandomService   secureRandomService;
 
-        this.chunkLength = OAuthPersistenceUtils.getChunkLength(params);
+  public OpenIdProcessorImpl(ExoContainerContext context, InitParams params, SecureRandomService secureRandomService) {
+    this.clientID = params.getValueParam("clientId").getValue();
+    this.clientSecret = params.getValueParam("clientSecret").getValue();
+    String redirectURLParam = params.getValueParam("redirectURL").getValue();
+    this.wellKnownConfigurationUrl = params.getValueParam("wellKnownConfigurationUrl").getValue();
+    String scope = params.getValueParam("scope").getValue();
+    this.accessType = params.getValueParam("accessType").getValue();
+    ValueParam appNameParam = params.getValueParam("applicationName");
+    if (appNameParam != null && appNameParam.getValue() != null) {
+      applicationName = appNameParam.getValue();
+    } else {
+      applicationName = "GateIn portal";
+    }
+    if (clientID == null || clientID.length() == 0 || clientID.trim().equals("<<to be replaced>>")) {
+      throw new IllegalArgumentException("Property 'clientId' needs to be provided. The value should be "
+          + "clientId of your OpenId application");
+    }
 
-        if (log.isDebugEnabled()) {
-            log.debug("configuration: clientId=" + clientID +
+    if (clientSecret == null || clientSecret.length() == 0 || clientSecret.trim().equals("<<to be replaced>>")) {
+      throw new IllegalArgumentException("Property 'clientSecret' needs to be provided. The value should be "
+          + "clientSecret of your OpenId application");
+    }
+
+
+    if (redirectURLParam == null || redirectURLParam.length() == 0) {
+      this.redirectURL = "http://localhost:8080/" + context.getName() + OAuthConstants.OPEN_ID_AUTHENTICATION_URL_PATH;
+    } else {
+      this.redirectURL = redirectURLParam.replaceAll("@@portal.container.name@@", context.getName());
+    }
+
+    addScopesFromString(scope, this.scopes);
+
+    this.chunkLength = OAuthPersistenceUtils.getChunkLength(params);
+
+    if (log.isDebugEnabled()) {
+      log.debug("configuration: clientId=" + clientID
+          +
                     ", clientSecret=" + clientSecret +
                     ", redirectURL=" + redirectURL +
                     ", scope=" + scopes +
                     ", accessType=" + accessType +
                     ", applicationName=" + applicationName +
                     ", chunkLength=" + chunkLength);
+    }
+
+    this.secureRandomService = secureRandomService;
+  }
+
+  @Override
+  public InteractionState<OpenIdAccessTokenContext> processOAuthInteraction(HttpServletRequest httpRequest,
+                                                                            HttpServletResponse httpResponse) throws IOException,
+                                                                                                              OAuthException {
+    return processOAuthInteractionImpl(httpRequest, httpResponse, this.scopes);
+  }
+
+  @Override
+  public InteractionState<OpenIdAccessTokenContext> processOAuthInteraction(HttpServletRequest httpRequest,
+                                                                            HttpServletResponse httpResponse,
+                                                                            String scope) throws IOException, OAuthException {
+    Set<String> scopes = new HashSet<String>();
+    addScopesFromString(scope, scopes);
+    return processOAuthInteractionImpl(httpRequest, httpResponse, scopes);
+  }
+
+  protected InteractionState<OpenIdAccessTokenContext> processOAuthInteractionImpl(HttpServletRequest request,
+                                                                                   HttpServletResponse response,
+                                                                                   Set<String> scopes) throws IOException {
+    HttpSession session = request.getSession();
+    String state = (String) session.getAttribute(OAuthConstants.ATTRIBUTE_AUTH_STATE);
+
+    // Very initial request to portal
+    if (state == null || state.isEmpty()) {
+
+      return initialInteraction(request, response, scopes);
+    } else if (state.equals(InteractionState.State.AUTH.name())) {
+      OAuth2AccessToken tokenResponse = obtainAccessToken(request);
+      OpenIdAccessTokenContext accessTokenContext = validateTokenAndUpdateScopes(new OpenIdAccessTokenContext(tokenResponse));
+      // // Clear session attributes
+      session.removeAttribute(OAuthConstants.ATTRIBUTE_AUTH_STATE);
+      session.removeAttribute(OAuthConstants.ATTRIBUTE_VERIFICATION_STATE);
+
+      return new InteractionState<>(InteractionState.State.FINISH, accessTokenContext);
+    }
+
+    // Likely shouldn't happen...
+    return new InteractionState<>(InteractionState.State.valueOf(state), null);
+  }
+
+  //
+  protected InteractionState<OpenIdAccessTokenContext> initialInteraction(HttpServletRequest request,
+                                                                          HttpServletResponse response,
+                                                                          Set<String> scopes) throws IOException {
+    String verificationState = String.valueOf(secureRandomService.getSecureRandom().nextLong());
+    String authorizeUrl = this.authenticationURL + "?" + "response_type=code" + "&client_id=" + this.clientID + "&scope="
+        + this.scopes.stream().collect(Collectors.joining(" ")) + "&redirect_uri=" + this.redirectURL + "&state="
+        + verificationState;
+
+    if (log.isTraceEnabled()) {
+      log.trace("Starting OAuth2 interaction with OpenId");
+      log.trace("URL to send to OpenId: " + authorizeUrl);
+    }
+
+    HttpSession session = request.getSession();
+    session.setAttribute(OAuthConstants.ATTRIBUTE_VERIFICATION_STATE, verificationState);
+    session.setAttribute(OAuthConstants.ATTRIBUTE_AUTH_STATE, InteractionState.State.AUTH.name());
+    response.sendRedirect(authorizeUrl);
+    return new InteractionState<OpenIdAccessTokenContext>(InteractionState.State.AUTH, null);
+  }
+
+  protected OAuth2AccessToken obtainAccessToken(HttpServletRequest request) throws IOException {
+    HttpSession session = request.getSession();
+    String stateFromSession = (String) session.getAttribute(OAuthConstants.ATTRIBUTE_VERIFICATION_STATE);
+    String stateFromRequest = request.getParameter(OAuthConstants.STATE_PARAMETER);
+    if (stateFromSession == null || stateFromRequest == null || !stateFromSession.equals(stateFromRequest)) {
+      throw new OAuthException(OAuthExceptionCode.INVALID_STATE,
+                               "Validation of state parameter failed. stateFromSession=" + stateFromSession
+                                   + ", stateFromRequest=" + stateFromRequest);
+    }
+
+    // Check if user didn't permit scope
+    String error = request.getParameter(OAuthConstants.ERROR_PARAMETER);
+    if (error != null) {
+      if (OAuthConstants.ERROR_ACCESS_DENIED.equals(error)) {
+        throw new OAuthException(OAuthExceptionCode.USER_DENIED_SCOPE, error);
+      } else {
+        throw new OAuthException(OAuthExceptionCode.UNKNOWN_ERROR, error);
+      }
+    } else {
+      String code = request.getParameter(OAuthConstants.CODE_PARAMETER);
+
+      Map<String, String> params = new HashMap<String, String>();
+      params.put(OAuthConstants.CODE_PARAMETER, code);
+      params.put(OAuthConstants.CLIENT_ID_PARAMETER, clientID);
+      params.put(OAuthConstants.CLIENT_SECRET_PARAMETER, clientSecret);
+      params.put(OAuthConstants.REDIRECT_URI_PARAMETER, redirectURL);
+      params.put("grant_type", "authorization_code");
+
+
+      OAuth2AccessToken tokenResponse = new OpenIdRequest<OAuth2AccessToken>() {
+
+        @Override
+        protected URL createURL() throws IOException {
+          return sendAccessTokenRequest();
         }
 
-        this.secureRandomService = secureRandomService;
-    }
-
-    @Override
-    public InteractionState<OpenIdAccessTokenContext> processOAuthInteraction(HttpServletRequest httpRequest,
-                                                                              HttpServletResponse httpResponse) throws IOException, OAuthException {
-        return processOAuthInteractionImpl(httpRequest, httpResponse, this.scopes);
-    }
-
-    @Override
-    public InteractionState<OpenIdAccessTokenContext> processOAuthInteraction(HttpServletRequest httpRequest, HttpServletResponse httpResponse, String scope) throws IOException, OAuthException {
-        Set<String> scopes = new HashSet<String>();
-        addScopesFromString(scope, scopes);
-        return processOAuthInteractionImpl(httpRequest, httpResponse, scopes);
-    }
-
-    protected InteractionState<OpenIdAccessTokenContext> processOAuthInteractionImpl(HttpServletRequest request, HttpServletResponse response, Set<String> scopes)
-            throws IOException {
-        HttpSession session = request.getSession();
-        String state = (String) session.getAttribute(OAuthConstants.ATTRIBUTE_AUTH_STATE);
-
-        // Very initial request to portal
-        if (state == null || state.isEmpty()) {
-
-            return initialInteraction(request, response, scopes);
-        } else if (state.equals(InteractionState.State.AUTH.name())) {
-            OAuth2AccessToken tokenResponse = obtainAccessToken(request);
-            OpenIdAccessTokenContext accessTokenContext = validateTokenAndUpdateScopes(new OpenIdAccessTokenContext(tokenResponse));
-//            // Clear session attributes
-            session.removeAttribute(OAuthConstants.ATTRIBUTE_AUTH_STATE);
-            session.removeAttribute(OAuthConstants.ATTRIBUTE_VERIFICATION_STATE);
-
-            return new InteractionState<>(InteractionState.State.FINISH, accessTokenContext);
+        @Override
+        protected OAuth2AccessToken invokeRequest(Map<String, String> params) throws IOException, JSONException {
+          URL url = createURL();
+          HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+          conn.setRequestMethod("POST");
+          conn.setDoOutput(true);
+          String urlParameters = params.keySet().stream().map(s -> s + "=" + params.get(s)).collect(Collectors.joining("&"));
+          conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+          conn.setRequestProperty("charset", "utf-8");
+          conn.setRequestProperty("Content-Length", Integer.toString(urlParameters.getBytes().length));
+          conn.setUseCaches(false);
+          try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {
+            wr.write(urlParameters.getBytes());
+          }
+          HttpResponseContext httpResponse = OAuthUtils.readUrlContent(conn);
+          if (httpResponse.getResponseCode() == 200) {
+            return parseResponse(httpResponse.getResponse());
+          } else if (httpResponse.getResponseCode() == 400) {
+            String errorMessage = "Error when obtaining content from OpenId. Error details: " + httpResponse.getResponse();
+            log.warn(errorMessage);
+            throw new OAuthException(OAuthExceptionCode.ACCESS_TOKEN_ERROR, errorMessage);
+          } else {
+            String errorMessage = "Unspecified IO error. Http response code: " + httpResponse.getResponseCode() + ", details: "
+                + httpResponse.getResponse();
+            log.warn(errorMessage);
+            throw new OAuthException(OAuthExceptionCode.IO_ERROR, errorMessage);
+          }
         }
 
-        // Likely shouldn't happen...
-        return new InteractionState<>(InteractionState.State.valueOf(state), null);
-    }
 
-    //
-    protected InteractionState<OpenIdAccessTokenContext> initialInteraction(HttpServletRequest request, HttpServletResponse response, Set<String> scopes) throws IOException {
-        String verificationState = String.valueOf(secureRandomService.getSecureRandom().nextLong());
-        String authorizeUrl = this.authenticationURL + "?"
-                + "response_type=code"
-                + "&client_id=" + this.clientID
-                + "&scope=" + this.scopes.stream().collect(Collectors.joining(" "))
-                + "&redirect_uri=" + this.redirectURL
-                + "&state=" + verificationState;
+        @Override
+        protected OAuth2AccessToken parseResponse(String httpResponse) throws JSONException {
+          JSONObject json = new JSONObject(httpResponse);
+          String accessToken = json.getString(OAuthConstants.ACCESS_TOKEN_PARAMETER);
+          if (log.isTraceEnabled())
+            log.trace("Access Token=" + accessToken);
 
-        if (log.isTraceEnabled()) {
-            log.trace("Starting OAuth2 interaction with OpenId");
-            log.trace("URL to send to OpenId: " + authorizeUrl);
+          return new OAuth2AccessToken(accessToken,
+                                       json.getString(OAuthConstants.TOKEN_TYPE_PARAMETER),
+                                       json.getInt(OAuthConstants.EXPIRES_IN_PARAMETER),
+                                       null,
+                                       json.has(OAuthConstants.SCOPE_PARAMETER) ? json.getString(OAuthConstants.SCOPE_PARAMETER)
+                                                                                : null,
+                                       json.toString());
+
         }
 
-        HttpSession session = request.getSession();
-        session.setAttribute(OAuthConstants.ATTRIBUTE_VERIFICATION_STATE, verificationState);
-        session.setAttribute(OAuthConstants.ATTRIBUTE_AUTH_STATE, InteractionState.State.AUTH.name());
-        response.sendRedirect(authorizeUrl);
-        return new InteractionState<OpenIdAccessTokenContext>(InteractionState.State.AUTH, null);
+      }.executeRequest(params);
+
+      if (log.isTraceEnabled()) {
+        log.trace("Successfully obtained accessToken from openid: " + tokenResponse);
+      }
+
+      return tokenResponse;
     }
+  }
 
-    protected OAuth2AccessToken obtainAccessToken(HttpServletRequest request) throws IOException {
-        HttpSession session = request.getSession();
-        String stateFromSession = (String) session.getAttribute(OAuthConstants.ATTRIBUTE_VERIFICATION_STATE);
-        String stateFromRequest = request.getParameter(OAuthConstants.STATE_PARAMETER);
-        if (stateFromSession == null || stateFromRequest == null || !stateFromSession.equals(stateFromRequest)) {
-            throw new OAuthException(OAuthExceptionCode.INVALID_STATE, "Validation of state parameter failed. stateFromSession="
-                    + stateFromSession + ", stateFromRequest=" + stateFromRequest);
-        }
 
-        // Check if user didn't permit scope
-        String error = request.getParameter(OAuthConstants.ERROR_PARAMETER);
-        if (error != null) {
-            if (OAuthConstants.ERROR_ACCESS_DENIED.equals(error)) {
-                throw new OAuthException(OAuthExceptionCode.USER_DENIED_SCOPE, error);
-            } else {
-                throw new OAuthException(OAuthExceptionCode.UNKNOWN_ERROR, error);
-            }
+  @Override
+  public OpenIdAccessTokenContext validateTokenAndUpdateScopes(OpenIdAccessTokenContext accessToken) throws OAuthException {
+    String scope = accessToken.getTokenData().getScope();
+    Claims customClaims;
+    try {
+      String tokenId = new JSONObject(accessToken.accessToken.getRawResponse()).get("id_token").toString();
+      customClaims = Jwts.parserBuilder()
+                         .setSigningKeyResolver(remoteJwkSigningKeyResolver)
+                         .requireIssuer(this.issuer)
+                         .requireAudience(this.clientID)
+                         .setAllowedClockSkewSeconds(60)
+                         .build()
+                         .parseClaimsJws(tokenId)
+                         .getBody();
+    } catch (IncorrectClaimException e) {
+      log.error("Issuer or audience have not the correct value in the token", e);
+      throw new OAuthException(OAuthExceptionCode.TOKEN_VALIDATION_ERROR,
+                               "Issuer or audience have not the correct value in the token",
+                               e);
+    } catch (MissingClaimException e) {
+      log.error("Required claims (issuer or audience) are missing in JWT Token", e);
+      throw new OAuthException(OAuthExceptionCode.TOKEN_VALIDATION_ERROR,
+                               "Required claims (issuer or audience) are missing in JWT Token",
+                               e);
+    } catch (JSONException e) {
+      log.error("Unable to parse the accessToken");
+      throw new OAuthException(OAuthExceptionCode.ACCESS_TOKEN_ERROR, "Unable to parse the accessToken", e);
+    }
+    OpenIdAccessTokenContext accessTokenContext = new OpenIdAccessTokenContext(accessToken.getTokenData(), scope);
+    if (customClaims != null) {
+      accessTokenContext.addCustomClaims(customClaims.entrySet()
+                                                     .stream()
+                                                     .filter(element -> element.getKey().equals("given_name")
+                                                         || element.getKey().equals("family_name")
+                                                         || element.getKey().equals("email"))
+                                                     .collect(Collectors.toMap(Map.Entry::getKey, x -> x.getValue().toString())));
+    }
+    return accessTokenContext;
+  }
+
+  @Override
+  public <C> C getAuthorizedSocialApiObject(OpenIdAccessTokenContext accessToken, Class<C> socialApiObjectType) {
+    return null;
+  }
+
+  @Override
+  public void saveAccessTokenAttributesToUserProfile(UserProfile userProfile,
+                                                     OAuthCodec codec,
+                                                     OpenIdAccessTokenContext accessToken) {
+    String encodedAccessToken = codec.encodeString(accessToken.accessToken.getAccessToken());
+    OAuthPersistenceUtils.saveLongAttribute(encodedAccessToken,
+                                            userProfile,
+                                            OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN,
+                                            false,
+                                            chunkLength);
+
+  }
+
+  @Override
+  public OpenIdAccessTokenContext getAccessTokenFromUserProfile(UserProfile userProfile, OAuthCodec codec) {
+    String encodedAccessToken = OAuthPersistenceUtils.getLongAttribute(userProfile,
+                                                                       OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN,
+                                                                       false);
+    String encodedAccessTokenSecret = OAuthPersistenceUtils.getLongAttribute(userProfile,
+                                                                             OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN_SECRET,
+                                                                             false);
+    String decodedAccessToken = codec.decodeString(encodedAccessToken);
+    String decodedAccessTokenSecret = codec.decodeString(encodedAccessTokenSecret);
+
+    if (decodedAccessToken == null || decodedAccessTokenSecret == null) {
+      return null;
+    } else {
+      OAuth2AccessToken token = new OAuth2AccessToken(decodedAccessToken, decodedAccessTokenSecret);
+      return new OpenIdAccessTokenContext(token);
+    }
+  }
+
+  @Override
+  public void removeAccessTokenFromUserProfile(UserProfile userProfile) {
+    OAuthPersistenceUtils.removeLongAttribute(userProfile, OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN, false);
+    OAuthPersistenceUtils.removeLongAttribute(userProfile, OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN_SECRET, false);
+  }
+
+  @Override
+  public JSONObject obtainUserInfo(OpenIdAccessTokenContext accessTokenContext) {
+    Map<String, String> params = new HashMap<>();
+    params.put(OAuthConstants.ACCESS_TOKEN_PARAMETER, accessTokenContext.getAccessToken());
+    OpenIdRequest<JSONObject> userInfoRequest = new OpenIdRequest<JSONObject>() {
+
+      @Override
+      protected URL createURL() throws IOException {
+        return getUserInfoURL();
+      }
+
+      @Override
+      protected JSONObject invokeRequest(Map<String, String> params) throws IOException, JSONException {
+        URL url = createURL();
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Authorization", "Bearer " + params.get(OAuthConstants.ACCESS_TOKEN_PARAMETER));
+        HttpResponseContext httpResponse = OAuthUtils.readUrlContent(conn);
+        if (httpResponse.getResponseCode() == 200) {
+          return parseResponse(httpResponse.getResponse());
         } else {
-            String code = request.getParameter(OAuthConstants.CODE_PARAMETER);
-
-            Map<String, String> params = new HashMap<String, String>();
-            params.put(OAuthConstants.CODE_PARAMETER, code);
-            params.put(OAuthConstants.CLIENT_ID_PARAMETER, clientID);
-            params.put(OAuthConstants.CLIENT_SECRET_PARAMETER, clientSecret);
-            params.put(OAuthConstants.REDIRECT_URI_PARAMETER, redirectURL);
-            params.put("grant_type", "authorization_code");
-
-
-            OAuth2AccessToken tokenResponse = new OpenIdRequest<OAuth2AccessToken>() {
-
-                @Override
-                protected URL createURL() throws IOException {
-                    return sendAccessTokenRequest();
-                }
-
-                @Override
-                protected OAuth2AccessToken invokeRequest(Map<String, String> params) throws IOException, JSONException {
-                    URL url = createURL();
-                    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-                    conn.setRequestMethod("POST");
-                    conn.setDoOutput(true);
-                    String urlParameters = params.keySet().stream().map(s -> s + "=" + params.get(s)).collect(Collectors.joining("&"));
-                    conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-                    conn.setRequestProperty("charset", "utf-8");
-                    conn.setRequestProperty("Content-Length", Integer.toString(urlParameters.getBytes().length));
-                    conn.setUseCaches(false);
-                    try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream())) {
-                        wr.write(urlParameters.getBytes());
-                    }
-                    HttpResponseContext httpResponse = OAuthUtils.readUrlContent(conn);
-                    if (httpResponse.getResponseCode() == 200) {
-                        return parseResponse(httpResponse.getResponse());
-                    } else if (httpResponse.getResponseCode() == 400) {
-                        String errorMessage = "Error when obtaining content from OpenId. Error details: " + httpResponse.getResponse();
-                        log.warn(errorMessage);
-                        throw new OAuthException(OAuthExceptionCode.ACCESS_TOKEN_ERROR, errorMessage);
-                    } else {
-                        String errorMessage = "Unspecified IO error. Http response code: " + httpResponse.getResponseCode() + ", details: " + httpResponse.getResponse();
-                        log.warn(errorMessage);
-                        throw new OAuthException(OAuthExceptionCode.IO_ERROR, errorMessage);
-                    }
-                }
-
-
-                @Override
-                protected OAuth2AccessToken parseResponse(String httpResponse) throws JSONException {
-                    JSONObject json = new JSONObject(httpResponse);
-                    String accessToken = json.getString(OAuthConstants.ACCESS_TOKEN_PARAMETER);
-                    if (log.isTraceEnabled())
-                        log.trace("Access Token=" + accessToken);
-
-                    return new OAuth2AccessToken(accessToken,
-                            json.getString(OAuthConstants.TOKEN_TYPE_PARAMETER),
-                            json.getInt(OAuthConstants.EXPIRES_IN_PARAMETER),
-                            null,
-                            json.has(OAuthConstants.SCOPE_PARAMETER) ?
-                                    json.getString(OAuthConstants.SCOPE_PARAMETER) : null,
-                            json.toString());
-
-                }
-
-            }.executeRequest(params);
-
-            if (log.isTraceEnabled()) {
-                log.trace("Successfully obtained accessToken from openid: " + tokenResponse);
-            }
-
-            return tokenResponse;
+          String errorMessage = "Unable to read OpenId userInfo endpoint. Http response code: " + httpResponse.getResponseCode()
+              + ", details: " + httpResponse.getResponse() + ". We will use claims in id_token";
+          log.info(errorMessage);
         }
+        return new JSONObject();
+      }
+
+      @Override
+      protected JSONObject parseResponse(String httpResponse) throws JSONException {
+        JSONObject json = new JSONObject(httpResponse);
+        return json;
+      }
+
+    };
+    JSONObject uinfo = userInfoRequest.executeRequest(params);
+
+    if (log.isTraceEnabled()) {
+      log.trace("Successfully obtained userInfo from openid: " + uinfo);
     }
 
+    return uinfo;
+  }
 
-    @Override
-    public OpenIdAccessTokenContext validateTokenAndUpdateScopes(OpenIdAccessTokenContext accessToken) throws OAuthException {
-        String scope = accessToken.getTokenData().getScope();
-        try {
-            String tokenId = new JSONObject(accessToken.accessToken.getRawResponse()).get("id_token").toString();
-            Jwts.parserBuilder()
-                    .setSigningKeyResolver(remoteJwkSigningKeyResolver)
-                    .requireIssuer(this.issuer)
-                    .requireAudience(this.clientID)
-                    .build().parseClaimsJws(tokenId)
-                    .getBody();
-        } catch (IncorrectClaimException e) {
-            log.error("Issuer or audience have not the correct value in the token", e);
-            throw new OAuthException(OAuthExceptionCode.TOKEN_VALIDATION_ERROR,
-                    "Issuer or audience have not the correct value in the token", e);
-        } catch (MissingClaimException e) {
-            log.error("Required claims (issuer or audience) are missing in JWT Token", e);
-            throw new OAuthException(OAuthExceptionCode.TOKEN_VALIDATION_ERROR,
-                    "Required claims (issuer or audience) are missing in JWT Token", e);
-        } catch (JSONException e) {
-            log.error("Unable to parse the accessToken");
-            throw new OAuthException(OAuthExceptionCode.ACCESS_TOKEN_ERROR,
-                    "Unable to parse the accessToken", e);
-        }
-        return new OpenIdAccessTokenContext(accessToken.getTokenData(), scope);
+  @Override
+  public void revokeToken(OpenIdAccessTokenContext accessToken) throws OAuthException {
+
+  }
+
+  // Parse given String and add all scopes from it to given Set
+  private void addScopesFromString(String scope, Set<String> scopes) {
+    String[] scopes2 = scope.split(" ");
+    for (String current : scopes2) {
+      scopes.add(current);
     }
+  }
 
-    @Override
-    public <C> C getAuthorizedSocialApiObject(OpenIdAccessTokenContext accessToken, Class<C> socialApiObjectType) {
-        return null;
+  protected URL sendAccessTokenRequest() throws IOException {
+    if (log.isTraceEnabled())
+      log.trace("AccessToken Request=" + this.accessTokenURL);
+    return new URL(this.accessTokenURL);
+  }
+
+  protected URL getUserInfoURL() throws IOException {
+    if (log.isTraceEnabled())
+      log.trace("UserInfo Request=" + this.userInfoURL);
+    return new URL(this.userInfoURL);
+  }
+
+  @Override
+  public void start() {
+    if (StringUtils.isBlank(this.wellKnownConfigurationUrl)) {
+      log.error("wellKnownConfigurationUrl is not configured");
+      return;
     }
-
-    @Override
-    public void saveAccessTokenAttributesToUserProfile(UserProfile userProfile, OAuthCodec codec, OpenIdAccessTokenContext accessToken) {
-        String encodedAccessToken = codec.encodeString(accessToken.accessToken.getAccessToken());
-        OAuthPersistenceUtils.saveLongAttribute(encodedAccessToken, userProfile, OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN,
-                false, chunkLength);
-
+    try {
+      String wellKnownConfigurationContent = readUrl(new URL(this.wellKnownConfigurationUrl));
+      if (wellKnownConfigurationContent != null) {
+        JSONObject json = new JSONObject(wellKnownConfigurationContent);
+        this.authenticationURL = json.getString("authorization_endpoint");
+        this.accessTokenURL = json.getString("token_endpoint");
+        this.userInfoURL = json.getString("userinfo_endpoint");
+        this.issuer = json.getString("issuer");
+        this.remoteJwkSigningKeyResolver = new RemoteJwkSigningKeyResolver(this.issuer);
+      }
+    } catch (JSONException e) {
+      log.error("Unable to read webKnownUrl content : " + this.wellKnownConfigurationUrl);
+    } catch (MalformedURLException e) {
+      log.error("WellKnowConfigurationUrl malformed : url" + this.wellKnownConfigurationUrl);
     }
+  }
 
-    @Override
-    public OpenIdAccessTokenContext getAccessTokenFromUserProfile(UserProfile userProfile, OAuthCodec codec) {
-        String encodedAccessToken = OAuthPersistenceUtils.getLongAttribute(userProfile,
-                OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN, false);
-        String encodedAccessTokenSecret = OAuthPersistenceUtils.getLongAttribute(userProfile,
-                OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN_SECRET, false);
-        String decodedAccessToken = codec.decodeString(encodedAccessToken);
-        String decodedAccessTokenSecret = codec.decodeString(encodedAccessTokenSecret);
+  @Override
+  public void stop() {
+    // Nothing to stop
+  }
 
-        if (decodedAccessToken == null || decodedAccessTokenSecret == null) {
-            return null;
-        } else {
-            OAuth2AccessToken token = new OAuth2AccessToken(decodedAccessToken, decodedAccessTokenSecret);
-            return new OpenIdAccessTokenContext(token);
-        }
+  private static String readUrl(URL url) {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+      StringBuilder buffer = new StringBuilder();
+      int read;
+      char[] chars = new char[1024];
+      while ((read = reader.read(chars)) != -1)
+        buffer.append(chars, 0, read);
+
+      return buffer.toString();
+    } catch (IOException e) {
+      log.error(e.getMessage());
     }
-
-    @Override
-    public void removeAccessTokenFromUserProfile(UserProfile userProfile) {
-        OAuthPersistenceUtils.removeLongAttribute(userProfile, OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN, false);
-        OAuthPersistenceUtils.removeLongAttribute(userProfile, OAuthConstants.PROFILE_OPEN_ID_ACCESS_TOKEN_SECRET, false);
-    }
-
-    @Override
-    public JSONObject obtainUserInfo(OpenIdAccessTokenContext accessTokenContext) {
-        Map<String, String> params = new HashMap<String, String>();
-        params.put(OAuthConstants.ACCESS_TOKEN_PARAMETER, accessTokenContext.getAccessToken());
-
-        OpenIdRequest<JSONObject> userInfoRequest = new OpenIdRequest<JSONObject>() {
-
-            @Override
-            protected URL createURL() throws IOException {
-                return getUserInfoURL();
-            }
-
-            @Override
-            protected JSONObject invokeRequest(Map<String, String> params) throws IOException, JSONException {
-                URL url = createURL();
-                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-                conn.setRequestMethod("GET");
-                conn.setRequestProperty("Authorization", "Bearer " + params.get(OAuthConstants.ACCESS_TOKEN_PARAMETER));
-                HttpResponseContext httpResponse = OAuthUtils.readUrlContent(conn);
-                if (httpResponse.getResponseCode() == 200) {
-                    return parseResponse(httpResponse.getResponse());
-                } else if (httpResponse.getResponseCode() == 400) {
-                    String errorMessage = "Error when obtaining content from OpenId. Error details: " + httpResponse.getResponse();
-                    log.warn(errorMessage);
-                    throw new OAuthException(OAuthExceptionCode.ACCESS_TOKEN_ERROR, errorMessage);
-                } else {
-                    String errorMessage = "Unspecified IO error. Http response code: " + httpResponse.getResponseCode() + ", details: " + httpResponse.getResponse();
-                    log.warn(errorMessage);
-                    throw new OAuthException(OAuthExceptionCode.IO_ERROR, errorMessage);
-                }
-            }
-
-            @Override
-            protected JSONObject parseResponse(String httpResponse) throws JSONException {
-                JSONObject json = new JSONObject(httpResponse);
-                return json;
-            }
-
-        };
-        JSONObject uinfo = userInfoRequest.executeRequest(params);
-
-        if (log.isTraceEnabled()) {
-            log.trace("Successfully obtained userInfo from openid: " + uinfo);
-        }
-
-        return uinfo;
-    }
-
-    @Override
-    public void revokeToken(OpenIdAccessTokenContext accessToken) throws OAuthException {
-
-    }
-
-    // Parse given String and add all scopes from it to given Set
-    private void addScopesFromString(String scope, Set<String> scopes) {
-        String[] scopes2 = scope.split(" ");
-        for (String current : scopes2) {
-            scopes.add(current);
-        }
-    }
-
-    protected URL sendAccessTokenRequest() throws IOException {
-        if (log.isTraceEnabled())
-            log.trace("AccessToken Request=" + this.accessTokenURL);
-        return new URL(this.accessTokenURL);
-    }
-
-    protected URL getUserInfoURL() throws IOException {
-        if (log.isTraceEnabled())
-            log.trace("UserInfo Request=" + this.userInfoURL);
-        return new URL(this.userInfoURL);
-    }
-
-    @Override
-    public void start() {
-        if (StringUtils.isBlank(this.wellKnownConfigurationUrl)) {
-            log.error("wellKnownConfigurationUrl is not configured");
-            return;
-        }
-        try {
-            String wellKnownConfigurationContent = readUrl(new URL(this.wellKnownConfigurationUrl));
-            if (wellKnownConfigurationContent != null) {
-                JSONObject json = new JSONObject(wellKnownConfigurationContent);
-                this.authenticationURL = json.getString("authorization_endpoint");
-                this.accessTokenURL = json.getString("token_endpoint");
-                this.userInfoURL = json.getString("userinfo_endpoint");
-                this.issuer = json.getString("issuer");
-                this.remoteJwkSigningKeyResolver = new RemoteJwkSigningKeyResolver(this.issuer);
-            }
-        } catch (JSONException e) {
-            log.error("Unable to read webKnownUrl content : " + this.wellKnownConfigurationUrl);
-        } catch (MalformedURLException e) {
-            log.error("WellKnowConfigurationUrl malformed : url" + this.wellKnownConfigurationUrl);
-        }
-    }
-
-    @Override
-    public void stop() {
-        // Nothing to stop
-    }
-
-    private static String readUrl(URL url) {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
-            StringBuilder buffer = new StringBuilder();
-            int read;
-            char[] chars = new char[1024];
-            while ((read = reader.read(chars)) != -1)
-                buffer.append(chars, 0, read);
-
-            return buffer.toString();
-        } catch (IOException e) {
-            log.error(e.getMessage());
-        }
-        return null;
-    }
+    return null;
+  }
 }

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/utils/OAuthUtils.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/utils/OAuthUtils.java
@@ -70,7 +70,7 @@ public class OAuthUtils {
                                                                                                     String avatar,
                                                                                                     OAuthProviderType<FacebookAccessTokenContext> facebookProviderType,
                                                                                                     FacebookAccessTokenContext fbAccessTokenContext) {
-    return new OAuthPrincipal<FacebookAccessTokenContext>(facebookPrincipal.getUsername(),
+    return new OAuthPrincipal<>(facebookPrincipal.getUsername(),
                                                           facebookPrincipal.getFirstName(),
                                                           facebookPrincipal.getLastName(),
                                                           facebookPrincipal.getAttribute("name"),
@@ -98,7 +98,7 @@ public class OAuthUtils {
       lastName = null;
     }
 
-    return new OAuthPrincipal<TwitterAccessTokenContext>(twitterUser.getScreenName(),
+    return new OAuthPrincipal<>(twitterUser.getScreenName(),
                                                          firstName,
                                                          lastName,
                                                          fullName,
@@ -114,7 +114,7 @@ public class OAuthUtils {
     // Assume that username is first part of email
     String email = userInfo.getEmail();
     String username = email != null ? email.substring(0, email.indexOf('@')) : userInfo.getGivenName();
-    return new OAuthPrincipal<GoogleAccessTokenContext>(username,
+    return new OAuthPrincipal<>(username,
                                                         userInfo.getGivenName(),
                                                         userInfo.getFamilyName(),
                                                         userInfo.getName(),

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/utils/OAuthUtils.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/utils/OAuthUtils.java
@@ -60,209 +60,238 @@ import org.json.JSONObject;
  */
 public class OAuthUtils {
 
-    // Private constructor for utils class
-    private OAuthUtils() {}
+  // Private constructor for utils class
+  private OAuthUtils() {
+  }
 
-    // Converting objects
+  // Converting objects
 
-    public static OAuthPrincipal<FacebookAccessTokenContext> convertFacebookPrincipalToOAuthPrincipal(FacebookPrincipal facebookPrincipal, String avatar,
-                                            OAuthProviderType<FacebookAccessTokenContext> facebookProviderType, FacebookAccessTokenContext fbAccessTokenContext) {
-        return new OAuthPrincipal<FacebookAccessTokenContext>(facebookPrincipal.getUsername(), facebookPrincipal.getFirstName(), facebookPrincipal.getLastName(),
-                facebookPrincipal.getAttribute("name"), facebookPrincipal.getEmail(), avatar, fbAccessTokenContext, facebookProviderType);
+  public static OAuthPrincipal<FacebookAccessTokenContext> convertFacebookPrincipalToOAuthPrincipal(FacebookPrincipal facebookPrincipal,
+                                                                                                    String avatar,
+                                                                                                    OAuthProviderType<FacebookAccessTokenContext> facebookProviderType,
+                                                                                                    FacebookAccessTokenContext fbAccessTokenContext) {
+    return new OAuthPrincipal<FacebookAccessTokenContext>(facebookPrincipal.getUsername(),
+                                                          facebookPrincipal.getFirstName(),
+                                                          facebookPrincipal.getLastName(),
+                                                          facebookPrincipal.getAttribute("name"),
+                                                          facebookPrincipal.getEmail(),
+                                                          avatar,
+                                                          fbAccessTokenContext,
+                                                          facebookProviderType);
+  }
+
+  public static OAuthPrincipal<TwitterAccessTokenContext> convertTwitterUserToOAuthPrincipal(twitter4j.User twitterUser,
+                                                                                             TwitterAccessTokenContext accessToken,
+                                                                                             OAuthProviderType<TwitterAccessTokenContext> twitterProviderType) {
+    String fullName = twitterUser.getName();
+    String firstName;
+    String lastName;
+    String avatar = twitterUser.getBiggerProfileImageURL();
+
+    int spaceIndex = fullName.lastIndexOf(' ');
+
+    if (spaceIndex != -1) {
+      firstName = fullName.substring(0, spaceIndex);
+      lastName = fullName.substring(spaceIndex + 1);
+    } else {
+      firstName = fullName;
+      lastName = null;
     }
 
-    public static OAuthPrincipal<TwitterAccessTokenContext> convertTwitterUserToOAuthPrincipal(twitter4j.User twitterUser, TwitterAccessTokenContext accessToken,
-                                                             OAuthProviderType<TwitterAccessTokenContext> twitterProviderType) {
-        String fullName = twitterUser.getName();
-        String firstName;
-        String lastName;
-        String avatar = twitterUser.getBiggerProfileImageURL();
+    return new OAuthPrincipal<TwitterAccessTokenContext>(twitterUser.getScreenName(),
+                                                         firstName,
+                                                         lastName,
+                                                         fullName,
+                                                         null,
+                                                         avatar,
+                                                         accessToken,
+                                                         twitterProviderType);
+  }
 
-        int spaceIndex = fullName.lastIndexOf(' ');
+  public static OAuthPrincipal<GoogleAccessTokenContext> convertGoogleInfoToOAuthPrincipal(Userinfo userInfo,
+                                                                                           GoogleAccessTokenContext accessToken,
+                                                                                           OAuthProviderType<GoogleAccessTokenContext> googleProviderType) {
+    // Assume that username is first part of email
+    String email = userInfo.getEmail();
+    String username = email != null ? email.substring(0, email.indexOf('@')) : userInfo.getGivenName();
+    return new OAuthPrincipal<GoogleAccessTokenContext>(username,
+                                                        userInfo.getGivenName(),
+                                                        userInfo.getFamilyName(),
+                                                        userInfo.getName(),
+                                                        userInfo.getEmail(),
+                                                        userInfo.getPicture(),
+                                                        accessToken,
+                                                        googleProviderType);
+  }
 
-        if (spaceIndex != -1) {
-            firstName = fullName.substring(0, spaceIndex);
-            lastName = fullName.substring(spaceIndex + 1);
+  public static OAuthPrincipal<OpenIdAccessTokenContext> convertOpenIdInfoToOAuthPrincipal(JSONObject userInfo,
+                                                                                           OpenIdAccessTokenContext accessTokenContext,
+                                                                                           OAuthProviderType<OpenIdAccessTokenContext> openIdProviderType) {
+    try {
+      String email = userInfo.has(OAuthConstants.EMAIL_ATTRIBUTE) ? userInfo.getString(OAuthConstants.EMAIL_ATTRIBUTE)
+                                                                  : accessTokenContext.getCustomClaims()
+                                                                                      .get(OAuthConstants.EMAIL_ATTRIBUTE);
+      String givenName =
+                       userInfo.has(OAuthConstants.GIVEN_NAME_ATTRIBUTE) ? userInfo.getString(OAuthConstants.GIVEN_NAME_ATTRIBUTE)
+                                                                         : accessTokenContext.getCustomClaims()
+                                                                                             .get(OAuthConstants.GIVEN_NAME_ATTRIBUTE);
+      String familyName =
+                        userInfo.has(OAuthConstants.FAMILY_NAME_ATTRIBUTE) ? userInfo.getString(OAuthConstants.FAMILY_NAME_ATTRIBUTE)
+                                                                           : accessTokenContext.getCustomClaims()
+                                                                                               .get(OAuthConstants.FAMILY_NAME_ATTRIBUTE);
+      String name = userInfo.has(OAuthConstants.NAME_ATTRIBUTE) ? userInfo.getString(OAuthConstants.NAME_ATTRIBUTE)
+                                                                : givenName + " " + familyName;
+      String picture =
+                     userInfo.has(OAuthConstants.PICTURE_ATTRIBUTE) ? userInfo.getString(OAuthConstants.PICTURE_ATTRIBUTE) : null;
+      return new OAuthPrincipal<>(null, givenName, familyName, name, email, picture, accessTokenContext, openIdProviderType);
+    } catch (JSONException jsonException) {
+      throw new OAuthException(OAuthExceptionCode.ACCESS_TOKEN_ERROR, "Error during user info reading: response format is ko");
+    }
+  }
+
+  public static User convertOAuthPrincipalToGateInUser(OAuthPrincipal principal) {
+    User gateinUser = new UserImpl(OAuthUtils.refineUserName(principal.getUserName()));
+    gateinUser.setFirstName(principal.getFirstName());
+    gateinUser.setLastName(principal.getLastName());
+    gateinUser.setEmail(principal.getEmail());
+    gateinUser.setDisplayName(principal.getDisplayName());
+    return gateinUser;
+  }
+
+  public static String getURLToRedirectAfterLinkAccount(HttpServletRequest request, HttpSession session) {
+    String urlToRedirect = (String) session.getAttribute(OAuthConstants.ATTRIBUTE_URL_TO_REDIRECT_AFTER_LINK_SOCIAL_ACCOUNT);
+    if (urlToRedirect == null) {
+      urlToRedirect = request.getContextPath();
+    } else {
+      session.removeAttribute(OAuthConstants.ATTRIBUTE_URL_TO_REDIRECT_AFTER_LINK_SOCIAL_ACCOUNT);
+    }
+
+    return urlToRedirect;
+  }
+
+  // HTTP related utils
+
+  /**
+   * Given a {@link java.util.Map} of params, construct a query string
+   *
+   * @param params parameters for query
+   * @return query string
+   */
+  public static String createQueryString(Map<String, String> params) {
+    StringBuilder queryString = new StringBuilder();
+    boolean first = true;
+    for (Map.Entry<String, String> entry : params.entrySet()) {
+      String paramName = entry.getKey();
+      String paramValue = entry.getValue();
+      if (first) {
+        first = false;
+      } else {
+        queryString.append("&");
+      }
+      queryString.append(paramName).append("=");
+      String encodedParamValue;
+      try {
+        if (paramValue == null)
+          throw new RuntimeException("paramValue is null for paramName=" + paramName);
+        encodedParamValue = URLEncoder.encode(paramValue, "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        throw new OAuthException(OAuthExceptionCode.UNKNOWN_ERROR, e);
+      }
+      queryString.append(encodedParamValue);
+    }
+    return queryString.toString();
+  }
+
+  public static String encodeParam(String param) {
+    try {
+      return URLEncoder.encode(param, "UTF-8");
+    } catch (UnsupportedEncodingException uee) {
+      throw new OAuthException(OAuthExceptionCode.UNKNOWN_ERROR, uee);
+    }
+  }
+
+  /**
+   * Whole HTTP response as String from given URLConnection
+   *
+   * @param connection
+   * @return whole HTTP response as String
+   */
+  public static HttpResponseContext readUrlContent(URLConnection connection) throws IOException {
+    StringBuilder result = new StringBuilder();
+
+    HttpURLConnection httpURLConnection = (HttpURLConnection) connection;
+    int statusCode = httpURLConnection.getResponseCode();
+
+    Reader reader = null;
+    try {
+      try {
+        reader = new InputStreamReader(connection.getInputStream());
+      } catch (IOException ioe) {
+        if (httpURLConnection.getErrorStream() != null) {
+          reader = new InputStreamReader(httpURLConnection.getErrorStream());
         } else {
-            firstName = fullName;
-            lastName = null;
+          return new HttpResponseContext(statusCode, "");
         }
+      }
 
-        return new OAuthPrincipal<TwitterAccessTokenContext>(twitterUser.getScreenName(), firstName, lastName, fullName, null, avatar, accessToken,
-                twitterProviderType);
-    }
+      char[] buffer = new char[50];
+      int nrOfChars;
+      while ((nrOfChars = reader.read(buffer)) != -1) {
+        result.append(buffer, 0, nrOfChars);
+      }
 
-    public static OAuthPrincipal<GoogleAccessTokenContext> convertGoogleInfoToOAuthPrincipal(Userinfo userInfo, GoogleAccessTokenContext accessToken,
-                                                               OAuthProviderType<GoogleAccessTokenContext> googleProviderType) {
-        // Assume that username is first part of email
-        String email = userInfo.getEmail();
-        String username = email != null ? email.substring(0, email.indexOf('@')) : userInfo.getGivenName();
-        return new OAuthPrincipal<GoogleAccessTokenContext>(username, userInfo.getGivenName(), userInfo.getFamilyName(), userInfo.getName(), userInfo.getEmail(),
-                userInfo.getPicture(), accessToken, googleProviderType);
+      String response = result.toString();
+      return new HttpResponseContext(statusCode, response);
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
     }
-    
-    public static OAuthPrincipal<OpenIdAccessTokenContext> convertOpenIdInfoToOAuthPrincipal(JSONObject userInfo,
-                                                                                             OpenIdAccessTokenContext accessToken,
-                                                                                             OAuthProviderType<OpenIdAccessTokenContext> openIdProviderType) {
+  }
+
+  /**
+   * Decode given String to map. For example for input:
+   * {@code accessToken=123456&expires=20071458} it returns map with two keys
+   * "accessToken" and "expires" and their corresponding values
+   *
+   * @param encodedData
+   * @return map with output data
+   */
+  public static Map<String, String> formUrlDecode(String encodedData) {
+    Map<String, String> params = new HashMap<String, String>();
+    String[] elements = encodedData.split("&");
+    for (String element : elements) {
+      String[] pair = element.split("=");
+      if (pair.length == 2) {
+        String paramName = pair[0];
+        String paramValue;
         try {
-            // Assume that username is first part of email
-            String email = userInfo.getString(OAuthConstants.EMAIL_ATTRIBUTE);
-
-            return new OAuthPrincipal<>(null,
-                                        userInfo.getString(OAuthConstants.GIVEN_NAME_ATTRIBUTE),
-                                        userInfo.getString(OAuthConstants.FAMILY_NAME_ATTRIBUTE),
-                                        userInfo.getString(OAuthConstants.NAME_ATTRIBUTE),
-                                        userInfo.getString(OAuthConstants.EMAIL_ATTRIBUTE),
-                                        userInfo.has(OAuthConstants.PICTURE_ATTRIBUTE) ? userInfo.getString(OAuthConstants.PICTURE_ATTRIBUTE)
-                                                                                       : null,
-                                        accessToken,
-                                        openIdProviderType);
-        } catch (JSONException jsonException) {
-            throw new OAuthException(OAuthExceptionCode.ACCESS_TOKEN_ERROR,
-                                     "Error during user info reading: response format is ko");
+          paramValue = URLDecoder.decode(pair[1], "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+          throw new RuntimeException(e);
         }
+        params.put(paramName, paramValue);
+      } else {
+        throw new RuntimeException("Unexpected name-value pair in response: " + element);
+      }
     }
-    
-    
-    
-    public static User convertOAuthPrincipalToGateInUser(OAuthPrincipal principal) {
-        User gateinUser = new UserImpl(OAuthUtils.refineUserName(principal.getUserName()));
-        gateinUser.setFirstName(principal.getFirstName());
-        gateinUser.setLastName(principal.getLastName());
-        gateinUser.setEmail(principal.getEmail());
-        gateinUser.setDisplayName(principal.getDisplayName());
-        return gateinUser;
+    return params;
+  }
+
+  public static String refineUserName(String username) {
+    final String ALLOWED_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012456789._";
+    final char replaced = '_';
+
+    if (username == null || username.isEmpty()) {
+      return "";
     }
 
-    public static String getURLToRedirectAfterLinkAccount(HttpServletRequest request, HttpSession session) {
-        String urlToRedirect = (String)session.getAttribute(OAuthConstants.ATTRIBUTE_URL_TO_REDIRECT_AFTER_LINK_SOCIAL_ACCOUNT);
-        if (urlToRedirect == null) {
-            urlToRedirect = request.getContextPath();
-        } else {
-            session.removeAttribute(OAuthConstants.ATTRIBUTE_URL_TO_REDIRECT_AFTER_LINK_SOCIAL_ACCOUNT);
-        }
-
-        return urlToRedirect;
+    final char[] chars = username.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      if (ALLOWED_CHARACTERS.indexOf(chars[i]) == -1) {
+        chars[i] = replaced;
+      }
     }
-
-    // HTTP related utils
-
-    /**
-     * Given a {@link java.util.Map} of params, construct a query string
-     *
-     * @param params parameters for query
-     * @return query string
-     */
-    public static String createQueryString(Map<String, String> params) {
-        StringBuilder queryString = new StringBuilder();
-        boolean first = true;
-        for (Map.Entry<String, String> entry : params.entrySet()) {
-            String paramName = entry.getKey();
-            String paramValue = entry.getValue();
-            if (first) {
-                first = false;
-            } else {
-                queryString.append("&");
-            }
-            queryString.append(paramName).append("=");
-            String encodedParamValue;
-            try {
-                if (paramValue == null)
-                    throw new RuntimeException("paramValue is null for paramName=" + paramName);
-                encodedParamValue = URLEncoder.encode(paramValue, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new OAuthException(OAuthExceptionCode.UNKNOWN_ERROR, e);
-            }
-            queryString.append(encodedParamValue);
-        }
-        return queryString.toString();
-    }
-
-    public static String encodeParam(String param) {
-        try {
-            return URLEncoder.encode(param, "UTF-8");
-        } catch (UnsupportedEncodingException uee) {
-            throw new OAuthException(OAuthExceptionCode.UNKNOWN_ERROR, uee);
-        }
-    }
-
-    /**
-     * Whole HTTP response as String from given URLConnection
-     *
-     * @param connection
-     * @return whole HTTP response as String
-     */
-    public static HttpResponseContext readUrlContent(URLConnection connection) throws IOException {
-        StringBuilder result = new StringBuilder();
-
-        HttpURLConnection httpURLConnection = (HttpURLConnection)connection;
-        int statusCode = httpURLConnection.getResponseCode();
-
-        Reader reader = null;
-        try {
-            try {
-                reader = new InputStreamReader(connection.getInputStream());
-            } catch (IOException ioe) {
-                reader = new InputStreamReader(httpURLConnection.getErrorStream());
-            }
-
-            char[] buffer = new char[50];
-            int nrOfChars;
-            while ((nrOfChars = reader.read(buffer)) != -1) {
-                result.append(buffer, 0, nrOfChars);
-            }
-
-            String response = result.toString();
-            return new HttpResponseContext(statusCode, response);
-        } finally {
-            if (reader != null) {
-                reader.close();
-            }
-        }
-    }
-
-    /**
-     * Decode given String to map. For example for input: {@code accessToken=123456&expires=20071458} it returns map with two keys
-     * "accessToken" and "expires" and their corresponding values
-     *
-     * @param encodedData
-     * @return map with output data
-     */
-    public static Map<String, String> formUrlDecode(String encodedData) {
-        Map<String, String> params = new HashMap<String, String>();
-        String[] elements = encodedData.split("&");
-        for (String element : elements) {
-            String[] pair = element.split("=");
-            if (pair.length == 2) {
-                String paramName = pair[0];
-                String paramValue;
-                try {
-                    paramValue = URLDecoder.decode(pair[1], "UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException(e);
-                }
-                params.put(paramName, paramValue);
-            } else {
-                throw new RuntimeException("Unexpected name-value pair in response: " + element);
-            }
-        }
-        return params;
-    }
-
-    public static String refineUserName(String username) {
-        final String ALLOWED_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012456789._";
-        final char replaced = '_';
-
-        if (username == null || username.isEmpty()) {
-            return "";
-        }
-
-        final char[] chars = username.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            if (ALLOWED_CHARACTERS.indexOf(chars[i]) == -1) {
-                chars[i] = replaced;
-            }
-        }
-        return new String(chars);
-    }
+    return new String(chars);
+  }
 }

--- a/component/web/oauth-common/src/test/java/org/gatein/security/oauth/test/TestOauthUtils.java
+++ b/component/web/oauth-common/src/test/java/org/gatein/security/oauth/test/TestOauthUtils.java
@@ -1,0 +1,70 @@
+package org.gatein.security.oauth.test;
+
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import org.gatein.security.oauth.common.OAuthConstants;
+import org.gatein.security.oauth.openid.OpenIdAccessTokenContext;
+import org.gatein.security.oauth.spi.OAuthPrincipal;
+import org.gatein.security.oauth.utils.OAuthUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TestOauthUtils {
+
+  @Test
+  public void testConvertOpenIdInfoToOAuthPrincipalWithUserInfo() throws JSONException {
+
+    JSONObject userInfo = new JSONObject();
+    userInfo.put(OAuthConstants.EMAIL_ATTRIBUTE,"usertest@acme.com");
+    userInfo.put(OAuthConstants.GIVEN_NAME_ATTRIBUTE,"User");
+    userInfo.put(OAuthConstants.FAMILY_NAME_ATTRIBUTE,"Test");
+    userInfo.put(OAuthConstants.NAME_ATTRIBUTE,"User Test");
+    userInfo.put(OAuthConstants.PICTURE_ATTRIBUTE,"https://www.test.com/avatar");
+
+    OAuth2AccessToken token = new OAuth2AccessToken("token","raw");
+    OpenIdAccessTokenContext openIdAccessTokenContext = new OpenIdAccessTokenContext(token, "openid");
+
+
+    OAuthPrincipal principal = OAuthUtils.convertOpenIdInfoToOAuthPrincipal(userInfo,openIdAccessTokenContext,null);
+
+    assertNull(principal.getName());
+    assertEquals("usertest@acme.com",principal.getEmail());
+    assertEquals("User",principal.getFirstName());
+    assertEquals("Test",principal.getLastName());
+    assertEquals("User Test",principal.getDisplayName());
+    assertEquals("https://www.test.com/avatar",principal.getAvatar());
+
+  }
+
+  @Test
+  public void testConvertOpenIdInfoToOAuthPrincipalWithCustomClaims() throws JSONException {
+
+    JSONObject userInfo = new JSONObject();
+
+    OAuth2AccessToken token = new OAuth2AccessToken("token","raw");
+    OpenIdAccessTokenContext openIdAccessTokenContext = new OpenIdAccessTokenContext(token, "openid");
+    Map<String, String> customClaims = new HashMap<>();
+    customClaims.put(OAuthConstants.EMAIL_ATTRIBUTE,"usertest@acme.com");
+    customClaims.put(OAuthConstants.GIVEN_NAME_ATTRIBUTE,"User");
+    customClaims.put(OAuthConstants.FAMILY_NAME_ATTRIBUTE,"Test");
+    customClaims.put(OAuthConstants.NAME_ATTRIBUTE,"User Test");
+    openIdAccessTokenContext.addCustomClaims(customClaims);
+
+
+    OAuthPrincipal principal = OAuthUtils.convertOpenIdInfoToOAuthPrincipal(userInfo,openIdAccessTokenContext,null);
+
+    assertNull(principal.getName());
+    assertEquals("usertest@acme.com",principal.getEmail());
+    assertEquals("User",principal.getFirstName());
+    assertEquals("Test",principal.getLastName());
+    assertEquals("User Test",principal.getDisplayName());
+    assertNull(principal.getAvatar());
+
+  }
+}

--- a/component/web/oauth-common/src/test/java/org/gatein/security/oauth/test/TestOpenIdAccessTokenContext.java
+++ b/component/web/oauth-common/src/test/java/org/gatein/security/oauth/test/TestOpenIdAccessTokenContext.java
@@ -1,0 +1,31 @@
+package org.gatein.security.oauth.test;
+
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import org.gatein.security.oauth.common.OAuthConstants;
+import org.gatein.security.oauth.openid.OpenIdAccessTokenContext;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestOpenIdAccessTokenContext {
+
+  @Test
+  public void testOpenIdAccessTokenContextCreation() {
+    OAuth2AccessToken token = new OAuth2AccessToken("token", "raw");
+    OpenIdAccessTokenContext tokenContext = new OpenIdAccessTokenContext(token,"openid");
+
+    assertEquals(0,tokenContext.getCustomClaims().size());
+
+    Map<String, String> customClaims = new HashMap<>();
+    customClaims.put("customClaims", "custom");
+    tokenContext.addCustomClaims(customClaims);
+
+    assertEquals(1,tokenContext.getCustomClaims().size());
+    assertEquals("custom",tokenContext.getCustomClaims().get("customClaims"));
+
+
+  }
+}

--- a/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/openid/OpenIdFilter.java
+++ b/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/openid/OpenIdFilter.java
@@ -65,10 +65,7 @@ public class OpenIdFilter extends OAuthProviderFilter<OpenIdAccessTokenContext> 
             log.trace("Obtained tokenResponse from OpenId authentication: " + accessTokenContext);
         }
 
-        OAuthPrincipal<OpenIdAccessTokenContext> oauthPrincipal = OAuthUtils.convertOpenIdInfoToOAuthPrincipal(userInfo,
-                                                                                                               accessTokenContext, getOAuthProvider());
-
-        return oauthPrincipal;
+        return OAuthUtils.convertOpenIdInfoToOAuthPrincipal(userInfo, accessTokenContext, getOAuthProvider());
     }
 
 }


### PR DESCRIPTION
Prior to this change, it was impossible to login using OIDC with ADFS server, because meeds try to read user information by calling userinfo endpoint. But ADFS server do not provide claims in the userinfo endpoint.
This change modify how to get user informations : in case userinfo do not contains wanted claims, we get it in the id_token.
We could take directly information in id_token without calling userinfo endpoint, but in certain cases, like when using Google Identity Server, we can get information like avatar in userinfo endpoint. So we keep the userinfo endpoint call, and if this call not working, we use id_token claims