### PR TITLE
fix: Default Cache configuration of Groups

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
@@ -317,7 +317,7 @@
             <field name="name"><string>portal.Role</string></field>
             <field name="strategy"  profiles="cluster"><string>${exo.cache.portal.role.strategy:LIRS}</string></field>
             <field name="maxSize"><int>${exo.cache.portal.role.MaxNodes:5000}</int></field>
-            <field name="liveTime"><long>${exo.cache.portal.role.TimeToLive:3600}</long></field>
+            <field name="liveTime"><long>${exo.cache.portal.role.TimeToLive:-1}</long></field>
             <field name="cacheMode"  profiles="cluster"><string>${exo.cache.portal.role.cacheMode:replication}</string></field>
           </object>
         </object-param>
@@ -328,7 +328,7 @@
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name"><string>portal.Group</string></field>
             <field name="strategy"  profiles="cluster"><string>${exo.cache.portal.group.strategy:LIRS}</string></field>
-            <field name="maxSize"><int>${exo.cache.portal.group.MaxNodes:100}</int></field>
+            <field name="maxSize"><int>${exo.cache.portal.group.MaxNodes:5000}</int></field>
             <field name="liveTime"><long>${exo.cache.portal.group.TimeToLive:-1}</long></field>
             <field name="cacheMode"  profiles="cluster"><string>${exo.cache.portal.group.cacheMode:replication}</string></field>
           </object>


### PR DESCRIPTION
Knowing that Group entities are highly solicited, the groups cache has to increase its size to not indue a performance regression by default. In addition, the Roles are almost immuable, thus its time to live has to be unlimited as other immutable caches (such as `TemplateService`).