### PR TITLE
feat: Update the default password hashing algorithm - EXO-65150  - Meeds-io/MIPs#69

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/PicketLinkIDMService.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/PicketLinkIDMService.java
@@ -19,8 +19,11 @@
 
 package org.exoplatform.services.organization.idm;
 
+import org.gatein.portal.idm.impl.store.attribute.ExtendedAttributeManager;
 import org.picketlink.idm.api.IdentitySession;
 import org.picketlink.idm.api.IdentitySessionFactory;
+import org.picketlink.idm.api.cfg.IdentityConfiguration;
+import org.picketlink.idm.spi.configuration.metadata.IdentityConfigurationMetaData;
 
 /**
  * @author <a href="mailto:boleslaw.dawidowicz@redhat.com">Boleslaw Dawidowicz</a>
@@ -32,5 +35,11 @@ public interface PicketLinkIDMService {
     IdentitySession getIdentitySession() throws Exception;
 
     IdentitySession getIdentitySession(String realm) throws Exception;
+
+    IdentityConfigurationMetaData getConfigMD();
+
+    IdentityConfiguration getIdentityConfiguration();
+
+    ExtendedAttributeManager getExtendedAttributeManager() throws Exception;
 
 }

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/PicketLinkIDMServiceImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/PicketLinkIDMServiceImpl.java
@@ -34,6 +34,7 @@ import org.exoplatform.services.database.HibernateService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.naming.InitialContextInitializer;
+import org.gatein.portal.idm.impl.store.attribute.ExtendedAttributeManager;
 import org.infinispan.Cache;
 import org.picketlink.idm.api.IdentitySession;
 import org.picketlink.idm.api.IdentitySessionFactory;
@@ -41,6 +42,7 @@ import org.picketlink.idm.api.SecureRandomProvider;
 import org.picketlink.idm.api.cfg.IdentityConfiguration;
 import org.picketlink.idm.cache.APICacheProvider;
 import org.picketlink.idm.common.exception.IdentityConfigurationException;
+import org.picketlink.idm.impl.api.session.IdentitySessionImpl;
 import org.picketlink.idm.impl.configuration.IdentityConfigurationImpl;
 import org.picketlink.idm.impl.configuration.jaxb2.JAXB2IdentityConfiguration;
 import org.picketlink.idm.impl.credential.DatabaseReadingSaltEncoder;
@@ -208,6 +210,16 @@ public class PicketLinkIDMServiceImpl implements PicketLinkIDMService, Startable
             throw new IllegalArgumentException("Realm name cannot be null");
         }
         return getIdentitySessionFactory().getCurrentIdentitySession(realm);
+    }
+
+    @Override
+    public IdentityConfiguration getIdentityConfiguration() {
+        return identityConfiguration;
+    }
+
+    @Override
+    public ExtendedAttributeManager getExtendedAttributeManager() throws Exception {
+      return new ExtendedAttributeManager((IdentitySessionImpl) getIdentitySession());
     }
 
     public String getRealmName() {

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -409,7 +409,7 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
         IdentitySession session = service_.getIdentitySession();
         org.picketlink.idm.api.User idmUser = session.getPersistenceManager().findUser(user.getUserName());
 
-        authenticated = session.getAttributesManager().validatePassword(idmUser, password);
+        authenticated = service_.getExtendedAttributeManager().validatePassword(idmUser, password);
       } catch (Exception e) {
         handleException("Cannot authenticate user: " + user.getUserName() + "; ", e);
       }

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
@@ -572,9 +572,8 @@ public class PicketLinkIDMExternalStoreService implements IDMExternalStoreServic
   }
 
   private boolean validatePassword(final org.picketlink.idm.api.User idmUser, String password) throws Exception {
-    return (Boolean) executeOnExternalStoreFuntion.apply(() -> {
-      return picketLinkIDMService.getIdentitySession().getAttributesManager().validatePassword(idmUser, password);
-    });
+    return (Boolean) executeOnExternalStoreFuntion.apply(() -> picketLinkIDMService.getExtendedAttributeManager()
+                                                                                   .validatePassword(idmUser, password));
   }
 
   private void checkEnabled() {

--- a/component/identity/src/main/java/org/gatein/portal/idm/impl/store/attribute/ExtendedAttributeManager.java
+++ b/component/identity/src/main/java/org/gatein/portal/idm/impl/store/attribute/ExtendedAttributeManager.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2023 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.gatein.portal.idm.impl.store.attribute;
+
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.organization.idm.PicketLinkIDMService;
+import org.picketlink.idm.api.Attribute;
+import org.picketlink.idm.api.User;
+import org.picketlink.idm.common.exception.IdentityException;
+import org.picketlink.idm.impl.api.PasswordCredential;
+import org.picketlink.idm.impl.api.session.IdentitySessionImpl;
+import org.picketlink.idm.impl.api.session.managers.AttributesManagerImpl;
+import org.picketlink.idm.impl.credential.DatabaseReadingSaltEncoder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExtendedAttributeManager extends AttributesManagerImpl {
+
+  public static final String          OLD_PASSWORD_SALT_USER_ATTRIBUTE = "passwordSalt";
+
+  public static final String          PASSWORD_SALT_USER_ATTRIBUTE     = "passwordSalt128";
+
+  private static PicketLinkIDMService idmService;
+
+  public ExtendedAttributeManager(IdentitySessionImpl session) {
+    super(session);
+  }
+
+  @Override
+  public boolean validatePassword(User user, String password) throws IdentityException {
+
+    Attribute salt128 = getAttribute(user.getKey(), PASSWORD_SALT_USER_ATTRIBUTE);
+    if (salt128 != null) {
+      return super.validatePassword(user, password);
+    } else {
+      DatabaseReadingSaltEncoder oldCredentialEncoder = new DatabaseReadingSaltEncoder();
+      oldCredentialEncoder.setIdentitySession(getIdentitySession());
+      oldCredentialEncoder.initialize(getCredentialEncoderProps(),
+                                      getIdmService().getIdentityConfiguration().getIdentityConfigurationRegistry());
+      if (getRepository().validateCredential(getInvocationContext(),
+                                             createIdentityObject(user),
+                                             new PasswordCredential(password, oldCredentialEncoder, user.getKey()))) {
+        removeAttributes(user.getKey(), new String[] { OLD_PASSWORD_SALT_USER_ATTRIBUTE });
+        updatePassword(user, password);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Map<String, String> getCredentialEncoderProps() {
+    Map<String, String> props = new HashMap<>();
+    getIdmService().getConfigMD().getRealms().get(0).getOptions().forEach((k, v) -> props.put(k, v.get(0)));
+    return props;
+  }
+
+  private static PicketLinkIDMService getIdmService() {
+    if (idmService == null) {
+      ExoContainer container = ExoContainerContext.getCurrentContainer();
+      idmService = container.getComponentInstanceOfType(PicketLinkIDMService.class);
+    }
+    return idmService;
+  }
+}

--- a/component/identity/src/main/resources/picketlink-idm-config.xml
+++ b/component/identity/src/main/resources/picketlink-idm-config.xml
@@ -37,11 +37,15 @@
         </option>
         <option>
           <name>credentialEncoder.class</name>
-          <value>org.picketlink.idm.impl.credential.DatabaseReadingSaltEncoder</value>
+          <value>${exo.plidm.password.class:org.exoplatform.web.security.hash.Argon2IdPasswordEncoder}</value>
         </option>
         <option>
           <name>credentialEncoder.hashAlgorithm</name>
-          <value>SHA-256</value>
+          <value>${exo.plidm.password.hash:SHA-256}</value>
+        </option>
+        <option>
+          <name>credentialEncoder.secureRandomAlgorithm</name>
+          <value>${exo.plidm.password.secureRandomAlgorithm:SHA1PRNG}</value>
         </option>
       </options>
     </realm>

--- a/component/identity/src/test/resources/conf/picketlink/exo.portal.component.identity-picketlink-idm-config.xml
+++ b/component/identity/src/test/resources/conf/picketlink/exo.portal.component.identity-picketlink-idm-config.xml
@@ -30,6 +30,24 @@
       <identity-type-mappings>
         <user-mapping>USER</user-mapping>
       </identity-type-mappings>
+      <options>
+        <option>
+          <name>template</name>
+          <value>true</value>
+        </option>
+        <option>
+          <name>credentialEncoder.class</name>
+          <value>org.picketlink.idm.impl.credential.DatabaseReadingSaltEncoder</value>
+        </option>
+        <option>
+          <name>credentialEncoder.hashAlgorithm</name>
+          <value>SHA-256</value>
+        </option>
+        <option>
+          <name>credentialEncoder.secureRandomAlgorithm</name>
+          <value>SHA1PRNG</value>
+        </option>
+      </options>
     </realm>
   </realms>
   <repositories>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-config.xml
@@ -37,7 +37,7 @@
         </option>
         <option>
           <name>credentialEncoder.class</name>
-          <value>${exo.plidm.password.class:org.picketlink.idm.impl.credential.DatabaseReadingSaltEncoder}</value>
+          <value>${exo.plidm.password.class:org.exoplatform.web.security.hash.Argon2IdPasswordEncoder}</value>
         </option>
         <option>
           <name>credentialEncoder.hashAlgorithm</name>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
@@ -37,7 +37,7 @@
         </option>
         <option>
           <name>credentialEncoder.class</name>
-          <value>${exo.plidm.password.class:org.picketlink.idm.impl.credential.DatabaseReadingSaltEncoder}</value>
+          <value>${exo.plidm.password.class:org.exoplatform.web.security.hash.Argon2IdPasswordEncoder}</value>
         </option>
         <option>
           <name>credentialEncoder.hashAlgorithm</name>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
@@ -37,7 +37,7 @@
         </option>
         <option>
           <name>credentialEncoder.class</name>
-          <value>${exo.plidm.password.class:org.picketlink.idm.impl.credential.DatabaseReadingSaltEncoder}</value>
+          <value>${exo.plidm.password.class:org.exoplatform.web.security.hash.Argon2IdPasswordEncoder}</value>
         </option>
         <option>
           <name>credentialEncoder.hashAlgorithm</name>


### PR DESCRIPTION
Prior to this change, Old created passwords are hashed by the old encoder algorithm and need un upgrade mechanism  to re-hash theses password without asking users to create new ones. 
This PR is a part of the upgrade mechanism, will check the password slat attribute and validate it by the proper algorithm, if it's hashed by the old algorithm then it will be updated by the new one.