### PR TITLE
fix : fix membership format in groups Rest endpoint - EXO-59678 - meeds-io/meeds#371

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/GroupRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/GroupRestResourcesV1.java
@@ -573,7 +573,7 @@ public class GroupRestResourcesV1 implements ResourceContainer {
       }
   )
   public Response deleteMembership(@Parameter(
-      description = "Membership identifier with format: MEMBERSHIP_TYPE:GROUP_ID:USER_NAME", required = true
+      description = "Membership identifier with format: MEMBERSHIP_TYPE:USER_NAME:GROUP_ID", required = true
   ) @QueryParam(
     "membershipId"
   ) String membershipId) throws Exception {


### PR DESCRIPTION
Prior to this fix the documentation of the function **org.exoplatform.portal.rest.GroupRestResourcesV1#deleteMembership** indicates that the membership format should be :
 - **MEMBERSHIP_TYPE:GROUP_ID:USER_NAME** whereas it should be
- **MEMBERSHIP_TYPE:USER_NAME:GROUP_ID**

this fix will make sure to update the documentation with the correct format

(cherry picked from commit c28eae623d00575623fb6c3d66087d9a902e356c)