### PR TITLE
fix: Add hidden class when portlet is empty-MEED-2977-Meeds-io/meeds#1313

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
@@ -144,7 +144,6 @@
 							</div>		
 						</div>
 					</div>
-					
 					<%//Begin Bottom Decorator %>
 					<div class="bottomDecorator clearfix">
 						<div class="resizeArea" title="<%=_ctx.appRes("UIPortlet.tooltip.ResizeWindow");%>"><span></span></div>
@@ -166,13 +165,17 @@
 			{
 				cssStyle += "height: "+ windowHeight +";";
 			}
+			String hiddenClass = "";
+			if(org.apache.commons.lang.StringUtils.isBlank(portletContent.toString())) {
+			  hiddenClass = "hidden";
+			}
  %>
  				<div id="<%=editMode == EditMode.NO_EDIT ? portletId : "EditMode-"+ portletId%>">
-					<div class="PORTLET-FRAGMENT" style="${cssStyle}">
+					<div class="PORTLET-FRAGMENT $hiddenClass" style="${cssStyle}">
  						<% 
 							if(hasAccessPermission)
               {
-							   println portletContent; 
+							   println portletContent;
               }
 							else
 							{

--- a/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
@@ -166,7 +166,7 @@
 				cssStyle += "height: "+ windowHeight +";";
 			}
 			String hiddenClass = "";
-			if(org.apache.commons.lang.StringUtils.isBlank(portletContent.toString())) {
+			if(portletContent == null || org.apache.commons.lang.StringUtils.isBlank(portletContent.toString())) {
 			  hiddenClass = "hidden";
 			}
  %>


### PR DESCRIPTION
Prior to this change, in all space pages (except the space home page) an extra margin in the top is displayed. This margin is due to the padding-bottom added to all portlet in the platform.
This PR adds the CSS class hidden to the portlet when there is no content to display.