### PR TITLE
fix: Fix Misleading Transaction status on IDM listeners - MEED-2899 - Meeds-io/meeds#1276

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -42,7 +42,7 @@ import org.exoplatform.services.organization.externalstore.IDMExternalStoreServi
  */
 public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
 
-  private List<UserEventListener> listeners_ = new ArrayList<UserEventListener>(3);
+  private static final String     LISTENER_EXECUTION_ERR_MSG = "Error executing %s on listener %s for user %s";
 
   public static final String      USER_PASSWORD        = EntityMapperUtils.USER_PASSWORD;
 
@@ -88,6 +88,8 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
 
     USER_NON_PROFILE_KEYS = Collections.unmodifiableSet(keys);
   }
+
+  private List<UserEventListener> listeners_ = new ArrayList<UserEventListener>(3);
 
   public UserDAOImpl(PicketLinkIDMOrganizationServiceImpl orgService, PicketLinkIDMService idmService) {
     super(orgService, idmService);
@@ -387,10 +389,7 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
   }
 
   public boolean authenticateExternal(String username, String password) throws Exception {
-    ExoContainer currentContainer = ExoContainerContext.getCurrentContainer();
-    if (currentContainer == null || (currentContainer instanceof RootContainer)) {
-      currentContainer = PortalContainer.getInstance();
-    }
+    ExoContainer currentContainer = getPortalContainer();
     IDMExternalStoreService externalStoreService = currentContainer.getComponentInstanceOfType(IDMExternalStoreService.class);
     if (externalStoreService == null || !externalStoreService.isEnabled()) {
       return false;
@@ -702,38 +701,40 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
 
 
   //
-  private void preSave(User user, boolean isNew) throws Exception {
+  private void preSave(User user, boolean isNew) {
     for (UserEventListener listener : listeners_) {
-      listener.preSave(user, isNew);
+      executeWithTransaction(() -> preSave(listener, user, isNew));
     }
   }
 
-  private void postSave(User user, boolean isNew) throws Exception {
+  private void postSave(User user, boolean isNew) {
     for (UserEventListener listener : listeners_) {
-      listener.postSave(user, isNew);
+      executeWithTransaction(() -> postSave(listener, user, isNew));
     }
   }
 
-  private void preDelete(User user) throws Exception {
+  private void preDelete(User user) {
     for (UserEventListener listener : listeners_) {
-      listener.preDelete(user);
+      executeWithTransaction(() -> preDelete(listener, user));
     }
   }
 
-  private void postDelete(User user) throws Exception {
+  private void postDelete(User user) {
     for (UserEventListener listener : listeners_) {
-      listener.postDelete(user);
+      executeWithTransaction(() -> postDelete(listener, user));
     }
   }
 
-  private void preSetEnabled(User user) throws Exception {
-    for (UserEventListener listener : listeners_)
-      listener.preSetEnabled(user);
+  private void preSetEnabled(User user) {
+    for (UserEventListener listener : listeners_) {
+      executeWithTransaction(() -> preSetEnabled(listener, user));
+    }
   }
 
   private void postSetEnabled(User user) throws Exception {
-    for (UserEventListener listener : listeners_)
-      listener.postSetEnabled(user);
+    for (UserEventListener listener : listeners_) {
+      executeWithTransaction(() -> postSetEnabled(listener, user));
+    }
   }
 
   public void persistUserInfo(User user, IdentitySession session, boolean isNew) throws Exception {
@@ -919,6 +920,122 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
 
   private boolean disableUserActived() {
     return orgService.getConfiguration().isDisableUserActived();
+  }
+
+  private void preSave(UserEventListener listener, User user, boolean isNew) {
+    try {
+      listener.preSave(user, isNew);
+    } catch (Exception e) {
+      // throw the error if the operation shouldn't continue
+      throw new IllegalStateException(String.format(LISTENER_EXECUTION_ERR_MSG,
+                                                    "preSave",
+                                                    listener.getClass().getName(),
+                                                    user.getUserName()),
+                                      e);
+    }
+  }
+
+  private void postSave(UserEventListener listener, User user, boolean isNew) {
+    try {
+      listener.postSave(user, isNew);
+    } catch (Exception e) {
+      // Just log the error to not stop event propagation
+      log.warn(String.format(LISTENER_EXECUTION_ERR_MSG,
+                             "postSave",
+                             listener.getClass().getName(),
+                             user.getUserName()),
+               e);
+    }
+  }
+
+  private void preDelete(UserEventListener listener, User user) {
+    try {
+      listener.preDelete(user);
+    } catch (Exception e) {
+      // throw the error if the operation shouldn't continue
+      throw new IllegalStateException(String.format(LISTENER_EXECUTION_ERR_MSG,
+                                                    "preDelete",
+                                                    listener.getClass().getName(),
+                                                    user.getUserName()),
+                                      e);
+    }
+  }
+
+  private void postDelete(UserEventListener listener, User user) {
+    try {
+      listener.postDelete(user);
+    } catch (Exception e) {
+      // Just log the error to not stop event propagation
+      log.warn(String.format(LISTENER_EXECUTION_ERR_MSG,
+                             "postDelete",
+                             listener.getClass().getName(),
+                             user.getUserName()),
+               e);
+    }
+  }
+
+  private void preSetEnabled(UserEventListener listener, User user) {
+    try {
+      listener.preSetEnabled(user);
+    } catch (Exception e) {
+      // throw the error if the operation shouldn't continue
+      throw new IllegalStateException(String.format(LISTENER_EXECUTION_ERR_MSG,
+                                                    "preSetEnabled",
+                                                    listener.getClass().getName(),
+                                                    user.getUserName()),
+                                      e);
+    }
+  }
+
+  private void postSetEnabled(UserEventListener listener, User user) {
+    try {
+      listener.postSetEnabled(user);
+    } catch (Exception e) {
+      // Just log the error to not stop event propagation
+      log.warn(String.format(LISTENER_EXECUTION_ERR_MSG,
+                             "postSetEnabled",
+                             listener.getClass().getName(),
+                             user.getUserName()),
+               e);
+    }
+  }
+
+  public void executeWithTransaction(Runnable runnable) {
+    int transactionCount = restartTransaction();
+    ExoContainer portalContainer = getPortalContainer();
+    if (transactionCount == 0) {
+      orgService.startRequest(portalContainer);
+    }
+    try {
+      runnable.run();
+    } finally {
+      if (transactionCount == 0 && orgService.isStarted(portalContainer)) {
+        orgService.endRequest(portalContainer);
+      }
+    }
+  }
+
+  protected int restartTransaction() {
+    ExoContainer portalContainer = getPortalContainer();
+    int i = 0;
+    // Close transactions until no encapsulated transaction
+    while (orgService.isStarted(portalContainer)) {
+      orgService.endRequest(portalContainer);
+      i++;
+    }
+    // Restart transactions with the same number of encapsulations
+    for (int j = 0; j < i; j++) {
+      orgService.startRequest(portalContainer);
+    }
+    return i;
+  }
+
+  private ExoContainer getPortalContainer() {
+    ExoContainer currentContainer = ExoContainerContext.getCurrentContainer();
+    if (currentContainer == null || (currentContainer instanceof RootContainer)) {
+      currentContainer = PortalContainer.getInstance();
+    }
+    return currentContainer;
   }
 
 }

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableMembershipHandlerImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/cache/CacheableMembershipHandlerImpl.java
@@ -174,11 +174,14 @@ public class CacheableMembershipHandlerImpl extends MembershipDAOImpl {
     disableCacheInThread.set(true);
     try {
       super.linkMembership(user, g, mt, broadcast);
-      if (useCacheList) {
-        membershipCache.remove(new MembershipCacheKey(user.getUserName(), null, null));
-      }
     } finally {
       disableCacheInThread.set(false);
+      if (user != null && g != null && mt != null) {
+        membershipCache.remove(new MembershipCacheKey(user.getUserName(), g.getId(), mt.getName()));
+        if (useCacheList) {
+          membershipCache.remove(new MembershipCacheKey(user.getUserName(), null, null));
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Prior to this change, right after creating the user we may not access the user information (inside listeners by example) from stores until the Transaction is committed.

This change will commit the IDM transaction before and after each listener execution to ensure to have fresh IDM status before executing the next one from the list.

Without this change by example, the IDM Caches can be populated by wrong information like the list of memberships that will be empty due to the fact that the modifications made by the listener
'`org.exoplatform.services.organization.plugin.NewUserEventListener`' aren't committed yet.