### PR TITLE
feat: Update navigation REST service to retrieve only current site navigation - EXO-63564 - Meeds-io/meeds#51 

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortal.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortal.java
@@ -113,9 +113,10 @@ public interface UserPortal {
      * @param siteType site type: PORTAL, GROUP or USER
      * @param scope an optional scope
      * @param filterConfig an optional filter
+     * @param includeGlobal to include global nodes
      * @return a {@link Collection} of {@link UserNode}
      */
-    Collection<UserNode> getNodes(SiteType siteType, Scope scope, UserNodeFilterConfig filterConfig);
+    Collection<UserNode> getNodes(SiteType siteType, Scope scope, UserNodeFilterConfig filterConfig, boolean includeGlobal);
 
     /**
      * Load the list of user nodes computed from the list of
@@ -126,14 +127,14 @@ public interface UserPortal {
      * @param      scope            an optional scope
      * @param      filterConfig     an optional filter
      * @return                      a {@link Collection} of {@link UserNode}
-     * @deprecated                  use {@link #getNodes(SiteType, Scope, UserNodeFilterConfig)}
+     * @deprecated                  use {@link #getNodes(SiteType, Scope, UserNodeFilterConfig, boolean)}
      *                              instead since no need of filtering on Spaces nodes due to
      *                              introduction of new {@link SiteType#SPACE} that allows to
      *                              get space navigations
      */
     @Deprecated(forRemoval = true, since ="6.5")
     default Collection<UserNode> getNodes(SiteType siteType, String excludedSiteName, Scope scope, UserNodeFilterConfig filterConfig) {
-      return getNodes(siteType, scope, filterConfig);
+      return getNodes(siteType, scope, filterConfig, true);
     }
 
     /**

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
@@ -140,7 +140,7 @@ public class UserPortalImpl implements UserPortal {
   }
 
   @Override
-  public Collection<UserNode> getNodes(SiteType siteType, Scope scope, UserNodeFilterConfig filterConfig) {
+  public Collection<UserNode> getNodes(SiteType siteType, Scope scope, UserNodeFilterConfig filterConfig, boolean includeGlobal) {
 
     Collection<UserNode> resultUserNodes = new ArrayList<>();
     Set<String> addedUserNodesURI = new HashSet<>();
@@ -148,7 +148,8 @@ public class UserPortalImpl implements UserPortal {
       SiteKey siteKey = userNavigation.getKey();
       if (siteKey.getType() != siteType
           || (siteType == SiteType.GROUP && siteKey.getName().startsWith(SPACES_SITE_TYPE_PREFIX))
-          || (siteType == SiteType.SPACE && !siteKey.getName().startsWith(SPACES_SITE_TYPE_PREFIX))) {
+          || (siteType == SiteType.SPACE && !siteKey.getName().startsWith(SPACES_SITE_TYPE_PREFIX))
+          || (!includeGlobal && siteKey.getName().equalsIgnoreCase(service.getGlobalPortal()))) {
         continue;
       }
 

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
@@ -286,7 +286,7 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
         assertEquals(PortalConfig.PORTAL_TYPE, portalCfg.getType());
         assertEquals("classic", portalCfg.getName());
         UserPortal userPortal = userPortalCfg.getUserPortal();
-        Collection<UserNode> nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig);
+        Collection<UserNode> nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig, true);
         assertNotNull(nodes);
 
         int initialNodesSize = nodes.size();
@@ -298,7 +298,7 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
           userPortalCfg = userPortalConfigSer_.getUserPortalConfig("classic", "root");
           portalCfg = userPortalCfg.getPortalConfig();
           userPortal = userPortalCfg.getUserPortal();
-          nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig);
+          nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig, true);
           assertNotNull(nodes);
 
           assertEquals(initialNodesSize + 1, nodes.size());


### PR DESCRIPTION

Prior to this change, for portal site type when retrieving the navigation nodes  of a specific siteName, the navigation rest service returns by default also the navigation nodes of default site "Global". After this change, we have added includeGlobal query param for the navigation rest service in order to allow including or excluding the Global site extra navigation nodes.