### PR TITLE
fix: Add passwordSalt128 attribute to non profile keys - EXO-65823 - Meeds-io/meeds#1061

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -62,7 +62,10 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
 
   public static final String      USER_ORGANIZATION_ID = EntityMapperUtils.USER_ORGANIZATION_ID;
 
-  public static final String      USER_ENABLED         = EntityMapperUtils.USER_ENABLED;
+  public static final String      USER_ENABLED          = EntityMapperUtils.USER_ENABLED;
+
+  public static final String      USER_PASSWORD_SALT128 = "passwordSalt128";
+
 
   public static final Set<String> USER_NON_PROFILE_KEYS;
 
@@ -81,6 +84,7 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
     keys.add(USER_ORGANIZATION_ID);
     keys.add(USER_ENABLED);
     keys.add(ORIGINATING_STORE);
+    keys.add(USER_PASSWORD_SALT128);
 
     USER_NON_PROFILE_KEYS = Collections.unmodifiableSet(keys);
   }


### PR DESCRIPTION
After adding new passwordSalt128 attribute for the new hashing algorithm, the attribute was returned in gatein-profile and added inside social profile. 
This PR adds the attribute to the non profile attributes list, to prevent it from being returned in gatein-profile.
