### PR TITLE
fix: Allow to create a user with hyphen in user if authorized by regexp property - EXO-66876 - meeds-io/meeds#1197

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserFieldValidator.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserFieldValidator.java
@@ -200,7 +200,7 @@ public class UserFieldValidator {
   }
 
   private static boolean isSymbol(char c) {
-    return c == '_' || c == '.';
+    return c == '_' || c == '.' || c == '-' ;
   }
 
   private static String getLabel(Locale locale, String key, Object... values) {

--- a/component/portal/src/test/java/org/exoplatform/portal/rest/UserFieldValidatorTest.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/rest/UserFieldValidatorTest.java
@@ -102,4 +102,17 @@ public class UserFieldValidatorTest {
     assertNotNull(passwordValidator.validate(Locale.ENGLISH, "Aa123456"));
     assertNull(passwordValidator.validate(Locale.ENGLISH, "newPassword1"));
   }
+
+
+  @Test
+  public void testValidateFieldRegexWithHyphen() {
+    System.setProperty("gatein.validators.fieldregexphyphen.regexp", "[a-z1-9-]*");
+
+    try {
+      UserFieldValidator fieldValidator = new UserFieldValidator("fieldregexphyphen", true, false);
+      assertNull(fieldValidator.validate(Locale.ENGLISH, "a123-456"));
+    } finally {
+      System.setProperty("gatein.validators.fieldregexphyphen.regexp", "");
+    }
+  }
 }


### PR DESCRIPTION
Before this fix, even if the eregexp to validate username allow to use hyphen in username, it was not working This is due to a check around symbols which only authorize _ and . This commit add the - as authorized symbol

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
