### PR TITLE
feat: Change the character set for description column of PORTAL_SITES table to utf8mb4 in order to support emojis insertion - EXO-65345 - Meeds-io/MIPs#68

### DIFF
--- a/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
+++ b/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
@@ -367,4 +367,9 @@
       <column name="UPDATED_DATE" type="BIGINT" defaultValueNumeric="0" />
     </addColumn>
   </changeSet>
+  <changeSet author="portal" id="1.0.0-34" dbms="mysql">
+    <sql>
+      ALTER TABLE PORTAL_SITES MODIFY COLUMN DESCRIPTION longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this change, the default character set for the description column in the PORTAL_SITE table is utf8, so we can't add text containing emojis. After this change, we replace the column's character set with utf8mb4 so that the description column can support emojis.