### PR TITLE
feat: Refactor findSites method to ignore empty sites - EXO-65013 - Meeds-io/MIPs#68

### DIFF
--- a/component/management/src/main/java/org/gatein/api/PortalImpl.java
+++ b/component/management/src/main/java/org/gatein/api/PortalImpl.java
@@ -197,20 +197,15 @@ public class PortalImpl implements Portal {
                                Comparator<PortalConfig> comparator,
                                boolean includeAllSites) {
     try {
-      if (pagination != null) {
         ListAccess<PortalConfig> access = layoutService.find2(query, comparator);
         int size = access.getSize();
-        int offset = pagination.getOffset();
-        int limit = pagination.getLimit();
+        int offset = pagination != null ? pagination.getOffset() : 0;
+        int limit = pagination != null ?  pagination.getLimit() : size;
         if (offset >= size) {
           return Collections.emptyList();
         }
-
         PortalConfig[] sites = loadSites(includeAllSites, access, size, offset, limit);
-        return fromList(Arrays.asList(sites).subList(pagination.getOffset(), sites.length));
-      } else {
-        return fromList(layoutService.find(query, comparator).getAll());
-      }
+        return fromList(Arrays.asList(sites).subList(offset, sites.length));
     } catch (Throwable e) {
       throw new ApiException("Failed to query for sites", e);
     }

--- a/component/management/src/test/java/org/gatein/api/PortalImplTest.java
+++ b/component/management/src/test/java/org/gatein/api/PortalImplTest.java
@@ -220,6 +220,18 @@ public class PortalImplTest extends AbstractApiTest {
         assertNotNull(sites);
         assertEquals(1, sites.size());
         assertEquals(defaultSiteId.getName(), sites.get(0).getId().getName());
+
+        createSite(new SiteId("empty site"), false);
+
+        sites = portal.findSites(new SiteQuery.Builder().withAllSiteTypes().build());
+        assertNotNull(sites);
+        assertEquals(1, sites.size());
+        assertEquals(defaultSiteId.getName(), sites.get(0).getId().getName());
+
+        sites = portal.findSites(new SiteQuery.Builder().withAllSiteTypes().includeEmptySites(true).build());
+        assertNotNull(sites);
+        assertEquals(2, sites.size());
+
     }
 
     @Test


### PR DESCRIPTION
Prior to this change, sites were filtered using the includeEmptySites filter only when pagination is needed.
In our case, as we have more than one site, the pagination is set to null, so all sites are included, and the includeEmptySites filter is not taken into account.
After this change, in all cases (with/without pagination) the sites will be filtered and empty sites will not loaded.