### PR TITLE
fix:  Align Css cache TTL to JS cache TTL - EXO-60487 - Meeds-io/meeds#362

### DIFF
--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/SkinService.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/SkinService.java
@@ -134,7 +134,7 @@ public class SkinService extends AbstractResourceService implements Startable {
   public static final long                                      MAX_AGE;
 
   static {
-    long seconds = 86400;
+    long seconds = 604800;
     String propValue = PropertyManager.getProperty("gatein.assets.css.max-age");
     if (propValue != null) {
       try {


### PR DESCRIPTION
Prior to this change in SkinService Css cache TTL is MAX_AGE and default value is set to 86400s (1day), For js, default value is set to 604800s (7days).
This PR should align css default max_age to 604800.

