### PR TITLE
feat: Allow to store Global Default Language in DB for LocaleConfiguService - MEED-2260 - Meeds-io/meeds#994

### DIFF
--- a/component/api/src/main/java/org/exoplatform/services/resources/LocaleConfigService.java
+++ b/component/api/src/main/java/org/exoplatform/services/resources/LocaleConfigService.java
@@ -44,4 +44,13 @@ public interface LocaleConfigService {
      */
     Collection<LocaleConfig> getLocalConfigs();
 
+    /**
+     * Saves new default locale
+     * 
+     * @param locale {@link LocaleConfig#getLocaleName()} to set as default
+     */
+    default void saveDefaultLocaleConfig(String locale) {
+      throw new UnsupportedOperationException();
+    };
+
 }

--- a/component/resources/pom.xml
+++ b/component/resources/pom.xml
@@ -29,7 +29,7 @@
   <name>GateIn Portal Component Resources</name>
   <description>Internationalization and localization resources</description>
   <properties>
-    <exo.test.coverage.ratio>0.63</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.64</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/component/resources/src/main/java/org/exoplatform/services/resources/impl/LocaleConfigServiceImpl.java
+++ b/component/resources/src/main/java/org/exoplatform/services/resources/impl/LocaleConfigServiceImpl.java
@@ -23,143 +23,236 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.apache.commons.lang3.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.configuration.ConfigurationManager;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.IdentityResourceBundle;
 import org.exoplatform.services.resources.LocaleConfig;
 import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.resources.Orientation;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
