### PR TITLE
feat: Rename Default Branding Company Title and allow to extend login page titles - MEED-1303 - Meeds-io/MIPs#29

### DIFF
--- a/component/web/resources/src/main/java/org/exoplatform/web/application/JspBasedWebHandler.java
+++ b/component/web/resources/src/main/java/org/exoplatform/web/application/JspBasedWebHandler.java
@@ -19,7 +19,6 @@ package org.exoplatform.web.application;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -174,7 +173,7 @@ public abstract class JspBasedWebHandler extends WebRequestHandler {
       SkinURL url = skin.createURL(controllerContext);
       url.setOrientation(orientation);
       return url.toString();
-    }).collect(Collectors.toList());
+    }).toList();
   }
 
   private Set<String> getPageScripts(JavascriptManager javascriptManager,

--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -35,6 +35,7 @@ import org.gatein.wci.security.Credentials;
 import org.json.JSONObject;
 
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.container.xml.InitParams;
@@ -371,7 +372,6 @@ public class LoginHandler extends JspBasedWebHandler {
     JSONObject jsConfig = javascriptConfigService.getJSConfig(controllerContext, request.getLocale());
     if (jsConfig.has(JS_PATHS_PARAM)) {
       JSONObject jsConfigPaths = jsConfig.getJSONObject(JS_PATHS_PARAM);
-      @SuppressWarnings("unchecked")
       Iterator<String> keys = jsConfigPaths.keys();
       while (keys.hasNext()) {
         String module = keys.next();
@@ -391,6 +391,9 @@ public class LoginHandler extends JspBasedWebHandler {
 
       String forgotPasswordPath = passwordRecoveryService.getPasswordRecoverURL(null, null);
       params.put("forgotPasswordPath", request.getContextPath() + forgotPasswordPath);
+
+      params.put("authenticationTitle", PropertyManager.getProperty("portal.authentication.title"));
+      params.put("authenticationSubtitle", PropertyManager.getProperty("portal.authentication.subtitle"));
 
       if (status != LoginStatus.AUTHENTICATED && status != LoginStatus.UNAUTHENTICATED) {
         params.put("errorCode", status.getErrorCode());

--- a/web/portal/src/main/webapp/WEB-INF/conf/branding/branding-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/branding/branding-configuration.xml
@@ -8,7 +8,7 @@
     <init-params>
       <value-param>
         <name>exo.branding.company.name</name>
-        <value>${exo.branding.company.name:Employee Recognition}</value>
+        <value>${exo.branding.company.name:Web3 Hub}</value>
       </value-param>
       <value-param>
         <name>exo.branding.company.siteName</name>


### PR DESCRIPTION
Prior to this change, the default Branding Company Slogan was 'Employee Recognition'. this change will update it to use 'Web3 Hub' as made on deed-tenant addon. In addition, this change will add two labels coming from 'exo.properties' file that allows to customize displayed labels in login page.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
