### PR TITLE
fix: Trim the username/email field to login - EXO-61937 (#532)

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -156,6 +156,9 @@ public class LoginHandler extends JspBasedWebHandler {
     }
 
     String username = request.getParameter("username");
+    if (username != null) {
+      username = username.trim();
+    }
     String password = request.getParameter("password");
 
     final String portalContextPath = servletContext.getContextPath();


### PR DESCRIPTION
before this change, when a username or email address contains a space in the beginning/end (ex: " root"), the login action is not executed and an error is displayed
after this change, spaces are cleaned (trim() for the username) to send the correct value for the authentication.