### PR TITLE
fix: Fix Id Generator in Tests - MEED-2700 - Meeds-io/MIPs#93

### DIFF
--- a/component/common/src/test/java/org/exoplatform/jpa/mock/AbstractInMemoryDAO.java
+++ b/component/common/src/test/java/org/exoplatform/jpa/mock/AbstractInMemoryDAO.java
@@ -30,11 +30,11 @@ import org.exoplatform.services.log.Log;
 
 public class AbstractInMemoryDAO<E> implements GenericDAO<E, Long> {
 
-  private static final Log                   LOG         = ExoLogger.getLogger(AbstractInMemoryDAO.class);
+  private static final Log                   LOG          = ExoLogger.getLogger(AbstractInMemoryDAO.class);
+
+  protected static final AtomicLong          ID_GENERATOR = new AtomicLong();
 
   protected Class<E>                         modelClass;
-
-  protected AtomicLong                       idGenerator = new AtomicLong();
 
   protected static Map<String, Map<Long, ?>> allEntities = new HashMap<>();
 
@@ -73,7 +73,7 @@ public class AbstractInMemoryDAO<E> implements GenericDAO<E, Long> {
 
   @Override
   public E create(E entity) {
-    long id = idGenerator.incrementAndGet();
+    long id = ID_GENERATOR.incrementAndGet();
     setId(entity, id);
     entities.put(id, entity);
     return entity;


### PR DESCRIPTION
Prior to this change, the Id generation in Unit Tests isn't generating a unique id during all Unit Tests execution. In fact, when starting a new Unit test suite, by example, the idGenerator restarts from 1 while caches aren't refreshed to delete all cache entries. Consequently, we can have an old entity from previous test execution. This change will make the idGenerator static and reusable through tests to ensure unicity.