### PR TITLE
fix: Clean insert left/right dropdown from UISimpleColumn container - EXO-64611 - Meeds-io/MIPs#51

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl
@@ -89,28 +89,9 @@
                     <i class="uiIconContainerConfig uiIconWhite"></i>
                     <span><%=HTMLEntityEncoder.getInstance().encode(strTitle)%></span>
                     <%if(hasPermission) {%>
-                      <div class="dropdown" style="display: inline-block">
-                        <a data-toggle="dropdown" class="dropdown-toggle" rel='tooltip' data-placement='bottom' title="<%= _ctx.appRes("UIColumnContainer.tooltip.insertColumn") %>">
-                          <i class="uiIconArrowDown uiIconWhite"></i>
-                        </a>
-                        <% /*Begin Popup Menu*/ %>
-                        <ul class="dropdown-menu" role="menu">
-                          <li>                            
-                            <a class="OptionItem" href="javascript:void(0);" onclick="<%= uicomponent.event("InsertColumn", org.exoplatform.portal.webui.container.UIColumnContainer.INSERT_BEFORE) %>">
-                              <%= _ctx.appRes("UIColumnContainer.label.insertLeft") %>
-                            </a>
-                          </li>
-                          <li>                            
-                            <a class="OptionItem" href="javascript:void(0);" onclick="<%= uicomponent.event("InsertColumn", org.exoplatform.portal.webui.container.UIColumnContainer.INSERT_AFTER) %>">
-                              <%= _ctx.appRes("UIColumnContainer.label.insertRight") %>
-                            </a>
-                          </li>
-                        </ul>                                             
-                        <% /*End Popup Menu*/ %>
-                      </div>
                       <a href="javascript:void(0);" onclick="<%=uicomponent.event("EditContainer")%>" rel="tooltip" data-placement="bottom" title="<%=_ctx.appRes("UIColumnContainer.tooltip.editContainer")%>"><i class="uiIconEdit uiIconWhite"></i></a>
                       <a href="javascript:void(0);" onclick="<%=uicomponent.event("DeleteComponent")%>" rel="tooltip" data-placement="bottom" title="<%=_ctx.appRes("UIColumnContainer.tooltip.closeContainer")%>"><i class="uiIconTrash uiIconWhite"></i></a>
-                    <%}%>                   
+                    <%}%>
                   </div>
                 <%/*End InfoBar*/ %>
               </div>


### PR DESCRIPTION

Prior to this fix, bts_dropdown requirejs is removed from UISimpleColumn container since bootstrap is nomore needed in Meeds which makes the insert right/left action not working since it is based on the bts_dropdown js. After this commit, since this action can be performed by interface when adding or editing a page which is not available for meeds, we have cleaned the UISimpleColumn container by removing this useless action.