### PR TITLE
fix: Set "displayed" property of space sites to true - EXO-67478

### DIFF
--- a/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
+++ b/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
@@ -430,4 +430,10 @@
       <column name="BANNER_FILE_ID" type="BIGINT"/>
     </createIndex>
   </changeSet>
+  
+  <changeSet author="portal" id="1.0.0-39">
+    <sql>
+      UPDATE PORTAL_SITES set DISPLAYED=1 where NAME LIKE '/spaces/%';
+    </sql>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this fix, for some spaces created before setting "displayed" property to true, the value of the "displayed" property still having value false which causes a problem of displaying the space site pages without the shared layout due to the standalone/aggregated switch rule.
After this change, we have added a liquibase changelog to set all space sites "displayed" property to true in order to avoid these problems.