### PR TITLE
fix: Fix Crowdin Configuration - Meeds-io/MIPs#42

### DIFF
--- a/translations.properties
+++ b/translations.properties
@@ -21,19 +21,9 @@
 baseDir=platform/gatein-portal/
 
 # exoadmin portlets
-#portlet/AccountPortlet.properties=portlet/exoadmin/src/main/resources/locale/portlet/exoadmin/AccountPortlet_en.properties
 portlet/ApplicationRegistryPortlet.properties=portlet/exoadmin/src/main/resources/locale/portlet/exoadmin/ApplicationRegistryPortlet_en.properties
-portlet/OrganizationPortlet.properties=portlet/exoadmin/src/main/resources/locale/portlet/exoadmin/OrganizationPortlet_en.properties
-portlet/RegisterPortlet.properties=portlet/exoadmin/src/main/resources/locale/portlet/exoadmin/RegisterPortlet_en.properties
-#portlet/StarToolbarPortlet.properties=portlet/exoadmin/src/main/resources/locale/portlet/exoadmin/StarToolbarPortlet_en.properties
-#portlet/UserToolbarPortlet.properties=portlet/exoadmin/src/main/resources/locale/portlet/exoadmin/UserToolbarPortlet_en.properties
 
 # web portlets
-#portlet/BreadcumbsPortlet.properties=portlet/web/src/main/resources/locale/portlet/web/BreadcumbsPortlet_en.properties
-#portlet/GroovyPortlet.properties=portlet/web/src/main/resources/locale/portlet/web/GroovyPortlet_en.properties
-portlet/LogoPortlet.properties=portlet/web/src/main/resources/locale/portlet/web/LogoPortlet_en.properties
-#portlet/NavigationPortlet.properties=portlet/web/src/main/resources/locale/portlet/portal/NavigationPortlet_en.properties
-portlet/PortalNavigationPortlet.properties=portlet/web/src/main/resources/locale/portlet/portal/PortalNavigationPortlet_en.properties
 portlet/HamburgerMenu.properties=web/portal/src/main/resources/locale/portal/HamburgerMenu_en.properties
 
 #webui


### PR DESCRIPTION
This change will delete outdated and deprecated I18N properties files from Crowdin configuration and synchro.