### PR TITLE
fix: Fix blank page displayed when login with non existing email - EXO-59754 - Meeds-io/meeds#298

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -254,6 +254,10 @@ public class LoginHandler extends JspBasedWebHandler {
         if (users != null && users.getSize() > 0) {
           return users.load(0, 1)[0].getUserName();
         }
+        else {
+          LOG.debug("Can not get users by email");
+          dispatch(context, loginPath.toString(), LoginStatus.FAILED);
+        }
       } catch (RuntimeException e) {
         LOG.warn("Can not login with an email associated to many users");
         dispatch(context, loginPath.toString(), LoginStatus.MANY_USERS_WITH_SAME_EMAIL);


### PR DESCRIPTION
Prior to this change, a blank page is displayed when trying to login with a non existing email. After this commit, we ensure to send failed authentication status when the findUsersByQuery with the taped email not returns users.