### PR TITLE
feat: Use Branding Name in Mail Subject instead of Property - MEED-2258 - Meeds-io/meeds#992

### DIFF
--- a/component/common/src/main/java/org/exoplatform/commons/utils/MailUtils.java
+++ b/component/common/src/main/java/org/exoplatform/commons/utils/MailUtils.java
@@ -22,7 +22,7 @@ public class MailUtils {
 
   public static String getSenderName() {
     SettingValue<?> name = getSettingService().get(Context.GLOBAL, Scope.GLOBAL.id(null), SENDER_NAME_PARAM);
-    return name != null ? (String) name.getValue() : System.getProperty("exo.notifications.portalname", getBrandingCompanyName());
+    return name != null ? (String) name.getValue() : getBrandingCompanyName();
   }
 
   public static String getSenderEmail() {

--- a/component/common/src/test/java/org/exoplatform/commons/utils/MailUtilsTest.java
+++ b/component/common/src/test/java/org/exoplatform/commons/utils/MailUtilsTest.java
@@ -80,11 +80,6 @@ public class MailUtilsTest {
     senderName = MailUtils.getSenderName();
     assertEquals(companyName, senderName);
 
-    companyName = "Company Name From property";
-    System.setProperty("exo.notifications.portalname", companyName);
-    senderName = MailUtils.getSenderName();
-    assertEquals(companyName, senderName);
-
     companyName = "Company Name From Settings";
     SettingValue settingValue = SettingValue.create(companyName);
     when(settingService.get(Context.GLOBAL, Scope.GLOBAL.id(null), SENDER_NAME_PARAM)).thenReturn(settingValue);

--- a/component/portal/src/test/resources/conf/exo.portal.component.portal-configuration.xml
+++ b/component/portal/src/test/resources/conf/exo.portal.component.portal-configuration.xml
@@ -270,17 +270,6 @@
     </init-params>
   </component>
 
-  <component>
-    <key>MailProperties</key>
-    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
-    <init-params>
-      <properties-param>
-        <name>MailProperties</name>
-        <property name="exo.notifications.portalname" value="Meeds Builders" />
-      </properties-param>
-    </init-params>
-  </component>
-
   <external-component-plugins>
     <target-component>org.exoplatform.services.organization.OrganizationService</target-component>
     <component-plugin>


### PR DESCRIPTION
Prior to this change, the property name 'exo.notifications.portalname' with default value when not set 'eXo' was used in Email subjects. This change will allow to use Branding Name instead.