### PR TITLE
feat: Allow to hide pages or part of page switch Hub Access Type - MEED-2811 - Meeds-io/MIPs#100

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/mop/navigation/NodeManager.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/navigation/NodeManager.java
@@ -185,7 +185,9 @@ public class NodeManager {
         NodeChangeQueue<NodeContext<N>> changes = rebased.getChanges();
         if (changes != null) {
             changes.broadcast(persister);
-            changes.broadcast(listener);
+            if (listener != null) {
+              changes.broadcast(listener);
+            }
 
             // Update the tree handles to the persistent values
             for (Map.Entry<String, String> entry : persister.toPersist.entrySet()) {

--- a/component/api/src/main/java/org/exoplatform/portal/mop/service/NavigationService.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/service/NavigationService.java
@@ -77,6 +77,19 @@ public interface NavigationService extends org.exoplatform.portal.mop.navigation
                               NodeChangeListener<NodeContext<N>> listener);
 
   /**
+   * @param siteKey
+   * @return
+   */
+  NodeContext<NodeContext<?>> loadNode(SiteKey siteKey);
+
+  /**
+   * @param siteKey
+   * @param navUri
+   * @return
+   */
+  NodeContext<NodeContext<?>> loadNode(SiteKey siteKey, String navUri);
+
+  /**
    * Load a navigation node from a specified navigation by its id
    *
    * @param  model    the node model

--- a/component/portal/src/main/java/io/meeds/portal/security/listener/PortalRegistrationUpdateListener.java
+++ b/component/portal/src/main/java/io/meeds/portal/security/listener/PortalRegistrationUpdateListener.java
@@ -1,0 +1,61 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.portal.security.listener;
+
+import java.util.List;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.Visibility;
+import org.exoplatform.portal.mop.navigation.NodeContext;
+import org.exoplatform.portal.mop.navigation.NodeState;
+import org.exoplatform.portal.mop.service.NavigationService;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+
+import io.meeds.portal.security.constant.UserRegistrationType;
+
+public class PortalRegistrationUpdateListener extends Listener<Object, UserRegistrationType> {
+
+  private NavigationService navigationService;
+
+  private List<String>      managedPages;
+
+  public PortalRegistrationUpdateListener(NavigationService navigationService, InitParams params) {
+    this.navigationService = navigationService;
+    this.managedPages = params.getValuesParam("managed-pages").getValues();
+  }
+
+  @Override
+  public void onEvent(Event<Object, UserRegistrationType> event) throws Exception {
+    boolean isOpen = event.getData() == UserRegistrationType.OPEN;
+    managedPages.forEach(navUri -> {
+      NodeContext<NodeContext<?>> navNode = navigationService.loadNode(SiteKey.portal("public"), navUri);
+      if (navNode != null) {
+        NodeState state = navNode.getState()
+                                 .builder()
+                                 .visibility(isOpen ? Visibility.DISPLAYED : Visibility.HIDDEN)
+                                 .build();
+        navNode.setState(state);
+        navigationService.updateNode(Long.parseLong(navNode.getId()), state);
+      }
+    });
+  }
+
+}

--- a/component/portal/src/test/java/io/meeds/portal/security/listener/PortalRegistrationUpdateListenerTest.java
+++ b/component/portal/src/test/java/io/meeds/portal/security/listener/PortalRegistrationUpdateListenerTest.java
@@ -1,0 +1,98 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.portal.security.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValuesParam;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.Visibility;
+import org.exoplatform.portal.mop.navigation.NodeContext;
+import org.exoplatform.portal.mop.navigation.NodeState;
+import org.exoplatform.portal.mop.navigation.NodeState.Builder;
+import org.exoplatform.portal.mop.service.NavigationService;
+import org.exoplatform.services.listener.Event;
+
+import io.meeds.portal.security.constant.UserRegistrationType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PortalRegistrationUpdateListenerTest {
+
+  private static final String                 NAV_NODE_ID  = "1225";
+
+  private static final String                 NAV_NODE_URI = "publicSiteNodeUri";
+
+  @Mock
+  private NavigationService                   navigationService;
+
+  @Mock
+  private InitParams                          params;
+
+  @Mock
+  private NodeContext<NodeContext<?>>         navNode;
+
+  @Mock
+  private NodeState                           navState;
+
+  @Mock
+  private Builder                             navStateBuilder;
+
+  @Mock
+  private Event<Object, UserRegistrationType> event;
+
+  @Test
+  public void testUpdateRegistrationType() throws Exception {
+    ValuesParam valuesParam = new ValuesParam();
+    valuesParam.setValues(Arrays.asList(NAV_NODE_URI));
+    when(params.getValuesParam("managed-pages")).thenReturn(valuesParam);
+    when(navigationService.loadNode(SiteKey.portal("public"), NAV_NODE_URI)).thenReturn(navNode);
+    when(navNode.getId()).thenReturn(NAV_NODE_ID);
+    when(navNode.getState()).thenReturn(navState);
+    when(navState.builder()).thenReturn(navStateBuilder);
+    when(navStateBuilder.visibility(any())).thenReturn(navStateBuilder);
+    when(navStateBuilder.build()).thenReturn(navState);
+
+    PortalRegistrationUpdateListener registrationUpdateListener = new PortalRegistrationUpdateListener(navigationService, params);
+
+    when(event.getData()).thenReturn(UserRegistrationType.OPEN);
+    registrationUpdateListener.onEvent(event);
+
+    verify(navStateBuilder, times(1)).visibility(Visibility.DISPLAYED);
+    verify(navStateBuilder, never()).visibility(Visibility.HIDDEN);
+    verify(navigationService, times(1)).updateNode(Long.parseLong(NAV_NODE_ID), navState);
+
+    when(event.getData()).thenReturn(UserRegistrationType.RESTRICTED);
+    registrationUpdateListener.onEvent(event);
+    verify(navStateBuilder, times(1)).visibility(Visibility.HIDDEN);
+    verify(navigationService, times(2)).updateNode(Long.parseLong(NAV_NODE_ID), navState);
+  }
+
+}

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestLoadedPOM.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestLoadedPOM.java
@@ -121,6 +121,24 @@ public class TestLoadedPOM extends AbstractConfigTest {
     assertEquals(Visibility.TEMPORAL, nodeNavigation.getState().getVisibility());
   }
 
+  public void testLoadNode() throws Exception {
+    NodeContext<?> root = navService.loadNode(SiteKey.portal("test"));
+    assertEquals(5, root.getNodeCount());
+
+    NodeContext<?> nodeNavigation = navService.loadNode(SiteKey.portal("test"), "node_name");
+    assertEquals(0, nodeNavigation.getNodeCount());
+    assertEquals("node_name", nodeNavigation.getName());
+    assertEquals("node_label", nodeNavigation.getState().getLabel());
+    assertEquals("node_icon", nodeNavigation.getState().getIcon());
+    GregorianCalendar start = new GregorianCalendar(2000, 2, 21, 1, 33, 0);
+    start.setTimeZone(TimeZone.getTimeZone("UTC"));
+    assertEquals(start.getTime().getTime(), nodeNavigation.getState().getStartPublicationTime());
+    GregorianCalendar end = new GregorianCalendar(2009, 2, 21, 1, 33, 0);
+    end.setTimeZone(TimeZone.getTimeZone("UTC"));
+    assertEquals(end.getTime().getTime(), nodeNavigation.getState().getEndPublicationTime());
+    assertEquals(Visibility.TEMPORAL, nodeNavigation.getState().getVisibility());
+  }
+
   public void testPortal() throws Exception {
     PortalConfig portal = layoutService.getPortalConfig("test");
     assertNotNull(portal);

--- a/component/portal/src/test/java/org/exoplatform/portal/test/InitContainer1TestSuite.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/test/InitContainer1TestSuite.java
@@ -57,14 +57,13 @@ import org.exoplatform.portal.rest.UserRestResourcesTest;
 import org.exoplatform.portal.tree.list.TestListTree;
 import org.exoplatform.settings.rest.SettingResourceTest;
 
+import io.meeds.portal.security.listener.PortalRegistrationUpdateListenerTest;
 import io.meeds.portal.security.service.SettingSecurityServieTest;
-
-
-
 
 @RunWith(Suite.class)
 @SuiteClasses({
     SettingSecurityServieTest.class,
+    PortalRegistrationUpdateListenerTest.class,
     AccountSetupServiceTest.class,
     BrandingServiceImplTest.class,
     DefaultGroupVisibilityPluginTest.class,

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIOpenRegistrationContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIOpenRegistrationContainer.gtmpl
@@ -1,0 +1,9 @@
+<%
+  import io.meeds.portal.security.service.SecuritySettingService;
+  import io.meeds.portal.security.constant.UserRegistrationType;
+
+  if(_ctx.getRequestContext().getUIApplication().isEditing()
+     || UserRegistrationType.OPEN == uicomponent.getApplicationComponent(SecuritySettingService.class).getRegistrationType()) {
+    uicomponent.renderChildren();
+  }
+%>


### PR DESCRIPTION
This change will allow to hide/display :
- Page navigation in public site: when the Hub Access type changes. This is made using a listener that will be triggered once the Hub Access changes
- Page Body application: when the Hub Access type changes. This is made using a behavior container which will be used to hide applications in  when the Hub Access isn't of type .