### PR TITLE
fix: update indonesian language identifier - EXO-66238 - Meeds-io/meeds#1163

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/common/locales-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/locales-config.xml
@@ -171,7 +171,7 @@
   </locale-config>
 
   <locale-config>
-    <locale>in</locale>
+    <locale>id</locale>
     <output-encoding>UTF-8</output-encoding>
     <input-encoding>UTF-8</input-encoding>
     <description>Default configuration for the Indonesian locale</description>
@@ -199,4 +199,3 @@
   </locale-config>
 
 </locales-config>
-


### PR DESCRIPTION
Before this fix, the indoneasian language is not correctly configured. Since JDK 17, indonesian is 'id', and we use 'in'.
This commit modify the indonesian short identifier to respect jdk17

(cherry picked from commit https://github.com/Meeds-io/gatein-portal/commit/4eee46f30fcd0b4af520c0352ee7b04585c7ebc1)