### PR TITLE
feat: Move JS definition of Site names in Meeds - MEED-2811 - Meeds-io/MIPs#100

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -137,7 +137,6 @@
    <script type="text/javascript" id="portalHeadScripts">
      eXo.env.portal.context = "<%=docBase%>";
      eXo.env.portal.accessMode = "<%= rcontext.getAccessPath() == 0 ? "public" : "private" %>";
-     eXo.env.portal.portalName = "<%=rcontext.getPortalOwner()%>";
      eXo.env.portal.homeLink = "<%=userHomeLink%>";
      eXo.env.portal.stickyMenu = <%=stickyMenu%>;
      eXo.env.portal.containerName = "<%=PortalContainer.getInstance().getName()%>";

--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -522,14 +522,18 @@ public class PortalRequestContext extends WebuiRequestContext {
     public SiteKey getSiteKey() {
         return siteKey;
     }
-
+    
     public String getPortalOwner() {
-        UserPortalConfig userPortalConfig = getUserPortalConfig();
-        if (userPortalConfig != null && userPortalConfig.getPortalName() != null) {
-            return userPortalConfig.getPortalName();
-        } else {
-            return portalConfigService.getDefaultPortal();
-        }
+      UserPortalConfig userPortalConfig = getUserPortalConfig();
+      if (userPortalConfig != null && userPortalConfig.getPortalName() != null) {
+        return userPortalConfig.getPortalName();
+      } else {
+        return portalConfigService.getDefaultPortal();
+      }
+    }
+
+    public String getDefaultPortal() {
+      return portalConfigService.getDefaultPortal();
     }
 
     public String getNodePath() {


### PR DESCRIPTION
This change will allow to define the default site name and current site name in a gtmpl centralized in Meeds package knowing that applications are now referenced in different sites and not aggregated in a single one.