### PR TITLE
fix: Fix Anonymous access to site - MEED-2505 - Meeds-io/MIPs#84

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -682,13 +682,17 @@ public class UserPortalConfigService implements Startable {
      * @return User home page uri preference
      */
     public String getUserHomePage(String username) {
-      SettingValue<?> homePageSettingValue = settingService.get(Context.USER.id(username),
-                                                                HOME_PAGE_URI_PREFERENCE_SCOPE,
-                                                                HOME_PAGE_URI_PREFERENCE_KEY);
-      if (homePageSettingValue != null && homePageSettingValue.getValue() != null) {
-        return homePageSettingValue.getValue().toString();
+      if (StringUtils.isBlank(username)) {
+        return null;
+      } else {
+        SettingValue<?> homePageSettingValue = settingService.get(Context.USER.id(username),
+                                                                  HOME_PAGE_URI_PREFERENCE_SCOPE,
+                                                                  HOME_PAGE_URI_PREFERENCE_KEY);
+        if (homePageSettingValue != null && homePageSettingValue.getValue() != null) {
+          return homePageSettingValue.getValue().toString();
+        }
+        return PropertyManager.getProperty("exo.portal.user.defaultHome");
       }
-      return PropertyManager.getProperty("exo.portal.user.defaultHome");
     }
 
     /**

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -1122,11 +1122,15 @@ public class UIPortalApplication extends UIApplication {
      */
     public boolean isMenuSticky() {
       PortalRequestContext context = Util.getPortalRequestContext();
-      SettingValue<?> stickySettingValue = getApplicationComponent(SettingService.class).get(Context.USER.id(context.getRemoteUser()),
-                                                                                             Scope.APPLICATION.id("HamburgerMenu"),
-                                                                                             "Sticky");
-      return stickySettingValue == null ? Boolean.parseBoolean(System.getProperty("io.meeds.userPrefs.HamburgerMenu.sticky", "false"))
-                                        : Boolean.parseBoolean(stickySettingValue.getValue().toString());
+      if (StringUtils.isBlank(context.getRemoteUser())) {
+        return false;
+      } else {
+        SettingValue<?> stickySettingValue = getApplicationComponent(SettingService.class).get(Context.USER.id(context.getRemoteUser()),
+                                                                                               Scope.APPLICATION.id("HamburgerMenu"),
+                                                                                               "Sticky");
+        return stickySettingValue == null ? Boolean.parseBoolean(System.getProperty("io.meeds.userPrefs.HamburgerMenu.sticky", "false"))
+                                          : Boolean.parseBoolean(stickySettingValue.getValue().toString());
+      }
     }
 
     /**


### PR DESCRIPTION
Prior to this change some NPE errors are logged due to missing username while accessing a portal publically. This change will delete using username when the user isn't authenticated yet.