### PR TITLE
fix: SKK MIGAS - Switch to indonesian language ko - EXO-66238 - Meeds-io/meeds#1163

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/common/locales-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/locales-config.xml
@@ -171,7 +171,7 @@
   </locale-config>
 
   <locale-config>
-    <locale>in</locale>
+    <locale>id</locale>
     <output-encoding>UTF-8</output-encoding>
     <input-encoding>UTF-8</input-encoding>
     <description>Default configuration for the Indonesian locale</description>
@@ -199,4 +199,3 @@
   </locale-config>
 
 </locales-config>
-


### PR DESCRIPTION
Prior to this change, when connect with any user and go to personal settings then change language to indonesian, the page is displayed as 404 error page. To fix this, change the key code language from indonesian from in to id.