### PR TITLE
feat: Allow to change navigation order from XML with MERGE import mode - MEED-514 - Meeds-io/MIPs#16

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/importer/NavigationFragmentImporter.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/importer/NavigationFragmentImporter.java
@@ -21,8 +21,6 @@ package org.exoplatform.portal.mop.importer;
 
 import java.util.*;
 
-import org.apache.commons.lang3.StringUtils;
-
 import org.exoplatform.portal.config.model.*;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.description.DescriptionService;
@@ -179,7 +177,7 @@ public class NavigationFragmentImporter {
         }
 
         // Buffer the changes in a list
-        LinkedList<Change> changes = new LinkedList<Change>();
+        LinkedList<Change> changes = new LinkedList<>();
         while (it.hasNext()) {
             ListChangeType type = it.next();
             changes.add(new Change(type, it.getElement(), it.getIndex1(), it.getIndex2()));

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationConserve.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationConserve.java
@@ -34,7 +34,7 @@ public class TestImportNavigationConserve extends AbstractImportNavigationTest {
 
     @Override
     protected final void afterOnePhaseBoot(NodeContext<?> root) {
-        assertEquals(3, root.getNodeCount());
+        assertEquals(4, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_2", foo.getState().getIcon());
@@ -51,13 +51,20 @@ public class TestImportNavigationConserve extends AbstractImportNavigationTest {
         assertNotNull(daa);
         assertEquals("daa_icon", daa.getState().getIcon());
         assertEquals(0, daa.getNodeCount());
+        // CONSERVE is changed into MERGE when first startup
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
+        assertEquals(3, root.get("daa").getIndex());
     }
 
     @Override
     protected final void afterTwoPhasesBoot(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         assertNotNull(root.get("foo"));
         assertNotNull(root.get("daa"));
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
+        assertEquals(2, root.get("daa").getIndex());
     }
 
     @Override
@@ -66,7 +73,7 @@ public class TestImportNavigationConserve extends AbstractImportNavigationTest {
     }
 
     protected void assertState(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_1", foo.getState().getIcon());

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationInsert.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationInsert.java
@@ -34,7 +34,7 @@ public class TestImportNavigationInsert extends AbstractImportNavigationTest {
 
     @Override
     protected final void afterOnePhaseBoot(NodeContext<?> root) {
-        assertEquals(3, root.getNodeCount());
+        assertEquals(4, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_2", foo.getState().getIcon());
@@ -51,18 +51,25 @@ public class TestImportNavigationInsert extends AbstractImportNavigationTest {
         assertNotNull(daa);
         assertEquals("daa_icon", daa.getState().getIcon());
         assertEquals(0, daa.getNodeCount());
+        // INSERT is changed into MERGE when first startup
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
+        assertEquals(3, root.get("daa").getIndex());
     }
 
     @Override
     protected final void afterTwoPhasesBoot(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         assertNotNull(root.get("foo"));
         assertNotNull(root.get("daa"));
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
+        assertEquals(2, root.get("daa").getIndex());
     }
 
     @Override
     protected final void afterTwoPhaseOverrideReboot(NodeContext<?> root) {
-        assertEquals(3, root.getNodeCount());
+        assertEquals(4, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_1", foo.getState().getIcon());
@@ -79,6 +86,9 @@ public class TestImportNavigationInsert extends AbstractImportNavigationTest {
         assertNotNull(daa);
         assertEquals("daa_icon", daa.getState().getIcon());
         assertEquals(0, daa.getNodeCount());
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
+        assertEquals(3, root.get("daa").getIndex());
     }
 
 }

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationMerge.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationMerge.java
@@ -35,22 +35,29 @@ public class TestImportNavigationMerge extends AbstractImportNavigationTest {
     @Override
     protected final void afterOnePhaseBoot(NodeContext<?> root) {
         assertState(root);
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
     }
 
     @Override
     protected final void afterTwoPhasesBoot(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         assertNotNull(root.get("foo"));
         assertNotNull(root.get("daa"));
+        assertNotNull(root.get("baz"));
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
     }
 
     @Override
     protected final void afterTwoPhaseOverrideReboot(NodeContext<?> root) {
         assertState(root);
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
     }
 
     protected void assertState(NodeContext<?> root) {
-        assertEquals(3, root.getNodeCount());
+        assertEquals(4, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_2", foo.getState().getIcon());

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationOverwrite.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationOverwrite.java
@@ -35,11 +35,13 @@ public class TestImportNavigationOverwrite extends AbstractImportNavigationTest 
     @Override
     protected final void afterOnePhaseBoot(NodeContext<?> root) {
         assertState(root);
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
     }
 
     @Override
     protected final void afterTwoPhasesBoot(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_1", foo.getState().getIcon());
@@ -48,15 +50,19 @@ public class TestImportNavigationOverwrite extends AbstractImportNavigationTest 
         assertNotNull(bar);
         assertEquals("daa_icon", bar.getState().getIcon());
         assertEquals(0, bar.getNodeCount());
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
     }
 
     @Override
     protected final void afterTwoPhaseOverrideReboot(NodeContext<?> root) {
         assertState(root);
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
     }
 
     protected void assertState(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_2", foo.getState().getIcon());

--- a/component/portal/src/test/resources/org/exoplatform/portal/config/navigation1-conf/portal/classic/navigation.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/config/navigation1-conf/portal/classic/navigation.xml
@@ -25,6 +25,10 @@
   <priority>1</priority>
   <page-nodes>
     <node>
+      <name>baz</name>
+      <icon>baz_icon</icon>
+    </node>
+    <node>
       <name>foo</name>
       <icon>foo_icon_1</icon>
       <node>

--- a/component/portal/src/test/resources/org/exoplatform/portal/config/navigation2-conf/portal/classic/navigation.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/config/navigation2-conf/portal/classic/navigation.xml
@@ -32,5 +32,9 @@
       <name>bar</name>
       <icon>bar_icon</icon>
     </node>
+    <node>
+      <name>baz</name>
+      <icon>baz_icon</icon>
+    </node>
   </page-nodes>
 </node-navigation>


### PR DESCRIPTION
Prior to this change, when changing through XML the navigation nodes, it's not impacted even with importMode = 'MERGE'. This change allows to change the navigation nodes by XML configuration file.