### PR TITLE
fix: Avoid minifying third part library on server startup - Meeds-io/meeds#599

### DIFF
--- a/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -881,6 +881,7 @@
   <module>
     <name>eCharts</name>
     <script>
+      <minify>false</minify>
       <adapter>
         (function() {
         <include>/javascript/echarts.min.js</include>


### PR DESCRIPTION
Prior to this change, the already minified echarts.min.js file is minified again on server startup. This fix will disable minification on this library.