### PR TITLE
fix: correctly remove the remember me token if it does not manage to authenticate - EXO-63622 - Meeds-io/meeds#882

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/RememberMeFilter.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/RememberMeFilter.java
@@ -92,7 +92,7 @@ public class RememberMeFilter extends AbstractFilter {
             // Clear token cookie if we did not authenticate
             if (req.getRemoteUser() == null) {
                 Cookie cookie = new Cookie(LoginUtils.COOKIE_NAME, "");
-                cookie.setPath(req.getContextPath());
+                cookie.setPath("/");
                 cookie.setMaxAge(0);
                 cookie.setHttpOnly(true);
                 cookie.setSecure(req.isSecure());
@@ -132,7 +132,7 @@ public class RememberMeFilter extends AbstractFilter {
                 // Clear token cookie if we did not authenticate
                 if (req.getRemoteUser() == null) {
                     Cookie cookie = new Cookie(LoginUtils.OAUTH_COOKIE_NAME, "");
-                    cookie.setPath(req.getContextPath());
+                    cookie.setPath("/");
                     cookie.setMaxAge(0);
                     cookie.setHttpOnly(true);
                     cookie.setSecure(req.isSecure());


### PR DESCRIPTION
Before this fix, when the remember me token fail to authenticate the user, we try to invalidate the user cookie by setting max age to 0. But the context used for this was /portal instead of / so the cookie was not invalidated
This fix change the contextPath to the good one, so that the cookie is correctly removed.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
