### PR TITLE
fix: OIDC properties : Wellknown url isn't well extracted - EXO-59697 - meeds-io/meeds#288

### DIFF
--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
@@ -440,7 +440,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
         this.accessTokenURL = json.getString("token_endpoint");
         this.userInfoURL = json.getString("userinfo_endpoint");
         this.issuer = json.getString("issuer");
-        this.remoteJwkSigningKeyResolver = new RemoteJwkSigningKeyResolver(this.issuer);
+        this.remoteJwkSigningKeyResolver = new RemoteJwkSigningKeyResolver(this.wellKnownConfigurationUrl);
       }
     } catch (JSONException e) {
       log.error("Unable to read webKnownUrl content : " + this.wellKnownConfigurationUrl);

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
@@ -38,13 +38,13 @@ import java.util.*;
 
 public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
 
-    private final String issuer;
+  private final String     wellKnownUrl;
     private final Object lock = new Object();
     private Map<String, Key> keyMap = new HashMap<>();
     private static final Log LOG = ExoLogger.getLogger(RemoteJwkSigningKeyResolver.class);
 
-    RemoteJwkSigningKeyResolver(String issuer) {
-        this.issuer = issuer;
+    RemoteJwkSigningKeyResolver(String wellKnownUrl) {
+      this.wellKnownUrl = wellKnownUrl;
     }
 
     @Override
@@ -79,7 +79,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
 
     private void updateKeys() {
 
-        JSONObject configuration = getJson(issuer + "/.well-known/openid-configuration");
+      JSONObject configuration = getJson(wellKnownUrl);
         try {
             String jwksUrl = configuration != null ? configuration.getString("jwks_uri") : null;
             JSONObject keys = getJson(jwksUrl);

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
@@ -79,7 +79,7 @@ public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
 
     private void updateKeys() {
 
-      JSONObject configuration = getJson(wellKnownUrl);
+        JSONObject configuration = getJson(wellKnownUrl);
         try {
             String jwksUrl = configuration != null ? configuration.getString("jwks_uri") : null;
             JSONObject keys = getJson(jwksUrl);

--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/RemoteJwkSigningKeyResolver.java
@@ -38,7 +38,7 @@ import java.util.*;
 
 public class RemoteJwkSigningKeyResolver implements SigningKeyResolver {
 
-  private final String     wellKnownUrl;
+    private final String wellKnownUrl;
     private final Object lock = new Object();
     private Map<String, Key> keyMap = new HashMap<>();
     private static final Log LOG = ExoLogger.getLogger(RemoteJwkSigningKeyResolver.class);


### PR DESCRIPTION
Before this fix, during the OIDC protocol, we try to validate the JWT token For that, we use RemoteJwkSigningKeyResolver, and we initialize it with the issuer parameter. This class then rebuild the well-known url by concatenate issuer and "/.well-known/openid-configuration". When issuer is different from the well-know path, the class RemoteJwkSigningKeyResolver is unabel to find the well-known configuration file

This fix modify RemoteJwkSigningKeyResolver to pass in parameter the well-known url instead of the issuer

