### PR TITLE
fix: Fix Remember Me token not considered for REST endpoints - Meeds-io/meeds#603

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/web.xml
+++ b/web/portal/src/main/webapp/WEB-INF/web.xml
@@ -81,7 +81,7 @@
     <filter-class>org.exoplatform.web.login.RememberMeFilter</filter-class>
     <init-param>
       <param-name>ignoredPaths</param-name>
-      <param-value>/skins,/scripts,/rest,/favicon.ico</param-value>
+      <param-value>/skins,/scripts,/favicon.ico</param-value>
     </init-param>
   </filter>
 


### PR DESCRIPTION
Prior to this change, when the session timeout is reached, making ajax actions on UI without refreshing the page leads to a 403 HTTP error. This change will avoid excluding REST calls from RememberMeFilter to allow authenticating user using `rememberme` cookie and token.