### PR TITLE
feat: Introduce CMS Publisher group - MEED-2605 - Meeds-io/MIPs#92

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/organization-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/organization-configuration.xml
@@ -179,6 +179,22 @@
                 <value>
                   <object type="org.exoplatform.services.organization.OrganizationConfig$Group">
                     <field name="name">
+                      <string>web-contributors</string>
+                    </field>
+                    <field name="parentId">
+                      <string>/platform</string>
+                    </field>
+                    <field name="description">
+                      <string>the /platform/web-contributors group</string>
+                    </field>
+                    <field name="label">
+                      <string>Web Contributors</string>
+                    </field>
+                  </object>
+                </value>
+                <value>
+                  <object type="org.exoplatform.services.organization.OrganizationConfig$Group">
+                    <field name="name">
                       <string>organization</string>
                     </field>
                     <field name="parentId">
@@ -263,7 +279,7 @@
                       <string>root@gatein.com</string>
                     </field>
                     <field name="groups">
-                      <string>*:/platform/administrators,*:/platform/users,*:/organization/employees,member:/organization/management/executive-board</string>
+                      <string>*:/platform/administrators,*:/platform/web-contributors,*:/platform/users,*:/organization/employees,member:/organization/management/executive-board</string>
                     </field>
                   </object>
                 </value>


### PR DESCRIPTION
This change will add a new group for CMS managers `/platform/web-contributors` and assign it to `root` by default.