### PR TITLE
feat: Explicit Dependant versions of Core Foundation Projects - MEED-907

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,14 @@
   <name>GateIn - Portal</name>
   
   <properties>
+    <org.exoplatform.depmgt.version>21.x-SNAPSHOT</org.exoplatform.depmgt.version>
+    <org.exoplatform.kernel.version>6.4.x-SNAPSHOT</org.exoplatform.kernel.version>
+    <org.exoplatform.core.version>6.4.x-SNAPSHOT</org.exoplatform.core.version>
+    <org.exoplatform.ws.version>6.4.x-SNAPSHOT</org.exoplatform.ws.version>
+    <org.exoplatform.gatein.wci.version>6.4.x-SNAPSHOT</org.exoplatform.gatein.wci.version>
     <org.exoplatform.gatein.sso.version>6.4.x-SNAPSHOT</org.exoplatform.gatein.sso.version>
     <org.exoplatform.gatein.pc.version>6.4.x-SNAPSHOT</org.exoplatform.gatein.pc.version>
-    
+
     <!-- Default eXo profiles -->
     <surefire.exo.profiles>hsqldb</surefire.exo.profiles>
     
@@ -65,6 +70,42 @@
   
   <dependencyManagement>
     <dependencies>
+      <!-- Import versions of external dependencies to use -->
+      <dependency>
+        <groupId>org.exoplatform</groupId>
+        <artifactId>maven-depmgt-pom</artifactId>
+        <version>${org.exoplatform.depmgt.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Kernel dependencies -->
+      <dependency>
+        <groupId>org.exoplatform.kernel</groupId>
+        <artifactId>kernel-parent</artifactId>
+        <version>${org.exoplatform.kernel.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Core dependencies -->
+      <dependency>
+        <groupId>org.exoplatform.core</groupId>
+        <artifactId>core-parent</artifactId>
+        <version>${org.exoplatform.core.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- WS dependencies -->
+      <dependency>
+        <groupId>org.exoplatform.ws</groupId>
+        <artifactId>ws-parent</artifactId>
+        <version>${org.exoplatform.ws.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- GateIn-PC dependencies -->
       <dependency>
         <groupId>org.exoplatform.gatein.pc</groupId>
@@ -82,7 +123,16 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      
+
+      <!-- GateIn-WCI dependencies -->
+      <dependency>
+        <groupId>org.exoplatform.gatein.wci</groupId>
+        <artifactId>wci-parent</artifactId>
+        <version>${org.exoplatform.gatein.wci.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- Internal project artifacts -->
       <dependency>
         <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Prior to this change, the versions of kernel, core, ws and gatein-wci projects was inherited from gatein-sso and gatein-pc. This change will allow to explicitly choose a specific version for each CF project when releasing on CI/CD.

> **Note**: This change will require a manual rebase for other branches to introduce specific FB name

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
