### PR TITLE
fix : popup OpenID displayed - EXO-60961 - meeds-io/meeds#437

### DIFF
--- a/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/OAuthProviderFilter.java
+++ b/component/web/oauth-web/src/main/java/org/gatein/security/oauth/web/OAuthProviderFilter.java
@@ -86,6 +86,13 @@ public abstract class OAuthProviderFilter<T extends AccessTokenContext> extends 
         HttpServletResponse httpResponse = (HttpServletResponse)response;
         HttpSession session = httpRequest.getSession();
 
+        if (httpRequest.getRemoteUser() != null) {
+          //direct access to Auth url, redirect to context url, as user is already identified
+          httpResponse.sendRedirect(httpRequest.getContextPath());
+          return;
+        }
+
+
         // Restart current state if 'oauthInteraction' param has value 'start'
         String interaction = httpRequest.getParameter(OAuthConstants.PARAM_OAUTH_INTERACTION);
         if (OAuthConstants.PARAM_OAUTH_INTERACTION_VALUE_START.equals(interaction)) {


### PR DESCRIPTION
Before this fix, if an already connected user directly access to openidAuth url, he is redirected to Identity Provider. Then, after authentication, when coming back to eXo, a popup is displayed, saying "Social Network 'OpenId' connected for user 'xxx'". As the user is already connected, he should not be redirected to Identity Provider, but should return to the /portal context. This commit add a test to check if the remoteUser exists in the request. If yes, it redirect the user to /portal

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
