### PR TITLE
fix: LDAP user unable to login - EXO-67267 - meeds-io/meeds#1244

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
@@ -572,7 +572,7 @@ public class PicketLinkIDMExternalStoreService implements IDMExternalStoreServic
   }
 
   private boolean validatePassword(final org.picketlink.idm.api.User idmUser, String password) throws Exception {
-    return (Boolean) executeOnExternalStoreFuntion.apply(() -> picketLinkIDMService.getExtendedAttributeManager()
+    return (Boolean) executeOnExternalStoreFuntion.apply(() -> picketLinkIDMService.getIdentitySession().getAttributesManager()
                                                                                    .validatePassword(idmUser, password));
   }
 


### PR DESCRIPTION
Before this fix, an user in external store is unable to login This is due to last modification about password algorithm change. For a normal user, when the password is validated, we check if the password needs to be updated. For an external user, we should not check this as the password policy is managed by the external store.

Before this fix, we try to update password for external users to, and as we do not have write access on AD/LDAP, it is not working This commit remove the modification we done for external user, to simply validate the password.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
