### PR TITLE
fix: Move Scrollbar controlling in Portal UI - MEED-1956 - Meeds-io/meeds#755

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl
@@ -1,7 +1,5 @@
 <%
   _ctx.getRequestContext().getJavascriptManager()
-    .require("SHARED/bodyScrollListener", "bodyScrollListener");
-  _ctx.getRequestContext().getJavascriptManager()
     .require("SHARED/topbarLoading", "topbarLoading").addScripts("topbarLoading.init()");
 %>
 <div class="VuetifyApp TopbarLoadingContainer" id="$uicomponent.id">

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
@@ -1,6 +1,7 @@
 <%
   def rcontext = _ctx.getRequestContext() ;
   def jsManager = rcontext.getJavascriptManager();
+  jsManager.require("SHARED/bodyScrollListener", "bodyScrollListener");
   uicomponent.renderChildren();
 %>
 </div>


### PR DESCRIPTION
Prior to this change, in standalone pages, the scoll control script wasn't instanciated. This change will allow to controll scrollbar even in standalone pages (hidden shared layout and hidden site body).