### PR TITLE
fix: Fix Default Group cache sizing - MEED-1829 - Meeds-io/meeds#728

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
@@ -316,7 +316,7 @@
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name"><string>portal.Role</string></field>
             <field name="strategy"  profiles="cluster"><string>${exo.cache.portal.role.strategy:LIRS}</string></field>
-            <field name="maxSize"><int>${exo.cache.portal.role.MaxNodes:5000}</int></field>
+            <field name="maxSize"><int>${exo.cache.portal.role.MaxNodes:100}</int></field>
             <field name="liveTime"><long>${exo.cache.portal.role.TimeToLive:3600}</long></field>
             <field name="cacheMode"  profiles="cluster"><string>${exo.cache.portal.role.cacheMode:replication}</string></field>
           </object>
@@ -328,7 +328,7 @@
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name"><string>portal.Group</string></field>
             <field name="strategy"  profiles="cluster"><string>${exo.cache.portal.group.strategy:LIRS}</string></field>
-            <field name="maxSize"><int>${exo.cache.portal.group.MaxNodes:100}</int></field>
+            <field name="maxSize"><int>${exo.cache.portal.group.MaxNodes:5000}</int></field>
             <field name="liveTime"><long>${exo.cache.portal.group.TimeToLive:-1}</long></field>
             <field name="cacheMode"  profiles="cluster"><string>${exo.cache.portal.group.cacheMode:replication}</string></field>
           </object>


### PR DESCRIPTION
Change default Group Cache to use the same configuration as made for spaces. This will avoid a bottleneck in login phase.
At the same time, this reduces the size of MembershipType cache wich has only some elements into it (5 by default)