### PR TITLE
fix: Error in log when migrate from 1.2.5 to 1.3.x with psql database - EXO-62553 - meeds-io/meeds#692

### DIFF
--- a/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
+++ b/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
@@ -329,4 +329,18 @@
     <createSequence sequenceName="SEQ_PORTAL_PERMISSIONS_ID" startValue="1" />
   </changeSet>
 
+  <changeSet author="portal" id="1.0.0-30" dbms="postgresql">
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="bytea">
+        SELECT DATA_TYPE FROM information_schema.columns where table_name = 'portal_windows' and column_name = 'customization'
+      </sqlCheck>
+    </preConditions>
+    <sql>
+      ALTER TABLE PORTAL_WINDOWS ADD COLUMN customization_oid oid;
+      UPDATE PORTAL_WINDOWS SET customization_oid = lo_from_bytea(0, customization);
+      ALTER TABLE PORTAL_WINDOWS DROP COLUMN customization;
+      ALTER TABLE PORTAL_WINDOWS RENAME COLUMN customization_oid TO customization;
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/patches-changelog.txt
+++ b/patches-changelog.txt
@@ -2,4 +2,9 @@
 
    # 6.3.4 Patches changelog: 
 
+* 2023-02-17: Patch-6.3.4:1, Author: Jihed Chabbeh<jchabbeh@exoplatform.com>
+
+	-  https://github.com/exoplatform/web-conferencing/commit/fcbf298f227f8a557dbe5cecbbb321e9f7ad4ad1
+
+	-  https://github.com/Meeds-io/gatein-portal/pull/536
 


### PR DESCRIPTION
Before this fix, there was an error when performing migration from meed 1.2.5 to meeds 1.3.x with psql database This pb is due to liquibase update version in 1.3.x. With this update, blob type are now created in psql with oid type instead of bytea type When starting a fresh 1.3.x the type is correctly oid, so no problem to read it When performing a migration from 1.2.5, the type is still bytea and is not read correctly. The impact is on table PORTAL_WINDOWS, column customization

This fix add a liquibase update, which will be executed only if the type of this column is bytea. The update create a new temporary table, copy content into, and convert the bytea field to oid. Then drop the original table, then rename the temporary table with the original name.
cherry-picked from [PR](https://github.com/Meeds-io/gatein-portal/pull/536)