### PR TITLE
feat: Enhance the implementation of getNodes with includeGlobal API method -  EXO-63994 - Meeds-io/MIPs#51

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortal.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortal.java
@@ -113,6 +113,17 @@ public interface UserPortal {
      * @param siteType site type: PORTAL, GROUP or USER
      * @param scope an optional scope
      * @param filterConfig an optional filter
+     * @return a {@link Collection} of {@link UserNode}
+     */
+    Collection<UserNode> getNodes(SiteType siteType, Scope scope, UserNodeFilterConfig filterConfig);
+    
+    /**
+     * Load the list of user nodes computed from the list of
+     * {@link UserNavigation} of type siteType (PORTAL, GROUP or USER)
+     * 
+     * @param siteType site type: PORTAL, GROUP or USER
+     * @param scope an optional scope
+     * @param filterConfig an optional filter
      * @param includeGlobal to include global nodes
      * @return a {@link Collection} of {@link UserNode}
      */
@@ -127,14 +138,14 @@ public interface UserPortal {
      * @param      scope            an optional scope
      * @param      filterConfig     an optional filter
      * @return                      a {@link Collection} of {@link UserNode}
-     * @deprecated                  use {@link #getNodes(SiteType, Scope, UserNodeFilterConfig, boolean)}
+     * @deprecated                  use {@link #getNodes(SiteType, Scope, UserNodeFilterConfig)}
      *                              instead since no need of filtering on Spaces nodes due to
      *                              introduction of new {@link SiteType#SPACE} that allows to
      *                              get space navigations
      */
     @Deprecated(forRemoval = true, since ="6.5")
     default Collection<UserNode> getNodes(SiteType siteType, String excludedSiteName, Scope scope, UserNodeFilterConfig filterConfig) {
-      return getNodes(siteType, scope, filterConfig, true);
+      return getNodes(siteType, scope, filterConfig);
     }
 
     /**

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
@@ -140,6 +140,11 @@ public class UserPortalImpl implements UserPortal {
   }
 
   @Override
+  public Collection<UserNode> getNodes(SiteType siteType, Scope scope, UserNodeFilterConfig filterConfig) {
+    return getNodes(siteType, scope, filterConfig, true);
+  }
+  
+  @Override
   public Collection<UserNode> getNodes(SiteType siteType, Scope scope, UserNodeFilterConfig filterConfig, boolean includeGlobal) {
 
     Collection<UserNode> resultUserNodes = new ArrayList<>();

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
@@ -286,7 +286,7 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
         assertEquals(PortalConfig.PORTAL_TYPE, portalCfg.getType());
         assertEquals("classic", portalCfg.getName());
         UserPortal userPortal = userPortalCfg.getUserPortal();
-        Collection<UserNode> nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig, true);
+        Collection<UserNode> nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig);
         assertNotNull(nodes);
 
         int initialNodesSize = nodes.size();
@@ -298,7 +298,7 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
           userPortalCfg = userPortalConfigSer_.getUserPortalConfig("classic", "root");
           portalCfg = userPortalCfg.getPortalConfig();
           userPortal = userPortalCfg.getUserPortal();
-          nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig, true);
+          nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig);
           assertNotNull(nodes);
 
           assertEquals(initialNodesSize + 1, nodes.size());
@@ -309,6 +309,51 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
           UserNode lastUserNode = new ArrayList<>(nodes).get(initialNodesSize);
           assertEquals("systemhome", lastUserNode.getName());
           assertEquals("systemtest", lastUserNode.getNavigation().getKey().getName());
+        } finally {
+          userPortalConfigSer_.globalPortal_ = originalGlobalPortal;
+        }
+      }
+    }.execute("root");
+  }
+  
+  public void testGetUserNodesGlobalNotIncluded() {
+    new UnitTest() {
+      public void execute() throws Exception {
+        UserNodeFilterConfig.Builder filterConfigBuilder = UserNodeFilterConfig.builder();
+        filterConfigBuilder.withReadWriteCheck().withVisibility(Visibility.DISPLAYED, Visibility.TEMPORAL);
+        filterConfigBuilder.withTemporalCheck();
+        UserNodeFilterConfig filterConfig = filterConfigBuilder.build();
+
+        UserPortalConfig userPortalCfg = userPortalConfigSer_.getUserPortalConfig("classic", "john");
+        assertNotNull(userPortalCfg);
+        PortalConfig portalCfg = userPortalCfg.getPortalConfig();
+        assertNotNull(portalCfg);
+        assertEquals(PortalConfig.PORTAL_TYPE, portalCfg.getType());
+        assertEquals("classic", portalCfg.getName());
+        UserPortal userPortal = userPortalCfg.getUserPortal();
+        Collection<UserNode> nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig, false);
+        assertNotNull(nodes);
+
+        int initialNodesSize = nodes.size();
+        assertTrue(initialNodesSize > 0);
+
+        String originalGlobalPortal = userPortalConfigSer_.globalPortal_;
+        userPortalConfigSer_.globalPortal_ = "systemtest";
+        try {
+          userPortalCfg = userPortalConfigSer_.getUserPortalConfig("classic", "root");
+          portalCfg = userPortalCfg.getPortalConfig();
+          userPortal = userPortalCfg.getUserPortal();
+          nodes = userPortal.getNodes(SiteType.PORTAL, Scope.ALL, filterConfig, false);
+          assertNotNull(nodes);
+
+          assertEquals(initialNodesSize, nodes.size());
+          UserNode homeNode = nodes.iterator().next();
+          assertEquals("home", homeNode.getName());
+          assertEquals("classic", homeNode.getNavigation().getKey().getName());
+
+          UserNode lastUserNode = new ArrayList<>(nodes).get(nodes.size() - 1);
+          assertEquals("webexplorer", lastUserNode.getName());
+          assertEquals("classic", lastUserNode.getNavigation().getKey().getName());
         } finally {
           userPortalConfigSer_.globalPortal_ = originalGlobalPortal;
         }


### PR DESCRIPTION

Prior to this change, the default getNodes API method has been changed to introduce a new param **includeGlobal** in order to allow retrieving site navigation nodes without global site ones.
To avoid API breaking, we need to restore the default getNodes API method and introduce a new getNodes API method with the needed **includeGlobal** param with a dedicated UT.