### PR TITLE
feat: Allow to change navigation order from XML with MERGE import mode - MEED-514 - Meeds-io/MIPs#16

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/importer/NavigationFragmentImporter.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/importer/NavigationFragmentImporter.java
@@ -177,17 +177,24 @@ public class NavigationFragmentImporter {
         }
 
         // Buffer the changes in a list
-        LinkedList<Change> foo = new LinkedList<Change>();
+        LinkedList<Change> changes = new LinkedList<>();
         while (it.hasNext()) {
             ListChangeType type = it.next();
-            foo.add(new Change(type, it.getElement(), it.getIndex1(), it.getIndex2()));
+            changes.add(new Change(type, it.getElement(), it.getIndex1(), it.getIndex2()));
         }
+        changes.sort((change1, change2) -> {
+          PageNode srcNode1 = src.getNode(change1.name);
+          PageNode srcNode2 = src.getNode(change2.name);
+          int index1 = srcNode1 == null ? Integer.MAX_VALUE : src.getNodes().indexOf(srcNode1);
+          int index2 = srcNode2 == null ? Integer.MAX_VALUE : src.getNodes().indexOf(srcNode2);
+          return index1 - index2;
+        });
 
         // The last encountered child
         NodeContext<?> previousChild = null;
 
         // Replay the changes and apply them
