### PR TITLE
fix: Fix NullPointer exception when uploading an empty resource - EXO-59910 - Meeds-io/meeds#325

### DIFF
--- a/component/common/src/main/java/org/exoplatform/upload/UploadService.java
+++ b/component/common/src/main/java/org/exoplatform/upload/UploadService.java
@@ -150,7 +150,9 @@ public class UploadService {
 
         // commons-fileupload will store the temp file with name *.tmp
         // we need to rename it to our desired name
-        fileItem.getStoreLocation().renameTo(new File(storeLocation));
+        if (fileItem.getStoreLocation() != null) {
+          fileItem.getStoreLocation().renameTo(new File(storeLocation));
+        }
         File fileStore = new File(storeLocation);
         if (!fileStore.exists())
             try {


### PR DESCRIPTION
Prior to this change, a null pointer exception occurs when uploading an empty resource. After this commit, we try to avoid it by checking nullability of the store location in that case.