### PR TITLE
fix: when OpenID is not configured no warning should be displayed - EXO-62336 (#541)  - Meeds-io/meeds#757

### DIFF
--- a/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
+++ b/component/web/oauth-common/src/main/java/org/gatein/security/oauth/openid/OpenIdProcessorImpl.java
@@ -428,24 +428,27 @@ public class OpenIdProcessorImpl implements OpenIdProcessor, Startable {
 
   @Override
   public void start() {
-    if (StringUtils.isBlank(this.wellKnownConfigurationUrl)) {
-      log.error("wellKnownConfigurationUrl is not configured");
-      return;
-    }
-    try {
-      String wellKnownConfigurationContent = readUrl(new URL(this.wellKnownConfigurationUrl));
-      if (wellKnownConfigurationContent != null) {
-        JSONObject json = new JSONObject(wellKnownConfigurationContent);
-        this.authenticationURL = json.getString("authorization_endpoint");
-        this.accessTokenURL = json.getString("token_endpoint");
-        this.userInfoURL = json.getString("userinfo_endpoint");
-        this.issuer = json.getString("issuer");
-        this.remoteJwkSigningKeyResolver = new RemoteJwkSigningKeyResolver(this.wellKnownConfigurationUrl);
+    boolean openIdEnabled = Boolean.parseBoolean(System.getProperty("exo.oauth.openid.enabled"));
+    if (openIdEnabled) {
+      if (StringUtils.isBlank(this.wellKnownConfigurationUrl)) {
+        log.error("wellKnownConfigurationUrl is not configured");
+        return;
       }
-    } catch (JSONException e) {
-      log.error("Unable to read webKnownUrl content : " + this.wellKnownConfigurationUrl);
-    } catch (MalformedURLException e) {
-      log.error("WellKnowConfigurationUrl malformed : url" + this.wellKnownConfigurationUrl);
+      try {
+        String wellKnownConfigurationContent = readUrl(new URL(this.wellKnownConfigurationUrl));
+        if (wellKnownConfigurationContent != null) {
+          JSONObject json = new JSONObject(wellKnownConfigurationContent);
+          this.authenticationURL = json.getString("authorization_endpoint");
+          this.accessTokenURL = json.getString("token_endpoint");
+          this.userInfoURL = json.getString("userinfo_endpoint");
+          this.issuer = json.getString("issuer");
+          this.remoteJwkSigningKeyResolver = new RemoteJwkSigningKeyResolver(this.wellKnownConfigurationUrl);
+        }
+      } catch (JSONException e) {
+        log.error("Unable to read webKnownUrl content : " + this.wellKnownConfigurationUrl, e);
+      } catch (MalformedURLException e) {
+        log.error("WellKnowConfigurationUrl malformed : url" + this.wellKnownConfigurationUrl, e);
+      }
     }
   }
 


### PR DESCRIPTION
before this change, when OpenID is not configured, a malformed WellKnowConfigurationUrl error was displayed since the WellKnowConfigurationUrl parameter does not have a default value, it is not empty "${exo.oauth.openid.wellKnownConfigurationUrl}", which leads to parameter checking that results in an error. After this change, check if the provider is enabled or not to avoid chack in the disabled case.