- * @author Benjamin Mestrallet benjamin.mestrallet@exoplatform.com This Service is used to manage the locales that the
- *         applications can handle
+ * @author Benjamin Mestrallet benjamin.mestrallet@exoplatform.com This Service
+ *         is used to manage the locales that the applications can handle
  */
 public class LocaleConfigServiceImpl implements LocaleConfigService {
 
-    private static Log log = ExoLogger.getLogger(LocaleConfigServiceImpl.class);
+  public static final String                    LOCALE_DEFAULT_MODIFIED_EVENT    = "locale.config.default.modified";
 
-    private DocumentBuilderFactory factory;
+  private static final String                   DEFAULT_LOCALE_CONFIG_PARAM      = "locale.config.default";
 
-    private LocaleConfig defaultConfig_;
+  private static final Context                  GLOBAL_SETTINGS_CONTEXT          = Context.GLOBAL.id("GLOBAL_SETTINGS");
 
-    private Map<String, LocaleConfig> configs_;
+  private static final Scope                    GLOBAL_SETTINGS_SCOPE            = Scope.APPLICATION.id("GLOBAL_SETTINGS");
 
-    private static final Map<String, Orientation> orientations = new HashMap<String, Orientation>();
+  private static final String                   GLOBAL_SETTINGS_DEFAULT_LANGUAGE = "DEFAULT_LANGUAGE";
 
-    static {
-        orientations.put("lt", Orientation.LT);
-        orientations.put("rt", Orientation.RT);
-        orientations.put("tl", Orientation.TL);
-        orientations.put("tr", Orientation.TR);
+  private static final Log                      LOG                              =
+                                                    ExoLogger.getLogger(LocaleConfigServiceImpl.class);
+
+  private SettingService                        settingService;
+
+  private ListenerService                       listenerService;
+
+  private DocumentBuilderFactory                factory;
+
+  private String                                defaultLocale;
+
+  private LocaleConfig                          firstConfig;
+
+  private LocaleConfig                          defaultConfig;
+
+  private Map<String, LocaleConfig>             configs;
+
+  private static final Map<String, Orientation> orientations                     = new HashMap<>();
+
+  static {
+    orientations.put("lt", Orientation.LT);
+    orientations.put("rt", Orientation.RT);
+    orientations.put("tl", Orientation.TL);
+    orientations.put("tr", Orientation.TR);
+  }
+
+  public LocaleConfigServiceImpl(SettingService settingService,
+                                 ListenerService listenerService,
+                                 ConfigurationManager cmanager,
+                                 InitParams params)
+      throws Exception {
+    this.settingService = settingService;
+    this.listenerService = listenerService;
+
+    this.configs = new HashMap<>(10);
+    this.factory = DocumentBuilderFactory.newInstance();
+    if (params.containsKey(DEFAULT_LOCALE_CONFIG_PARAM)) {
+      this.defaultLocale = params.getValueParam(DEFAULT_LOCALE_CONFIG_PARAM).getValue();
     }
+    String confResource = params.getValueParam("locale.config.file").getValue();
+    InputStream is = cmanager.getInputStream(confResource);
+    parseConfiguration(is);
+  }
 
-    public LocaleConfigServiceImpl(InitParams params, ConfigurationManager cmanager) throws Exception {
-        configs_ = new HashMap<String, LocaleConfig>(10);
-        factory = DocumentBuilderFactory.newInstance();
-        String confResource = params.getValueParam("locale.config.file").getValue();
-        InputStream is = cmanager.getInputStream(confResource);
-        parseConfiguration(is);
+  @Override
+  public LocaleConfig getDefaultLocaleConfig() {
+    if (defaultConfig == null) {
+      computeDefaultConfig();
     }
+    return defaultConfig;
+  }
 
-    /**
-     * @return Return the default LocaleConfig
-     */
-    public LocaleConfig getDefaultLocaleConfig() {
-        return defaultConfig_;
-    }
+  @Override
+  public void saveDefaultLocaleConfig(String locale) {
+    String oldDefaultLocale = getDefaultLocaleConfig().getLocaleName();
 
-    /**
-     * @param lang a locale language
-     * @return The LocalConfig
-     */
-    public LocaleConfig getLocaleConfig(String lang) {
-        LocaleConfig config = configs_.get(lang);
-        if (config != null)
-            return config;
-        return defaultConfig_;
-    }
-
-    /**
-     * @return All the LocalConfig that manage by the service
-     */
-    public Collection<LocaleConfig> getLocalConfigs() {
-        return configs_.values();
-    }
-
-    protected void parseConfiguration(InputStream is) throws Exception {
-        factory.setIgnoringComments(true);
-        factory.setCoalescing(true);
-        factory.setNamespaceAware(false);
-        factory.setValidating(false);
-        DocumentBuilder parser = factory.newDocumentBuilder();
-        Document document = parser.parse(is);
-        NodeList nodes = document.getElementsByTagName("locale-config");
-        for (int i = 0; i < nodes.getLength(); i++) {
-            Node node = nodes.item(i);
-            NodeList children = node.getChildNodes();
-            LocaleConfig config = new LocaleConfigImpl();
-            for (int j = 0; j < children.getLength(); j++) {
-                Node element = children.item(j);
-                if ("locale".equals(element.getNodeName())) {
-                    config.setLocale(element.getFirstChild().getNodeValue());
-                } else if ("output-encoding".equals(element.getNodeName())) {
-                    config.setOutputEncoding(element.getFirstChild().getNodeValue());
-                } else if ("input-encoding".equals(element.getNodeName())) {
-                    config.setInputEncoding(element.getFirstChild().getNodeValue());
-                } else if ("description".equals(element.getNodeName())) {
-                    config.setDescription(element.getFirstChild().getNodeValue());
-                } else if ("orientation".equals(element.getNodeName())) {
-                    String s = element.getFirstChild().getNodeValue();
-                    Orientation orientation = orientations.get(s);
-                    if (orientation == null) {
-                        log.error("Wrong orientation value " + s);
-                    } else {
-                        config.setOrientation(orientation);
-                    }
-                }
-            }
-
-            //
-            if (config.getOrientation() == null) {
-                log.debug("No orientation found on the locale config, use the LT default");
-                config.setOrientation(Orientation.LT);
-            }
-
-            //
-            log.debug("Added locale config " + config + " to the set of locale configs");
-
-            //
-            String country = config.getLocale().getCountry();
-            if (country != null && country.length() > 0) {
-                configs_.put(config.getLanguage() + "_" + country, config);
-            } else {
-                configs_.put(config.getLanguage(), config);
-            }
-            if (i == 0)
-                defaultConfig_ = config;
+    try {
+      if (StringUtils.isBlank(locale)) {
+        settingService.remove(GLOBAL_SETTINGS_CONTEXT,
+                              GLOBAL_SETTINGS_SCOPE,
+                              GLOBAL_SETTINGS_DEFAULT_LANGUAGE);
+      } else {
+        if (!configs.containsKey(locale)) {
+          throw new IllegalArgumentException(String.format("Locale %s is not supported", locale));
         }
-
-        //
-        if (PropertyManager.isDevelopping()) {
-            LocaleConfig magicConfig = new LocaleConfigImpl();
-            magicConfig.setLocale(IdentityResourceBundle.MAGIC_LOCALE);
-            magicConfig.setDescription("Magic locale");
-            magicConfig.setInputEncoding("UTF-8");
-            magicConfig.setOutputEncoding("UTF-8");
-            magicConfig.setDescription("Default configuration for the debugging locale");
-            magicConfig.setOrientation(Orientation.LT);
-            configs_.put(magicConfig.getLanguage(), magicConfig);
-            log.debug("Added magic locale for debugging bundle usage at runtime");
-        }
+        settingService.set(GLOBAL_SETTINGS_CONTEXT,
+                           GLOBAL_SETTINGS_SCOPE,
+                           GLOBAL_SETTINGS_DEFAULT_LANGUAGE,
+                           SettingValue.create(locale));
+      }
+    } finally {
+      this.defaultConfig = null;
     }
+
+    String newDefaultLocale = getDefaultLocaleConfig().getLocaleName();
+    try {
+      this.listenerService.broadcast(LOCALE_DEFAULT_MODIFIED_EVENT, oldDefaultLocale, newDefaultLocale);
+    } catch (Exception e) {
+      LOG.warn("Error broadcasting locale change from {} to {}", oldDefaultLocale, newDefaultLocale, e);
+    }
+  }
+
+  @Override
+  public LocaleConfig getLocaleConfig(String lang) {
+    return configs.getOrDefault(lang, getDefaultLocaleConfig());
+  }
+
+  @Override
+  public Collection<LocaleConfig> getLocalConfigs() {
+    return configs.values();
+  }
+
+  protected void parseConfiguration(InputStream is) throws Exception { // NOSONAR
+    factory.setIgnoringComments(true);
+    factory.setCoalescing(true);
+    factory.setNamespaceAware(false);
+    factory.setValidating(false);
+    DocumentBuilder parser = factory.newDocumentBuilder();
+    Document document = parser.parse(is);
+    NodeList nodes = document.getElementsByTagName("locale-config");
+    for (int i = 0; i < nodes.getLength(); i++) {
+      Node node = nodes.item(i);
+      NodeList children = node.getChildNodes();
+      LocaleConfig config = new LocaleConfigImpl();
+      for (int j = 0; j < children.getLength(); j++) {
+        Node element = children.item(j);
+        if ("locale".equals(element.getNodeName())) {
+          config.setLocale(element.getFirstChild().getNodeValue());
+        } else if ("output-encoding".equals(element.getNodeName())) {
+          config.setOutputEncoding(element.getFirstChild().getNodeValue());
+        } else if ("input-encoding".equals(element.getNodeName())) {
+          config.setInputEncoding(element.getFirstChild().getNodeValue());
+        } else if ("description".equals(element.getNodeName())) {
+          config.setDescription(element.getFirstChild().getNodeValue());
+        } else if ("orientation".equals(element.getNodeName())) {
+          String s = element.getFirstChild().getNodeValue();
+          Orientation orientation = orientations.get(s);
+          if (orientation == null) {
+            LOG.error("Wrong orientation value " + s);
+          } else {
+            config.setOrientation(orientation);
+          }
+        }
+      }
+
+      //
+      if (config.getOrientation() == null) {
+        LOG.debug("No orientation found on the locale config, use the LT default");
+        config.setOrientation(Orientation.LT);
+      }
+
+      //
+      LOG.debug("Added locale config " + config + " to the set of locale configs");
+
+      //
+      String country = config.getLocale().getCountry();
+      if (StringUtils.isNotBlank(country)) {
+        this.configs.put(config.getLanguage() + "_" + country, config);
+      } else {
+        this.configs.put(config.getLanguage(), config);
+      }
+      if (i == 0) {
+        this.firstConfig = config;
+      }
+    }
+
+    //
+    if (PropertyManager.isDevelopping()) {
+      LocaleConfig magicConfig = new LocaleConfigImpl();
+      magicConfig.setLocale(IdentityResourceBundle.MAGIC_LOCALE);
+      magicConfig.setDescription("Magic locale");
+      magicConfig.setInputEncoding("UTF-8");
+      magicConfig.setOutputEncoding("UTF-8");
+      magicConfig.setDescription("Default configuration for the debugging locale");
+      magicConfig.setOrientation(Orientation.LT);
+      this.configs.put(magicConfig.getLanguage(), magicConfig);
+      LOG.debug("Added magic locale for debugging bundle usage at runtime");
+    }
+  }
+
+  private void computeDefaultConfig() {
+
+    // Replace default locale from stored locale
+    SettingValue<?> defaultLanguageValue = settingService.get(GLOBAL_SETTINGS_CONTEXT,
+                                                              GLOBAL_SETTINGS_SCOPE,
+                                                              GLOBAL_SETTINGS_DEFAULT_LANGUAGE);
+    String localeName;
+    if (defaultLanguageValue != null && StringUtils.isNotBlank(defaultLanguageValue.getValue().toString())) {
+      localeName = defaultLanguageValue.getValue().toString();
+    } else {
+      localeName = this.defaultLocale;
+    }
+
+    // If default locale set by properties or stored in SettingService, use it
+    // as default
+    if (StringUtils.isNotBlank(localeName)) {
+      this.defaultConfig = configs.entrySet()
+                                  .stream()
+                                  .filter(configEntry -> StringUtils.equals(configEntry.getKey(), localeName))
+                                  .map(Entry::getValue)
+                                  .findFirst()
+                                  .orElse(null);
+    }
+
+    // If not set by properties, neither stored in SettingService, use the first
+    // configured locale
+    if (this.defaultConfig == null) {
+      this.defaultConfig = firstConfig;
+    }
+  }
+
 }

--- a/component/resources/src/test/java/org/exoplatform/services/resources/TestLocaleConfigService.java
+++ b/component/resources/src/test/java/org/exoplatform/services/resources/TestLocaleConfigService.java
@@ -19,103 +19,194 @@
 
 package org.exoplatform.services.resources;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.configuration.ConfigurationManagerImpl;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.resources.impl.LocaleConfigImpl;
 import org.exoplatform.services.resources.impl.LocaleConfigServiceImpl;
 
 /**
- * @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
+ * @author  <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
  * @version $Revision$
  */
-public class TestLocaleConfigService extends AbstractResourceBundleTest {
+public class TestLocaleConfigService extends AbstractResourceBundleTest { // NOSONAR
 
-    public TestLocaleConfigService() {
+  private ListenerService listenerService;
+
+  public void testParseLocaleConfigFile() throws Exception {
+    PropertyManager.setProperty(PropertyManager.DEVELOPING, "false");
+    LocaleConfigService service = createService();
+    Map<String, LocaleConfig> map = createMap(service);
+    assertEquals(4, map.size());
+    assertCommonConfigs(service);
+  }
+
+  public void testDevMode() throws Exception {
+    PropertyManager.setProperty(PropertyManager.DEVELOPING, "true");
+    LocaleConfigService service = createService();
+    Map<String, LocaleConfig> map = createMap(service);
+    assertEquals(5, map.size());
+    assertCommonConfigs(service);
+    LocaleConfig ma = service.getLocaleConfig("ma");
+    assertLocaleConfig(ma,
+                       "ma",
+                       "Default configuration for the debugging locale",
+                       "UTF-8",
+                       "UTF-8",
+                       Orientation.LT,
+                       IdentityResourceBundle.MAGIC_LOCALE);
+  }
+
+  public void testDefaultConfiguredLanguage() throws Exception {
+    LocaleConfigService service = createService("fr");
+    LocaleConfig defaultLocaleConfig = service.getDefaultLocaleConfig();
+    assertNotNull(defaultLocaleConfig);
+    assertEquals("fr", defaultLocaleConfig.getLocaleName());
+  }
+
+  public void testDefaultStoredLanguage() throws Exception {
+    LocaleConfigService service = createService("fr");
+    service.saveDefaultLocaleConfig("en");
+
+    verify(listenerService, times(1)).broadcast(LocaleConfigServiceImpl.LOCALE_DEFAULT_MODIFIED_EVENT, "fr", "en");
+
+    LocaleConfig defaultLocaleConfig = service.getDefaultLocaleConfig();
+    assertNotNull(defaultLocaleConfig);
+    assertEquals("en", defaultLocaleConfig.getLocaleName());
+  }
+
+  public void testRemoveDefaultStoredLanguage() throws Exception {
+    LocaleConfigService service = createService("fr");
+    service.saveDefaultLocaleConfig("en");
+    verify(listenerService, times(1)).broadcast(LocaleConfigServiceImpl.LOCALE_DEFAULT_MODIFIED_EVENT, "fr", "en");
+    service.saveDefaultLocaleConfig(null);
+    verify(listenerService, times(1)).broadcast(LocaleConfigServiceImpl.LOCALE_DEFAULT_MODIFIED_EVENT, "en", "fr");
+
+    LocaleConfig defaultLocaleConfig = service.getDefaultLocaleConfig();
+    assertNotNull(defaultLocaleConfig);
+    assertEquals("fr", defaultLocaleConfig.getLocaleName());
+  }
+
+  public void testLocaleConfig() {
+    LocaleConfig ma = new LocaleConfigImpl();
+    ma.setLocale("ma");
+    assertEquals("ma", ma.getLocaleName());
+
+    LocaleConfig ma1 = new LocaleConfigImpl();
+    ma1.setLocale(new Locale("ma"));
+    assertEquals("ma", ma1.getLocaleName());
+  }
+
+  private Map<String, LocaleConfig> createMap(LocaleConfigService service) {
+    Map<String, LocaleConfig> map = new HashMap<>();
+    for (LocaleConfig config : service.getLocalConfigs()) {
+      map.put(config.getLanguage(), config);
+    }
+    return map;
+  }
+
+  private LocaleConfigService createService() throws Exception {
+    return createService(null);
+  }
+
+  private LocaleConfigService createService(String defaultLang) throws Exception {
+    ConfigurationManagerImpl cm = new ConfigurationManagerImpl();
+    InitParams params = new InitParams();
+    ValueParam param = new ValueParam();
+    param.setName("locale.config.file");
+    param.setValue("classpath:/resources/locales-config.xml");
+    params.addParameter(param);
+
+    if (StringUtils.isNotBlank(defaultLang)) {
+      param = new ValueParam();
+      param.setName("locale.config.default");
+      param.setValue(defaultLang);
+      params.addParameter(param);
     }
 
-    public TestLocaleConfigService(String s) {
-        super(s);
-    }
+    SettingService settingService = mock(SettingService.class);
+    this.listenerService = mock(ListenerService.class);
+    doAnswer(invocation -> {
+      when(settingService.get(invocation.getArgument(0),
+                              invocation.getArgument(1),
+                              invocation.getArgument(2))).thenReturn(invocation.getArgument(3));
+      return null;
+    }).when(settingService)
+      .set(any(),
+           any(),
+           any(),
+           any());
+    doAnswer(invocation -> {
+      reset(settingService);
+      return null;
+    }).when(settingService)
+      .remove(any(),
+              any(),
+              any());
 
-    public void testFoo() throws Exception {
-        PropertyManager.setProperty(PropertyManager.DEVELOPING, "false");
-        LocaleConfigService service = createService();
-        Map<String, LocaleConfig> map = createMap(service);
-        assertEquals(4, map.size());
-        assertCommonConfigs(service);
-    }
+    return new LocaleConfigServiceImpl(settingService, listenerService, cm, params);
+  }
 
-    public void testBar() throws Exception {
-        PropertyManager.setProperty(PropertyManager.DEVELOPING, "true");
-        LocaleConfigService service = createService();
-        Map<String, LocaleConfig> map = createMap(service);
-        assertEquals(5, map.size());
-        assertCommonConfigs(service);
-        LocaleConfig ma = service.getLocaleConfig("ma");
-        assertLocaleConfig(ma, "ma", "Default configuration for the debugging locale", "UTF-8", "UTF-8", Orientation.LT,
-                IdentityResourceBundle.MAGIC_LOCALE);
-    }
+  private void assertCommonConfigs(LocaleConfigService service) {
+    LocaleConfig en = service.getLocaleConfig("en");
+    LocaleConfig fr = service.getLocaleConfig("fr");
+    LocaleConfig ar = service.getLocaleConfig("ar");
+    LocaleConfig vi = service.getLocaleConfig("vi");
+    assertLocaleConfig(en,
+                       "en",
+                       "Default configuration for english locale",
+                       "UTF-8",
+                       "UTF-8",
+                       Orientation.LT,
+                       Locale.ENGLISH);
+    assertLocaleConfig(fr,
+                       "fr",
+                       "Default configuration for the french locale",
+                       "UTF-8",
+                       "UTF-8",
+                       Orientation.LT,
+                       Locale.FRENCH);
+    assertLocaleConfig(ar,
+                       "ar",
+                       "Default configuration for the arabic locale",
+                       "UTF-8",
+                       "UTF-8",
+                       Orientation.RT,
+                       new Locale("ar"));
+    assertLocaleConfig(vi,
+                       "vi",
+                       "Default configuration for the vietnam locale",
+                       "UTF-8",
+                       "UTF-8",
+                       Orientation.LT,
+                       new Locale("vi"));
+  }
 
-    public void testLocaleConfig() throws Exception {
-        LocaleConfig ma = new LocaleConfigImpl();
-        ma.setLocale("ma");
-        assertEquals("ma", ma.getLocaleName());
-
-        LocaleConfig ma1 = new LocaleConfigImpl();
-        ma1.setLocale(new Locale("ma"));
-        assertEquals("ma", ma1.getLocaleName());
-    }
-
-    private Map<String, LocaleConfig> createMap(LocaleConfigService service) {
-        Map<String, LocaleConfig> map = new HashMap<String, LocaleConfig>();
-        for (LocaleConfig config : service.getLocalConfigs()) {
-            map.put(config.getLanguage(), config);
-        }
-        return map;
-    }
-
-    private LocaleConfigService createService() throws Exception {
-        ConfigurationManagerImpl cm = new ConfigurationManagerImpl();
-        InitParams params = new InitParams();
-        ValueParam param = new ValueParam();
-        param.setName("locale.config.file");
-        param.setValue("classpath:/resources/locales-config.xml");
-        params.addParameter(param);
-
-        //
-        LocaleConfigService service = new LocaleConfigServiceImpl(params, cm);
-        return service;
-    }
-
-    private void assertCommonConfigs(LocaleConfigService service) {
-        LocaleConfig en = service.getLocaleConfig("en");
-        LocaleConfig fr = service.getLocaleConfig("fr");
-        LocaleConfig ar = service.getLocaleConfig("ar");
-        LocaleConfig vi = service.getLocaleConfig("vi");
-        assertLocaleConfig(en, "en", "Default configuration for english locale", "UTF-8", "UTF-8", Orientation.LT,
-                Locale.ENGLISH);
-        assertLocaleConfig(fr, "fr", "Default configuration for the french locale", "UTF-8", "UTF-8", Orientation.LT,
-                Locale.FRENCH);
-        assertLocaleConfig(ar, "ar", "Default configuration for the arabic locale", "UTF-8", "UTF-8", Orientation.RT,
-                new Locale("ar"));
-        assertLocaleConfig(vi, "vi", "Default configuration for the vietnam locale", "UTF-8", "UTF-8", Orientation.LT,
-                new Locale("vi"));
-    }
-
-    private void assertLocaleConfig(LocaleConfig config, String language, String description, String inputEncoding,
-            String outputEncoding, Orientation orientation, Locale locale) {
-        assertNotNull(config);
-        assertEquals(language, config.getLanguage());
-        assertEquals(description, config.getDescription());
-        assertEquals(inputEncoding, config.getInputEncoding());
-        assertEquals(outputEncoding, config.getOutputEncoding());
-        assertEquals(orientation, config.getOrientation());
-        assertEquals(locale, config.getLocale());
-    }
+  private void assertLocaleConfig(LocaleConfig config, String language, String description, String inputEncoding,
+                                  String outputEncoding, Orientation orientation, Locale locale) {
+    assertNotNull(config);
+    assertEquals(language, config.getLanguage());
+    assertEquals(description, config.getDescription());
+    assertEquals(inputEncoding, config.getInputEncoding());
+    assertEquals(outputEncoding, config.getOutputEncoding());
+    assertEquals(orientation, config.getOrientation());
+    assertEquals(locale, config.getLocale());
+  }
 }

--- a/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
@@ -169,6 +169,10 @@
     <type>org.exoplatform.services.resources.impl.LocaleConfigServiceImpl</type>
     <init-params>
       <value-param>
+        <name>locale.config.default</name>
+        <value>${io.meeds.defaultLocale:}</value>
+      </value-param>
+      <value-param>
         <name>locale.config.file</name>
         <value>war:/conf/common/locales-config.xml</value>
       </value-param>

--- a/web/portal/src/main/webapp/WEB-INF/conf/portal/web-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/portal/web-configuration.xml
@@ -53,6 +53,12 @@
   <component>
     <key>org.exoplatform.services.resources.LocalePolicy</key>
     <type>org.exoplatform.portal.application.localization.DefaultLocalePolicyService</type>
+    <init-params>
+      <value-param>
+        <name>useDefaultSiteLanguage</name>
+        <value>${io.meeds.useDefaultSiteLanguage:false}</value>
+      </value-param>
+    </init-params>
   </component>
 
   <component>

--- a/webui/portal/src/main/java/org/exoplatform/portal/application/localization/DefaultLocalePolicyService.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/localization/DefaultLocalePolicyService.java
@@ -24,9 +24,12 @@ package org.exoplatform.portal.application.localization;
 import java.util.List;
 import java.util.Locale;
 
+import org.picocontainer.Startable;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.resources.LocaleContextInfo;
 import org.exoplatform.services.resources.LocalePolicy;
-import org.picocontainer.Startable;
 
 /**
  * This service represents a default policy for determining LocaleConfig to be used for user's session. This service is
@@ -47,6 +50,20 @@ import org.picocontainer.Startable;
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
  */
 public class DefaultLocalePolicyService implements LocalePolicy, Startable {
+
+    private static final String USE_DEFAULT_SITE_LANGUAGE_PARAM = "useDefaultSiteLanguage";
+
+    private LocaleConfigService localeConfigService;
+
+    private boolean             useDefaultSiteLanguage;
+
+    public DefaultLocalePolicyService(LocaleConfigService localeConfigService, InitParams params) {
+      this.localeConfigService = localeConfigService;
+      if (params != null && params.containsKey(USE_DEFAULT_SITE_LANGUAGE_PARAM)) {
+        this.useDefaultSiteLanguage = Boolean.parseBoolean(params.getValueParam(USE_DEFAULT_SITE_LANGUAGE_PARAM).getValue());
+      }
+    }
+
     /**
      * @see LocalePolicy#determineLocale(LocaleContextInfo)
      */
@@ -62,8 +79,13 @@ public class DefaultLocalePolicyService implements LocalePolicy, Startable {
         else
             locale = getLocaleConfigForRegistered(context);
 
-        if (locale == null)
+        if (locale == null) {
+          if (useDefaultSiteLanguage) {
             locale = context.getPortalLocale();
+          } else {
+            locale = localeConfigService.getDefaultLocaleConfig().getLocale();
+          }
+        }
 
         return locale;
     }

--- a/webui/portal/src/main/java/org/exoplatform/portal/application/localization/NoBrowserLocalePolicyService.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/localization/NoBrowserLocalePolicyService.java
@@ -23,6 +23,8 @@ package org.exoplatform.portal.application.localization;
 
 import java.util.Locale;
 
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.services.resources.LocaleContextInfo;
 
 /**
@@ -32,6 +34,11 @@ import org.exoplatform.services.resources.LocaleContextInfo;
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
  */
 public class NoBrowserLocalePolicyService extends DefaultLocalePolicyService {
+
+    public NoBrowserLocalePolicyService(LocaleConfigService localeConfigService, InitParams params) {
+      super(localeConfigService, params);
+    }
+
     /**
      * Override super method with no-op.
      *


### PR DESCRIPTION
Prior to this change, the default language was set using an extension configuration from locale-config.xml. In fact, the first language configuration was used as default language. This change will unify the definition of default configuration using LocaleConfigService and will allow to change this default config by allowing to persist a new preferred value.