### PR TITLE
fix: Fix Triggering RememberMe filter on static resources - MEED-1597- Meeds-io/meeds#592

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenDAOImpl.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenDAOImpl.java
@@ -6,8 +6,6 @@ import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
-import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 public class TokenDAOImpl extends GenericDAOJPAImpl<TokenEntity, Long> implements TokenDAO {
@@ -32,12 +30,9 @@ public class TokenDAOImpl extends GenericDAOJPAImpl<TokenEntity, Long> implement
     @Override
     @ExoTransactional
     public void cleanExpired() {
-        TypedQuery<TokenEntity> query = getEntityManager().createNamedQuery("GateInToken.findExpired", TokenEntity.class);
+        Query query = getEntityManager().createNamedQuery("GateInToken.deleteExpiredTokens");
         query.setParameter("expireTime", System.currentTimeMillis());
-        List<TokenEntity> entities = query.getResultList();
-        if (entities != null && !entities.isEmpty()) {
-            this.deleteAll(entities);
-        }
+        query.executeUpdate();
     }
 
     @Override

--- a/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenEntity.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/jpa/TokenEntity.java
@@ -12,8 +12,7 @@ import java.util.Date;
 @NamedQueries({
         @NamedQuery(name = "GateInToken.findByTokenId", query = "SELECT t FROM GateInToken t WHERE t.tokenId = :tokenId"),
         @NamedQuery(name = "GateInToken.findByUser", query = "SELECT t FROM GateInToken t WHERE t.username = :username"),
-        @NamedQuery(name = "GateInToken.findExpired", query = "SELECT t FROM GateInToken t WHERE t.expirationTime < :expireTime"),
-        @NamedQuery(name = "GateInToken.cleanTokens", query = "DELETE FROM GateInToken t WHERE t.expirationTime < :expireTime"),
+        @NamedQuery(name = "GateInToken.deleteExpiredTokens", query = "DELETE FROM GateInToken t WHERE t.expirationTime < :expireTime"),
         @NamedQuery(name = "GateInToken.deleteTokensByUserAndType", query="DELETE FROM GateInToken t WHERE t.username = :username AND t.tokenType = :tokenType")
 })
 public class TokenEntity implements Serializable {

--- a/web/portal/src/main/webapp/WEB-INF/web.xml
+++ b/web/portal/src/main/webapp/WEB-INF/web.xml
@@ -79,6 +79,10 @@
   <filter>
     <filter-name>RememberMeFilter</filter-name>
     <filter-class>org.exoplatform.web.login.RememberMeFilter</filter-class>
+    <init-param>
+      <param-name>ignoredPaths</param-name>
+      <param-value>/skins,/scripts,/rest,/favicon.ico</param-value>
+    </init-param>
   </filter>
 
   <!--  Uncomment ErrorLoginFilter and LoginDetectorFilter for sending mail after successive number of bad login attempts. -->


### PR DESCRIPTION
Prior to this change, the scripts, css and rest calls triggers the RememberMeFilter when displaying login page. The RememberMefilter has to be triggered only on sites pages display to login the user when he has a cookie with name 'rememberme'. This change will at the same time fix the startup of CookieTokenService Based Services which will attempts to delete all at the same time all outdated tokens, which leads to some services to triggers an exception because the change has been already made asynchronously by other services inheriting from CookieTokenService. The fix is to execute by each service a 'DELETE' query on database instead of retrieving the entities and delete them one by one.