### PR TITLE
fix: Fix Misleading Transaction status on IDM listeners - MEED-2899 - Meeds-io/meeds#1276

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableMembershipHandlerImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableMembershipHandlerImpl.java
@@ -174,11 +174,14 @@ public class CacheableMembershipHandlerImpl extends MembershipDAOImpl {
     disableCacheInThread.set(true);
     try {
       super.linkMembership(user, g, mt, broadcast);
-      if (useCacheList) {
-        membershipCache.remove(new MembershipCacheKey(user.getUserName(), null, null));
-      }
     } finally {
       disableCacheInThread.set(false);
+      if (user != null && g != null && mt != null) {
+        membershipCache.remove(new MembershipCacheKey(user.getUserName(), g.getId(), mt.getName()));
+        if (useCacheList) {
+          membershipCache.remove(new MembershipCacheKey(user.getUserName(), null, null));
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Prior to this change, right after creating the user we may not access the user information (inside listeners by example) from stores until the Transaction is committed.

This change will commit the IDM transaction before and after each listener execution to ensure to have fresh IDM status before executing the next one from the list.

Without this change by example, the IDM Caches can be populated by wrong information like the list of memberships that will be empty due to the fact that the modifications made by the listener '`org.exoplatform.services.organization.plugin.NewUserEventListener`' aren't committed yet.