### PR TITLE
fix: TOP bar menu isn't displayed - EXO-62924 -  Meeds-io/meeds#787

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/mop/SiteKey.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/SiteKey.java
@@ -63,11 +63,11 @@ public final class SiteKey implements Serializable {
 
     // This will be used for transition in usage from PortalKey and SiteKey
     public SiteKey(String type, String name) {
-        if (PortalConfig.PORTAL_TYPE.equals(type)) {
+        if (PortalConfig.PORTAL_TYPE.equalsIgnoreCase(type)) {
             this.type = SiteType.PORTAL;
-        } else if (PortalConfig.GROUP_TYPE.equals(type)) {
+        } else if (PortalConfig.GROUP_TYPE.equalsIgnoreCase(type)) {
             this.type = SiteType.GROUP;
-        } else if (PortalConfig.USER_TYPE.equals(type)) {
+        } else if (PortalConfig.USER_TYPE.equalsIgnoreCase(type)) {
             this.type = SiteType.USER;
         } else {
             throw new NullPointerException("No null name can be provided");


### PR DESCRIPTION
prior to this change, the top bar menu is not displayed and an error 500 is thrown since it can not create a new sitekey with siteTypeName in uppercase
after this change, the siteTypeName is  compared with ignoring cases and the top bar menu is displayed