### PR TITLE
fix: Expire user password recovery tokens after a successful login - EXO-60312 - Meeds-io/meeds#363

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -187,6 +187,9 @@ public class LoginHandler extends JspBasedWebHandler {
       }
       if (request.getRemoteUser() != null) {
         status = LoginStatus.AUTHENTICATED;
+        // Delete user forgot-password tokens to invalidate recover password email link
+        CookieTokenService tokenService = AbstractTokenService.getInstance(CookieTokenService.class);
+        tokenService.deleteTokensByUsernameAndType(username, CookieTokenService.FORGOT_PASSWORD_TOKEN);
       }
     } else {
       LOG.debug("User already authenticated. Will redirect to initialURI");


### PR DESCRIPTION

Prior to this change, when clicking on forget password then doing a successful login, the old password recovery email links still work. After this commit, after a successful login all password recovery tokens should be deleted and expired.

(cherry picked from commit https://github.com/Meeds-io/gatein-portal/commit/a74f396791fcec7af95bf2018ecd4f91844e07f5)