### PR TITLE
fix: Fix Tested Classes - MEED-2290

### DIFF
--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -28,7 +28,7 @@
   <name>GateIn Portal Component Common</name>
 
   <properties>
-    <exo.test.coverage.ratio>0.40</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.43</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/component/common/src/test/resources/conf/exo.portal.component.settings-configuration-local.xml
+++ b/component/common/src/test/resources/conf/exo.portal.component.settings-configuration-local.xml
@@ -29,15 +29,18 @@
   </component>
 
   <component>
-      <type>org.exoplatform.settings.jpa.dao.SettingContextDAO</type>
+    <key>org.exoplatform.settings.jpa.SettingContextDAO</key>
+    <type>org.exoplatform.settings.jpa.dao.SettingContextDAO</type>
   </component>
 
   <component>
-      <type>org.exoplatform.settings.jpa.dao.SettingScopeDAO</type>
+    <key>org.exoplatform.settings.jpa.SettingScopeDAO</key>
+    <type>org.exoplatform.settings.jpa.dao.SettingScopeDAO</type>
   </component>
 
   <component>
-      <type>org.exoplatform.settings.jpa.dao.SettingsDAO</type>
+    <key>org.exoplatform.settings.jpa.SettingsDAO</key>
+    <type>org.exoplatform.settings.jpa.dao.SettingsDAO</type>
   </component>
 
   <component>


### PR DESCRIPTION
This change will fix Tested classes in integration tests to use Database instead of InMemory Implementation in integration Tests.