### PR TITLE
fix: Fix first and last name allowing the use of illegal eXo characters for external user names - EXO-60662 - Meeds-io/meeds#399

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/externalRegistration/ExternalRegistrationHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/externalRegistration/ExternalRegistrationHandler.java
@@ -72,9 +72,9 @@ public class ExternalRegistrationHandler extends WebRequestHandler {
 
   public static final String               FIRSTNAME           = "firstName";
 
-  public static final UserFieldValidator   LASTNAME_VALIDATOR  = new UserFieldValidator(LASTNAME, false, true);
+  public static final UserFieldValidator   LASTNAME_VALIDATOR  = new UserFieldValidator(LASTNAME, true, false);
 
-  public static final UserFieldValidator   FIRSTNAME_VALIDATOR = new UserFieldValidator(FIRSTNAME, false, true);
+  public static final UserFieldValidator   FIRSTNAME_VALIDATOR = new UserFieldValidator(FIRSTNAME, true, false);
 
   public static final String               NAME                = "external-registration";
 


### PR DESCRIPTION

Prior to this change, in the PR https://github.com/Meeds-io/gatein-portal/pull/457 we have used the first and last name validators in order to validate external user creation and forbid illegal chars but it was always possible to create an external user with a first name or a last name containing the character "@" at the end. After this change, to fix that we will use the username validator instead of first and last name validators for external user creation validation.