### PR TITLE
fix: new created disabled user displayed in active members list - EXO-64050

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
@@ -180,6 +180,7 @@ public class UserRestResourcesV1 implements ResourceContainer {
     String firstName = userEntity.getFirstName();
     String lastName = userEntity.getLastName();
     String password = userEntity.getPassword();
+    Boolean isEnabled = userEntity.isEnabled();
 
     Locale locale = request == null ? Locale.ENGLISH : request.getLocale();
 
@@ -231,8 +232,8 @@ public class UserRestResourcesV1 implements ResourceContainer {
        return Response.status(Response.Status.BAD_REQUEST).entity("USERNAME:ALREADY_EXISTS_AS_DELETED").build();
     }
 
-    if (!user.isEnabled()) {
-      organizationService.getUserHandler().setEnabled(userName, false, true);
+    if (!isEnabled) {
+      organizationService.getUserHandler().setEnabled(userName, isEnabled, true);
     }
 
     return Response.noContent().build();


### PR DESCRIPTION
Prior to this change, when launch exo server and send post request on /portal/rest/v1/users with enabled equal to false, the user is listed in active members. To fix this, during creation of this user set value enabled to false. After this change, user is created and added to ddisabled list.