### PR TITLE
feat: Delete Asynchronous Listeners Behavior in Test scope - MEED-2290 - Meeds-io/MIPs#50

### DIFF
--- a/component/portal/src/test/java/org/exoplatform/mock/ListenerServiceMock.java
+++ b/component/portal/src/test/java/org/exoplatform/mock/ListenerServiceMock.java
@@ -1,0 +1,92 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.mock;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+/**
+ * A class to delete Asynchronous calls to ListenerService in Test context
+ */
+@SuppressWarnings({
+    "rawtypes", "unchecked"
+})
+public class ListenerServiceMock extends ListenerService {
+
+  /**
+   * Listeners by name map.
+   */
+  private final Map<String, List<Listener>> listeners_ = new HashMap<>();
+
+  private static final Log                  LOG        = ExoLogger.getLogger("exo.kernel.component.common.ListenerService");
+
+  public ListenerServiceMock(ExoContainerContext ctx) {
+    super(ctx, null, null);
+  }
+
+  @Override
+  public void addListener(Listener listener) {
+    addListener(listener.getName(), listener);
+  }
+
+  @Override
+  public void addListener(String eventName, Listener listener) {
+    listeners_.computeIfAbsent(eventName, key -> new ArrayList<Listener>())
+              .add(listener);
+  }
+
+  @Override
+  public <S, D> void broadcast(String name, S source, D data) throws Exception {
+    List<Listener> list = listeners_.get(name);
+    if (list == null) {
+      return;
+    }
+    for (Listener<S, D> listener : list) {
+      try {
+        listener.onEvent(new Event<>(name, source, data));
+      } catch (Exception e) {
+        LOG.error("Exception while broadcasting event with name {}", name, e);
+      }
+    }
+  }
+
+  @Override
+  public <T extends Event> void broadcast(T event) throws Exception {
+    List<Listener> list = listeners_.get(event.getEventName());
+    if (list == null) {
+      return;
+    }
+    for (Listener listener : list) {
+      try {
+        listener.onEvent(event);
+      } catch (Exception e) {
+        LOG.error("Exception while broadcasting event {}: ", event, e);
+      }
+    }
+  }
+
+}

--- a/component/portal/src/test/java/org/exoplatform/mock/ListenerServiceMock.java
+++ b/component/portal/src/test/java/org/exoplatform/mock/ListenerServiceMock.java
@@ -37,12 +37,9 @@ import org.exoplatform.services.log.Log;
 })
 public class ListenerServiceMock extends ListenerService {
 
-  /**
-   * Listeners by name map.
-   */
-  private final Map<String, List<Listener>> listeners_ = new HashMap<>();
+  private static final Log                  LOG       = ExoLogger.getLogger("exo.kernel.component.common.ListenerService");
 
-  private static final Log                  LOG        = ExoLogger.getLogger("exo.kernel.component.common.ListenerService");
+  private final Map<String, List<Listener>> listeners = new HashMap<>();
 
   public ListenerServiceMock(ExoContainerContext ctx) {
     super(ctx, null, null);
@@ -55,13 +52,13 @@ public class ListenerServiceMock extends ListenerService {
 
   @Override
   public void addListener(String eventName, Listener listener) {
-    listeners_.computeIfAbsent(eventName, key -> new ArrayList<Listener>())
-              .add(listener);
+    listeners.computeIfAbsent(eventName, key -> new ArrayList<Listener>())
+             .add(listener);
   }
 
   @Override
   public <S, D> void broadcast(String name, S source, D data) throws Exception {
-    List<Listener> list = listeners_.get(name);
+    List<Listener> list = listeners.get(name);
     if (list == null) {
       return;
     }
@@ -76,7 +73,7 @@ public class ListenerServiceMock extends ListenerService {
 
   @Override
   public <T extends Event> void broadcast(T event) throws Exception {
-    List<Listener> list = listeners_.get(event.getEventName());
+    List<Listener> list = listeners.get(event.getEventName());
     if (list == null) {
       return;
     }

--- a/component/portal/src/test/resources/conf/exo.portal.component.portal-configuration-local.xml
+++ b/component/portal/src/test/resources/conf/exo.portal.component.portal-configuration-local.xml
@@ -104,11 +104,6 @@
     <key>org.exoplatform.web.login.recovery.PasswordRecoveryService</key>
     <type>org.exoplatform.mock.MockPasswordRecoveryService</type>
   </component>
-  
-  <component>
-    <key>org.exoplatform.services.listener.ListenerService</key>
-    <type>org.exoplatform.services.listener.ListenerService</type>
-  </component>
 
   <component>
     <key>org.exoplatform.portal.config.UserACL</key>

--- a/component/portal/src/test/resources/conf/exo.portal.component.portal-configuration.xml
+++ b/component/portal/src/test/resources/conf/exo.portal.component.portal-configuration.xml
@@ -148,7 +148,7 @@
   
   <component>
     <key>org.exoplatform.services.listener.ListenerService</key>
-    <type>org.exoplatform.services.listener.ListenerService</type>
+    <type>org.exoplatform.mock.ListenerServiceMock</type>
   </component>
 
   <component>


### PR DESCRIPTION
Prior to this change, the asynchronous listeners wasn't able to be tested in synchrnous mode. This change will allow to synchronously test asynchronous listeners for better Integration Tests Pertinence.