### PR TITLE
feat: Allow to display Page in a standalone - Meeds-io/meeds#755 - MEED-1912

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -79,6 +79,10 @@ import org.exoplatform.webui.application.WebuiApplication;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.url.ComponentURL;
+
+import lombok.Getter;
+import lombok.Setter;
+
 import org.gatein.common.http.QueryStringParser;
 import org.w3c.dom.Element;
 
@@ -138,6 +142,10 @@ public class PortalRequestContext extends WebuiRequestContext {
     private String cacheLevel_ = "cacheLevelPortlet";
 
     private boolean ajaxRequest_ = true;
+
+    @Getter
+    @Setter
+    private boolean standalonePage;
 
     private boolean forceFullUpdate = false;
 
@@ -227,6 +235,7 @@ public class PortalRequestContext extends WebuiRequestContext {
         }
 
         ajaxRequest_ = "true".equals(request_.getParameter("ajaxRequest"));
+        standalonePage = "true".equals(request_.getParameter("standalonePage"));
         String cache = request_.getParameter(CACHE_LEVEL);
         if (cache != null) {
             cacheLevel_ = cache;

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/page/UIPageBody.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/page/UIPageBody.java
@@ -20,6 +20,7 @@
 package org.exoplatform.portal.webui.page;
 
 import org.exoplatform.container.ExoContainer;
+import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.portal.config.model.Page;
 import org.exoplatform.portal.config.model.PageBody;
@@ -73,7 +74,7 @@ public class UIPageBody extends UIComponentDecorator {
     }
 
     public void setPageBody(UserNode pageNode, UIPortal uiPortal) throws Exception {
-        WebuiRequestContext context = Util.getPortalRequestContext();
+        PortalRequestContext context = Util.getPortalRequestContext();
         uiPortal.setMaximizedUIComponent(null);
 
         UIPage uiPage;
@@ -87,6 +88,7 @@ public class UIPageBody extends UIComponentDecorator {
         pageName = uiPage.getName();
         if (uiPage.isShowMaxWindow()) {
             uiPortal.setMaximizedUIComponent(uiPage);
+            context.setStandalonePage(true);
         } else {
             UIComponent maximizedComponent = uiPortal.getMaximizedUIComponent();
             if (maximizedComponent != null && maximizedComponent instanceof UIPage) {

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/page/UISiteBody.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/page/UISiteBody.java
@@ -22,6 +22,7 @@ package org.exoplatform.portal.webui.page;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.web.application.RequestContext;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.core.UIComponentDecorator;
@@ -35,9 +36,6 @@ public class UISiteBody extends UIComponentDecorator {
     /** The storage id. */
     private String storageId;
 
-    public UISiteBody() {
-    }
-
     public String getStorageId() {
         return storageId;
     }
@@ -46,12 +44,32 @@ public class UISiteBody extends UIComponentDecorator {
         this.storageId = storageId;
     }
 
+    @Override
+    public void processRender(WebuiRequestContext context) throws Exception {
+      PortalRequestContext requestContext = RequestContext.getCurrentInstance();
+      if (!requestContext.isStandalonePage()) {
+        processContainerRender(context);
+      } else {
+        processPageBodyRender(context);
+      }
+    }
+
     public String getSiteClass() {
-      String portalOwner = ((PortalRequestContext) PortalRequestContext.getCurrentInstance()).getPortalOwner();
+      String portalOwner = ((PortalRequestContext) RequestContext.getCurrentInstance()).getPortalOwner();
       if (StringUtils.isBlank(portalOwner)) {
         return "";
       } else {
         return portalOwner.toUpperCase() + "Site";
       }
     }
+
+    protected void processPageBodyRender(WebuiRequestContext context) throws Exception {
+      UIPageBody uiPageBody = findFirstComponentOfType(UIPageBody.class);
+      uiPageBody.processRender(context);
+    }
+
+    protected void processContainerRender(WebuiRequestContext context) throws Exception {
+      super.processRender(context);
+    }
+
 }

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UISharedLayout.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UISharedLayout.java
@@ -19,12 +19,34 @@
 
 package org.exoplatform.portal.webui.portal;
 
+import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.webui.container.UIContainer;
+import org.exoplatform.portal.webui.page.UISiteBody;
+import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 
 @ComponentConfig(
 
 )
 public class UISharedLayout extends UIContainer {
+
+  @Override
+  public void processRender(WebuiRequestContext context) throws Exception {
+    PortalRequestContext requestContext = WebuiRequestContext.getCurrentInstance();
+    if (!requestContext.isStandalonePage()) {
+      processContainerRender(context);
+    } else {
+      processSiteBodyRender(context);
+    }
+  }
+
+  protected void processSiteBodyRender(WebuiRequestContext context) throws Exception {
+    UISiteBody uiSiteBody = findFirstComponentOfType(UISiteBody.class);
+    uiSiteBody.processRender(context);
+  }
+
+  protected void processContainerRender(WebuiRequestContext context) throws Exception {
+    super.processRender(context);
+  }
 
 }

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -45,6 +45,7 @@ import org.exoplatform.portal.webui.page.UIPageActionListener.ChangeNodeActionLi
 import org.exoplatform.portal.webui.page.UISiteBody;
 import org.exoplatform.portal.webui.portal.PageNodeEvent;
 import org.exoplatform.portal.webui.portal.UIPortal;
+import org.exoplatform.portal.webui.portal.UISharedLayout;
 import org.exoplatform.portal.webui.util.PortalDataMapper;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.log.ExoLogger;
@@ -56,7 +57,6 @@ import org.exoplatform.services.resources.LocaleContextInfo;
 import org.exoplatform.services.resources.Orientation;
 import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.application.JavascriptManager;
-import org.exoplatform.web.application.RequireJS;
 import org.exoplatform.web.application.javascript.JavascriptConfigParser;
 import org.exoplatform.web.application.javascript.JavascriptConfigService;
 import org.exoplatform.web.url.MimeType;
@@ -791,12 +791,11 @@ public class UIPortalApplication extends UIApplication {
     private void initSharedLayout() throws Exception {
       Container container = layoutService.getSharedLayout(this.lastPortalOwner);
       if (container != null) {
-          org.exoplatform.portal.webui.container.UIContainer uiContainer = createUIComponent(
-                  org.exoplatform.portal.webui.container.UIContainer.class, null, null);
-          uiContainer.setStorageId(container.getStorageId());
-          PortalDataMapper.toUIContainer(uiContainer, container);
-          uiContainer.setRendered(true);
-          this.uiViewWorkingWorkspace.setUIComponent(uiContainer);
+        UISharedLayout uiContainer = createUIComponent(UISharedLayout.class, null, null);
+        uiContainer.setStorageId(container.getStorageId());
+        PortalDataMapper.toUIContainer(uiContainer, container);
+        uiContainer.setRendered(true);
+        this.uiViewWorkingWorkspace.setUIComponent(uiContainer);
       }
       refreshCachedUI();
     }

--- a/webui/portal/src/test/java/org/exoplatform/portal/webui/workspace/UISharedLayoutTest.java
+++ b/webui/portal/src/test/java/org/exoplatform/portal/webui/workspace/UISharedLayoutTest.java
@@ -1,0 +1,85 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.portal.webui.workspace;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.portal.webui.portal.UISharedLayout;
+import org.exoplatform.web.application.RequestContext;
+import org.exoplatform.webui.application.WebuiRequestContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UISharedLayoutTest {
+
+  private static final MockedStatic<RequestContext> PORTAL_REQUEST_CONTEXT = mockStatic(RequestContext.class);
+
+  @Mock
+  private PortalRequestContext                      pcontext;
+
+  @AfterClass
+  public static void afterRunBare() {
+    PORTAL_REQUEST_CONTEXT.close();
+  }
+
+  @Before
+  public void setUp() {
+    PORTAL_REQUEST_CONTEXT.when(() -> RequestContext.getCurrentInstance()).thenReturn(pcontext);
+  }
+
+  @Test
+  public void testStandaloneRender() throws Exception {
+    AtomicInteger siteBodyRenderCount = new AtomicInteger(0);
+    AtomicInteger overallRenderCount = new AtomicInteger(0);
+
+    UISharedLayout sharedLayout = new UISharedLayout() {
+      @Override
+      protected void processSiteBodyRender(WebuiRequestContext context) throws Exception {
+        siteBodyRenderCount.incrementAndGet();
+      }
+
+      @Override
+      protected void processContainerRender(WebuiRequestContext context) throws Exception {
+        overallRenderCount.incrementAndGet();
+      }
+    };
+    sharedLayout.processRender(pcontext);
+
+    assertEquals(1, overallRenderCount.get());
+    assertEquals(0, siteBodyRenderCount.get());
+
+    when(pcontext.isStandalonePage()).thenReturn(true);
+    sharedLayout.processRender(pcontext);
+
+    assertEquals(1, overallRenderCount.get());
+    assertEquals(1, siteBodyRenderCount.get());
+  }
+
+}

--- a/webui/portal/src/test/java/org/exoplatform/portal/webui/workspace/UISiteBodyTest.java
+++ b/webui/portal/src/test/java/org/exoplatform/portal/webui/workspace/UISiteBodyTest.java
@@ -1,0 +1,85 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.portal.webui.workspace;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.portal.webui.page.UISiteBody;
+import org.exoplatform.web.application.RequestContext;
+import org.exoplatform.webui.application.WebuiRequestContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UISiteBodyTest {
+
+  private static final MockedStatic<RequestContext> PORTAL_REQUEST_CONTEXT = mockStatic(RequestContext.class);
+
+  @Mock
+  private PortalRequestContext                      pcontext;
+
+  @AfterClass
+  public static void afterRunBare() {
+    PORTAL_REQUEST_CONTEXT.close();
+  }
+
+  @Before
+  public void setUp() {
+    PORTAL_REQUEST_CONTEXT.when(() -> RequestContext.getCurrentInstance()).thenReturn(pcontext);
+  }
+
+  @Test
+  public void testStandaloneRender() throws Exception {
+    AtomicInteger pageBodyRenderCount = new AtomicInteger(0);
+    AtomicInteger overallRenderCount = new AtomicInteger(0);
+
+    UISiteBody uiSiteBody = new UISiteBody() {
+      @Override
+      protected void processPageBodyRender(WebuiRequestContext context) throws Exception {
+        pageBodyRenderCount.incrementAndGet();
+      }
+
+      @Override
+      protected void processContainerRender(WebuiRequestContext context) throws Exception {
+        overallRenderCount.incrementAndGet();
+      }
+    };
+    uiSiteBody.processRender(pcontext);
+
+    assertEquals(1, overallRenderCount.get());
+    assertEquals(0, pageBodyRenderCount.get());
+
+    when(pcontext.isStandalonePage()).thenReturn(true);
+    uiSiteBody.processRender(pcontext);
+
+    assertEquals(1, overallRenderCount.get());
+    assertEquals(1, pageBodyRenderCount.get());
+  }
+
+}


### PR DESCRIPTION
Prior to this change, the Show Maximized Window parameter in pages configuration processes shared and site layouts. This change will disable display and processing of upper layouts of the page to display only the content of the designated page.
In addition, this change will allow to enable this mode on any page using a request parameter `standalonePage=true`.