### PR TITLE
fix: fiw when OpenID not configured an error WellKnowConfigurationUrl malformed displayed - EXO-62336

### DIFF
--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
@@ -429,7 +429,7 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
   @Override
   public void start() {
     if (StringUtils.isBlank(this.wellKnownConfigurationUrl)) {
-      log.error("wellKnownConfigurationUrl is not configured");
+      log.info("wellKnownConfigurationUrl is not configured");
       return;
     }
     try {

--- a/web/portal/src/main/webapp/WEB-INF/conf/sso/oauth-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/sso/oauth-configuration.xml
@@ -157,7 +157,7 @@
       </value-param>
       <value-param>
         <name>wellKnownConfigurationUrl</name>
-        <value>${exo.oauth.openid.wellKnownConfigurationUrl}</value>
+        <value>${exo.oauth.openid.wellKnownConfigurationUrl:}</value>
       </value-param>
     </init-params>
   </component>


### PR DESCRIPTION
before this change, when OpenID is not configured, a malformed WellKnowConfigurationUrl error was displayed
since the WellKnowConfigurationUrl parameter does not have a default value, it is not empty "${exo.oauth.openid.wellKnownConfigurationUrl}", which leads to parameter checking that results in an error.
After this change, an empty default value is added to avoid checking the value when it is not configured.