-        for (Change change : foo) {
+        for (Change change : changes) {
             PageNode srcChild = src.getNode(change.name);
             NodeContext<?> dstChild = dst.get(change.name);
 
@@ -199,7 +206,7 @@ public class NavigationFragmentImporter {
 
                     //
                     if (config.updatedSame) {
-                        update(srcChild, dstChild, labelMap);
+                        update(src, dst, srcChild, dstChild, labelMap);
                     }
 
                     //
@@ -216,7 +223,7 @@ public class NavigationFragmentImporter {
                 case ADD:
                     if (src.getNode(change.name) != null) {
                         if (config.updatedSame) {
-                            update(srcChild, dstChild, labelMap);
+                            update(src, dst, srcChild, dstChild, labelMap);
                         }
                         previousChild = dstChild;
                     } else {
@@ -278,8 +285,21 @@ public class NavigationFragmentImporter {
         return child;
     }
 
-    private void update(PageNode src, NodeContext<?> target, Map<NodeContext<?>, Map<Locale, org.exoplatform.portal.mop.State>> labelMap) {
+    private void update(PageNodeContainer srcParent, NodeContext dstParent, PageNode src, NodeContext<?> target, Map<NodeContext<?>, Map<Locale, org.exoplatform.portal.mop.State>> labelMap) {
         target.setState(src.getState());
+
+        int srcIndex = srcParent.getNodes().indexOf(src);
+        if (srcIndex <= 0) {
+          dstParent.add(0, target);
+        } else {
+          PageNode previousSrcNode = srcParent.getNodes().get(srcIndex - 1);
+          NodeContext previousTargetNode = dstParent.get(previousSrcNode.getName());
+          if (previousTargetNode != null) {
+            dstParent.add(previousTargetNode.getIndex() + 1, target);
+          } else {
+            dstParent.add(null, target);
+          }
+        }
 
         // Update extended labels if necessary
         I18NString labels = src.getLabels();

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationConserve.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationConserve.java
@@ -34,7 +34,7 @@ public class TestImportNavigationConserve extends AbstractImportNavigationTest {
 
     @Override
     protected final void afterOnePhaseBoot(NodeContext<?> root) {
-        assertEquals(3, root.getNodeCount());
+        assertEquals(4, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_2", foo.getState().getIcon());
@@ -51,13 +51,20 @@ public class TestImportNavigationConserve extends AbstractImportNavigationTest {
         assertNotNull(daa);
         assertEquals("daa_icon", daa.getState().getIcon());
         assertEquals(0, daa.getNodeCount());
+        // CONSERVE is changed into MERGE when first startup
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
+        assertEquals(3, root.get("daa").getIndex());
     }
 
     @Override
     protected final void afterTwoPhasesBoot(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         assertNotNull(root.get("foo"));
         assertNotNull(root.get("daa"));
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
+        assertEquals(2, root.get("daa").getIndex());
     }
 
     @Override
@@ -66,7 +73,7 @@ public class TestImportNavigationConserve extends AbstractImportNavigationTest {
     }
 
     protected void assertState(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_1", foo.getState().getIcon());

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationInsert.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationInsert.java
@@ -34,7 +34,7 @@ public class TestImportNavigationInsert extends AbstractImportNavigationTest {
 
     @Override
     protected final void afterOnePhaseBoot(NodeContext<?> root) {
-        assertEquals(3, root.getNodeCount());
+        assertEquals(4, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_2", foo.getState().getIcon());
@@ -51,18 +51,25 @@ public class TestImportNavigationInsert extends AbstractImportNavigationTest {
         assertNotNull(daa);
         assertEquals("daa_icon", daa.getState().getIcon());
         assertEquals(0, daa.getNodeCount());
+        // INSERT is changed into MERGE when first startup
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
+        assertEquals(3, root.get("daa").getIndex());
     }
 
     @Override
     protected final void afterTwoPhasesBoot(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         assertNotNull(root.get("foo"));
         assertNotNull(root.get("daa"));
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
+        assertEquals(2, root.get("daa").getIndex());
     }
 
     @Override
     protected final void afterTwoPhaseOverrideReboot(NodeContext<?> root) {
-        assertEquals(3, root.getNodeCount());
+        assertEquals(4, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_1", foo.getState().getIcon());
@@ -79,6 +86,9 @@ public class TestImportNavigationInsert extends AbstractImportNavigationTest {
         assertNotNull(daa);
         assertEquals("daa_icon", daa.getState().getIcon());
         assertEquals(0, daa.getNodeCount());
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
+        assertEquals(3, root.get("daa").getIndex());
     }
 
 }

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationMerge.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationMerge.java
@@ -35,22 +35,29 @@ public class TestImportNavigationMerge extends AbstractImportNavigationTest {
     @Override
     protected final void afterOnePhaseBoot(NodeContext<?> root) {
         assertState(root);
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
     }
 
     @Override
     protected final void afterTwoPhasesBoot(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         assertNotNull(root.get("foo"));
         assertNotNull(root.get("daa"));
+        assertNotNull(root.get("baz"));
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
     }
 
     @Override
     protected final void afterTwoPhaseOverrideReboot(NodeContext<?> root) {
         assertState(root);
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
     }
 
     protected void assertState(NodeContext<?> root) {
-        assertEquals(3, root.getNodeCount());
+        assertEquals(4, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_2", foo.getState().getIcon());

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationOverwrite.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestImportNavigationOverwrite.java
@@ -35,11 +35,13 @@ public class TestImportNavigationOverwrite extends AbstractImportNavigationTest 
     @Override
     protected final void afterOnePhaseBoot(NodeContext<?> root) {
         assertState(root);
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
     }
 
     @Override
     protected final void afterTwoPhasesBoot(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_1", foo.getState().getIcon());
@@ -48,15 +50,19 @@ public class TestImportNavigationOverwrite extends AbstractImportNavigationTest 
         assertNotNull(bar);
         assertEquals("daa_icon", bar.getState().getIcon());
         assertEquals(0, bar.getNodeCount());
+        assertEquals(0, root.get("baz").getIndex());
+        assertEquals(1, root.get("foo").getIndex());
     }
 
     @Override
     protected final void afterTwoPhaseOverrideReboot(NodeContext<?> root) {
         assertState(root);
+        assertEquals(2, root.get("baz").getIndex());
+        assertEquals(0, root.get("foo").getIndex());
     }
 
     protected void assertState(NodeContext<?> root) {
-        assertEquals(2, root.getNodeCount());
+        assertEquals(3, root.getNodeCount());
         NodeContext<?> foo = root.get("foo");
         assertNotNull(foo);
         assertEquals("foo_icon_2", foo.getState().getIcon());

--- a/component/portal/src/test/resources/org/exoplatform/portal/config/navigation1-conf/portal/classic/navigation.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/config/navigation1-conf/portal/classic/navigation.xml
@@ -25,6 +25,10 @@
   <priority>1</priority>
   <page-nodes>
     <node>
+      <name>baz</name>
+      <icon>baz_icon</icon>
+    </node>
+    <node>
       <name>foo</name>
       <icon>foo_icon_1</icon>
       <node>

--- a/component/portal/src/test/resources/org/exoplatform/portal/config/navigation2-conf/portal/classic/navigation.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/config/navigation2-conf/portal/classic/navigation.xml
@@ -32,5 +32,9 @@
       <name>bar</name>
       <icon>bar_icon</icon>
     </node>
+    <node>
+      <name>baz</name>
+      <icon>baz_icon</icon>
+    </node>
   </page-nodes>
 </node-navigation>


### PR DESCRIPTION
Prior to this change, when changing through XML the navigation nodes, it's not impacted even with importMode = 'MERGE'. This change allows to change the navigation nodes by XML configuration file.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
