### PR TITLE
fix: Account is locked when password is changed - EXO-59903

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
@@ -302,8 +302,7 @@ public class UserRestResourcesV1 implements ResourceContainer {
       return Response.status(Response.Status.BAD_REQUEST).entity("EMAIL:ALREADY_EXISTS").build();
     }
 
-    if (StringUtils.isNotBlank(password)
-        || !StringUtils.equals(email, user.getEmail())
+    if (!StringUtils.equals(email, user.getEmail())
         || !StringUtils.equals(lastName, user.getLastName())
         || !StringUtils.equals(firstName, user.getFirstName())) {
       user.setEmail(email);
@@ -312,6 +311,13 @@ public class UserRestResourcesV1 implements ResourceContainer {
       user.setPassword(password);
       user.setDisplayName(firstName+" "+lastName);
       organizationService.getUserHandler().saveUser(user, true);
+    }
+
+    if (StringUtils.isNotBlank(password)) {
+      // we save the password separatly from saving the user, because when changing
+      // password, we need to remove rememberme token
+      // related to this password as they are no more valid
+      passwordRecoveryService.getActiveChangePasswordConnector().changePassword(userName, password);
     }
 
     if (user.isEnabled() != enabled) {

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/DefaultChangePasswordConnector.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/DefaultChangePasswordConnector.java
@@ -5,17 +5,24 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
+import org.exoplatform.web.security.security.CookieTokenService;
 
 public class DefaultChangePasswordConnector extends ChangePasswordConnector {
   
   private OrganizationService organizationService;
-  
+
+  private CookieTokenService  cookieTokenService;
+
   public final static String LOG_SERVICE_NAME = "changePassword";
   
   protected static Log log = ExoLogger.getLogger(DefaultChangePasswordConnector.class);
   
-  public DefaultChangePasswordConnector(InitParams initParams, OrganizationService organizationService) {
+  public DefaultChangePasswordConnector(InitParams initParams,
+                                        OrganizationService organizationService,
+                                        CookieTokenService cookieTokenService) {
     this.organizationService=organizationService;
+    this.cookieTokenService = cookieTokenService;
+
   }
   
   /**
@@ -41,8 +48,9 @@ public class DefaultChangePasswordConnector extends ChangePasswordConnector {
     long startTime = System.currentTimeMillis();
     user.setPassword(password);
     organizationService.getUserHandler().saveUser(user, true);
+    cookieTokenService.deleteTokensByUsernameAndType(user.getUserName(), "");
     long totalTime = System.currentTimeMillis() - startTime;
-  
+
     log.info("service={} operation={} parameters=\"user:{}\" status=ok duration_ms={}",
              LOG_SERVICE_NAME, "changeInternalPassword", user.getUserName(), totalTime);
   }

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryHandler.java
@@ -152,11 +152,9 @@ public class PasswordRecoveryHandler extends WebRequestHandler {
                 //
                 if (errors.isEmpty()) {
                     if (service.changePass(tokenId, remindPasswordTokenService.FORGOT_PASSWORD_TOKEN, username, password)) {
-                        success = bundle.getString("gatein.forgotPassword.resetPasswordSuccess");
-                        password = "";
-                        confirmPass = "";
                         String currentPortalContainerName = PortalContainer.getCurrentPortalContainerName();
                         res.sendRedirect("/" + currentPortalContainerName + "/login");
+                        return true;
                     } else {
                         errors.add(bundle.getString("gatein.forgotPassword.resetPasswordFailure"));
                     }

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
@@ -30,6 +30,7 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.web.login.externalRegistration.ExternalRegistrationHandler;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.web.security.security.CookieTokenService;
 import org.gatein.wci.security.Credentials;
 
 import org.exoplatform.commons.utils.I18N;
@@ -64,6 +65,8 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
 
   private final RemindPasswordTokenService     remindPasswordTokenService;
 
+  private final CookieTokenService             cookieTokenService;
+
   private final BrandingService                brandingService;
 
   private final WebAppController               webController;
@@ -79,12 +82,14 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
                                      MailService mailService,
                                      ResourceBundleService bundleService,
                                      RemindPasswordTokenService remindPasswordTokenService,
+                                     CookieTokenService cookieTokenService,
                                      WebAppController controller,
                                      BrandingService brandingService) {
     this.orgService = orgService;
     this.mailService = mailService;
     this.bundleService = bundleService;
     this.remindPasswordTokenService = remindPasswordTokenService;
+    this.cookieTokenService = cookieTokenService;
     this.webController = controller;
     this.brandingService = brandingService;
     this.changePasswordConnectorMap = new HashMap<>();
@@ -128,6 +133,11 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
       try {
         remindPasswordTokenService.deleteToken(tokenId, tokenType);
         remindPasswordTokenService.deleteTokensByUsernameAndType(username, tokenType);
+
+        // delete all token which have no type
+        // this is rememberMe token
+        // as user have change his password, these tokens are no more valid
+        cookieTokenService.deleteTokensByUsernameAndType(username, "");
 
       } catch (Exception ex) {
         log.warn("Can not delete token: " + tokenId, ex);


### PR DESCRIPTION
Before this fix, when a user have a tab openend with an active remember token, and changing his password, the rememberme token is used to try authentication But, as the password was changed, the authentication fails at multiple times, which lead to lock the account

This fix delete from tokenStore all rememberme token of the users, as they are all no more valid, so that when the tab is refresh with an old rememberme token, it is not found by the server, and so ignored. Then the login form is displayed without locking the account.

(cherry picked from commit https://github.com/Meeds-io/gatein-portal/commit/91335959cebbd62e8c47c88926b4193018d00e24)