### PR TITLE
feat: Implement temporalCheck API param to getNavigations rest API - EXO-63240 - Meeds-io/MIPs#51

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/rest/NavigationRest.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/rest/NavigationRest.java
@@ -56,7 +56,7 @@ public class NavigationRest implements ResourceContainer {
 
   private static final Visibility[]         DEFAULT_VISIBILITIES = Visibility.values();
 
-  private static final UserNodeFilterConfig USER_FILTER_CONFIG   = getUserFilterConfig(DEFAULT_VISIBILITIES);
+  private static final UserNodeFilterConfig USER_FILTER_CONFIG   = getUserFilterConfig(DEFAULT_VISIBILITIES, false);
 
   private UserPortalConfigService           portalConfigService;
 
@@ -159,13 +159,17 @@ public class NavigationRest implements ResourceContainer {
                                          boolean includeGlobal,
                                          @Parameter(description = "to include extra node page details in results")
                                          @QueryParam("expandPageDetails")
-                                         boolean expandPageDetails) {
+                                         boolean expandPageDetails,
+                                         @Parameter(description = "to check the navigation nodes scheduling start and end dates")
+                                         @DefaultValue("true")
+                                         @QueryParam("temporalCheck")
+                                         boolean temporalCheck) {
     // this function return nodes and not navigations
     if (StringUtils.isBlank(siteTypeName)) {
       return Response.status(400).build();
     }
 
-    return getNavigations(request, siteTypeName, siteName, scopeName, nodeId, visibilityNames, includeGlobal, expandPageDetails);
+    return getNavigations(request, siteTypeName, siteName, scopeName, nodeId, visibilityNames, includeGlobal, expandPageDetails, temporalCheck);
   }
 
   @Path("/categories")
@@ -195,7 +199,8 @@ public class NavigationRest implements ResourceContainer {
                                   String nodeId,
                                   List<String> visibilityNames,
                                   boolean includeGlobal,
-                                  boolean expandPageDetails) {
+                                  boolean expandPageDetails,
+                                  boolean temporalCheck) {
     ConversationState state = ConversationState.getCurrent();
     Identity userIdentity = state == null ? null : state.getIdentity();
     String username = userIdentity == null ? null : userIdentity.getUserId();
@@ -227,8 +232,8 @@ public class NavigationRest implements ResourceContainer {
     }
 
     UserNodeFilterConfig userFilterConfig = USER_FILTER_CONFIG;
-    if (visibilities.length > 0) {
-      userFilterConfig = getUserFilterConfig(visibilities);
+    if (visibilities.length > 0 || temporalCheck) {
+      userFilterConfig = getUserFilterConfig(visibilities, temporalCheck);
     }
 
     String portalName = siteName;
@@ -320,9 +325,12 @@ public class NavigationRest implements ResourceContainer {
     return result;
   }
 
-  private static UserNodeFilterConfig getUserFilterConfig(Visibility[] visibilities) {
+  private static UserNodeFilterConfig getUserFilterConfig(Visibility[] visibilities, boolean temporalCheck) {
     UserNodeFilterConfig.Builder builder = UserNodeFilterConfig.builder();
-    builder.withReadWriteCheck().withVisibility(visibilities).withTemporalCheck().withReadCheck();
+    builder.withReadWriteCheck().withVisibility(visibilities).withReadCheck();
+    if(temporalCheck) {
+      builder.withTemporalCheck();
+    }
     return builder.build();
   }
 

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/rest/NavigationRest.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/rest/NavigationRest.java
@@ -56,8 +56,6 @@ public class NavigationRest implements ResourceContainer {
 
   private static final Visibility[]         DEFAULT_VISIBILITIES = Visibility.values();
 
-  private static final UserNodeFilterConfig USER_FILTER_CONFIG   = getUserFilterConfig(DEFAULT_VISIBILITIES, false);
-
   private UserPortalConfigService           portalConfigService;
 
   private NavigationCategoryService         navigationCategoryService;
@@ -231,10 +229,7 @@ public class NavigationRest implements ResourceContainer {
                      .build();
     }
 
-    UserNodeFilterConfig userFilterConfig = USER_FILTER_CONFIG;
-    if (visibilities.length > 0 || temporalCheck) {
-      userFilterConfig = getUserFilterConfig(visibilities, temporalCheck);
-    }
+    UserNodeFilterConfig userFilterConfig = getUserFilterConfig(visibilities, temporalCheck);
 
     String portalName = siteName;
     if (siteType != SiteType.PORTAL || StringUtils.isBlank(siteName)) {
@@ -327,7 +322,7 @@ public class NavigationRest implements ResourceContainer {
 
   private static UserNodeFilterConfig getUserFilterConfig(Visibility[] visibilities, boolean temporalCheck) {
     UserNodeFilterConfig.Builder builder = UserNodeFilterConfig.builder();
-    builder.withReadWriteCheck().withVisibility(visibilities).withReadCheck();
+    builder.withReadWriteCheck().withVisibility(visibilities.length > 0 ? visibilities : DEFAULT_VISIBILITIES).withReadCheck();
     if(temporalCheck) {
       builder.withTemporalCheck();
     }


### PR DESCRIPTION
Prior to this change, when retrieving navigation nodes, a temporal check for scheduled nodes is always applied in order to retrieve only those respecting the start and end scheduling dates interval.
For some cases, we need to always retrieve scheduled nodes regardless start and end scheduling dates, for that we have added the temporalCheck boolean param for getNavigations rest API to specify if the temporal check should be applied or not.