### PR TITLE
fix: Set "displayed" property of space sites to true - EXO-67478 - Meeds-io/MIPs#88

### DIFF
--- a/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
+++ b/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
@@ -430,4 +430,10 @@
       <column name="BANNER_FILE_ID" type="BIGINT"/>
     </createIndex>
   </changeSet>
+  
+  <changeSet author="portal" id="1.0.0-39" dbms="mysql">
+    <sql>
+      UPDATE PORTAL_SITES set DISPLAYED=1 where NAME LIKE '/spaces/%';
+    </sql>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Before this fix, some spaces created before setting "displayed" property to true, the value of the "displayed" property still having value false which causes a problem of displaying the space site pages without the shared layout due to the standalone/aggregated switch rule. After this change, a liquibase changeSet will be added to set all space sites "displayed" property to true in order to avoid these problems.