### PR TITLE
feat: Allow to define a Reusable Skin Module - MEED-2994 - Meeds-io/MIPs#108

### DIFF
--- a/component/scripting/src/test/resources/UIPortalApplication.gtmpl
+++ b/component/scripting/src/test/resources/UIPortalApplication.gtmpl
@@ -37,6 +37,9 @@
     <%}%>
     <%for(portletSkin in portletSkins) {
     def url = portletSkin.createURL();
+    if (url == null) {
+      continue;
+    }
     url.setOrientation(orientation);
     %>
       <link id="${portletSkin.id}" rel="stylesheet" type="text/css" href= "$url" />

--- a/component/web/resources/pom.xml
+++ b/component/web/resources/pom.xml
@@ -30,7 +30,7 @@
   <description>GateIn web resource serving services such as Javascript, skins and stylesheets</description>
 
   <properties>
-    <exo.test.coverage.ratio>0.63</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.65</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/CompositeResourceResolver.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/CompositeResourceResolver.java
@@ -23,6 +23,9 @@ import java.io.Reader;
 import java.util.Map;
 
 import org.exoplatform.services.log.Log;
+
+import org.apache.commons.lang3.StringUtils;
+
 import org.exoplatform.services.log.ExoLogger;
 
 /**
@@ -67,7 +70,7 @@ class CompositeResourceResolver implements ResourceResolver {
                 String module = Codec.decode(blah[i + 1]);
                 SkinKey key = new SkinKey(module, name);
                 SkinConfig skin = skins.get(key);
-                if (skin != null) {
+                if (skin != null && StringUtils.isNotBlank(skin.getCSSPath())) {
                     sb.append("@import url(").append(skin.getCSSPath()).append(");").append("\n");
                 }
             }

--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/CompositeSkin.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/CompositeSkin.java
@@ -33,6 +33,8 @@ import org.exoplatform.web.controller.QualifiedName;
 import org.exoplatform.web.controller.router.URIWriter;
 import org.exoplatform.web.url.MimeType;
 import org.exoplatform.services.log.ExoLogger;
+
+import org.apache.commons.lang3.StringUtils;
 import org.gatein.portal.controller.resource.ResourceRequestHandler;
 
 /**
@@ -58,7 +60,9 @@ class CompositeSkin implements Skin {
     CompositeSkin(SkinService service, Collection<SkinConfig> skins, String compositeId) {
         TreeMap<String, SkinConfig> urlSkins = new TreeMap<String, SkinConfig>();
         for (SkinConfig skin : skins) {
-            urlSkins.put(skin.getCSSPath(), skin);
+            if (StringUtils.isNotBlank(skin.getCSSPath())) {
+              urlSkins.put(skin.getCSSPath(), skin);
+            }
         }
 
         //

--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/SimpleSkin.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/SimpleSkin.java
@@ -21,6 +21,7 @@ package org.exoplatform.portal.resource;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.exoplatform.commons.utils.PropertyManager;
@@ -30,98 +31,161 @@ import org.exoplatform.web.WebAppController;
 import org.exoplatform.web.controller.QualifiedName;
 import org.exoplatform.web.controller.router.URIWriter;
 import org.exoplatform.web.url.MimeType;
+
+import lombok.Getter;
+import lombok.Setter;
+
 import org.exoplatform.services.log.ExoLogger;
+
+import org.apache.commons.lang3.StringUtils;
 import org.gatein.portal.controller.resource.ResourceRequestHandler;
 
 /**
- * An implementation of the skin config.
- *
- * Created by The eXo Platform SAS Jan 19, 2007
+ * An implementation of the skin config. Created by The eXo Platform SAS Jan 19,
+ * 2007
  */
 class SimpleSkin implements SkinConfig {
 
-    private final String module_;
+  private final String       module;
 
-    private final String name_;
+  private final String       name;
 
-    private final String cssPath_;
+  private final String       cssPath;
 
-    private final String id_;
+  private final String       id;
 
-    private final int priority;
+  private final int          priority;
 
-    public SimpleSkin(SkinService service, String module, String name, String cssPath) {
-        this(service, module, name, cssPath, Integer.MAX_VALUE);
+  private final boolean      filtered;
+
+  private final List<String> additionalModules;
+
+  private String             type;
+
+  public SimpleSkin(SkinService service, String module, String name, String cssPath) {
+    this(service, module, name, cssPath, Integer.MAX_VALUE);
+  }
+
+  public SimpleSkin(SkinService service, String module, String name, String cssPath, int cssPriority) {
+    this.module = module;
+    this.name = name;
+    this.cssPath = cssPath;
+    this.id = module.replace('/', '_');
+    priority = cssPriority;
+    additionalModules = null;
+    filtered = false;
+  }
+
+  public SimpleSkin(String module, String name, String cssPath, int cssPriority, List<String> additionalModules) {
+    this.module = module;
+    this.name = name;
+    this.cssPath = cssPath;
+    this.id = module.replace('/', '_');
+    this.priority = cssPriority;
+    this.additionalModules = additionalModules;
+    this.filtered = false;
+  }
+
+  public SimpleSkin(String module, String name, String cssPath, int cssPriority, boolean filtered) {
+    this.module = module;
+    this.name = name;
+    this.cssPath = cssPath;
+    this.id = module.replace('/', '_');
+    this.priority = cssPriority;
+    this.additionalModules = null;
+    this.filtered = filtered;
+  }
+
+  @Override
+  public int getCSSPriority() {
+    return priority;
+  }
+
+  @Override
+  public String getId() {
+    return this.id;
+  }
+
+  @Override
+  public String getModule() {
+    return this.module;
+  }
+
+  @Override
+  public String getCSSPath() {
+    return this.cssPath;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
+  }
+
+  @Override
+  public boolean isFiltered() {
+    return filtered;
+  }
+
+  @Override
+  public List<String> getAdditionalModules() {
+    return additionalModules;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String toString() {
+    return "SimpleSkin[id=" + this.id + ",module=" + this.module + ",name=" + this.name + ",cssPath=" + this.cssPath +
+        ", priority=" + priority +
+        "]";
+  }
+
+  public SkinURL createURL(final ControllerContext context) {
+    if (context == null) {
+      throw new NullPointerException("No controller context provided");
     }
-
-    public SimpleSkin(SkinService service, String module, String name, String cssPath, int cssPriority) {
-        module_ = module;
-        name_ = name;
-        cssPath_ = cssPath;
-        id_ = module.replace('/', '_');
-        priority = cssPriority;
+    if (StringUtils.isBlank(this.cssPath)) {
+      return null;
     }
+    return new SkinURL() {
 
-    public int getCSSPriority() {
-        return priority;
-    }
+      Orientation orientation = null;
 
-    public String getId() {
-        return id_;
-    }
+      boolean     compress    = !PropertyManager.isDevelopping();
 
-    public String getModule() {
-        return module_;
-    }
+      public void setOrientation(Orientation orientation) {
+        this.orientation = orientation;
+      }
 
-    public String getCSSPath() {
-        return cssPath_;
-    }
+      @Override
+      public String toString() {
+        try {
+          String resource = cssPath.substring(1, cssPath.length() - ".css".length());
 
-    public String getName() {
-        return name_;
-    }
+          //
+          Map<QualifiedName, String> params = new HashMap<QualifiedName, String>();
+          params.put(ResourceRequestHandler.VERSION_QN, ResourceRequestHandler.VERSION);
+          params.put(ResourceRequestHandler.ORIENTATION_QN, orientation == Orientation.RT ? "rt" : "lt");
+          params.put(ResourceRequestHandler.COMPRESS_QN, compress ? "min" : "");
+          params.put(WebAppController.HANDLER_PARAM, "skin");
+          params.put(ResourceRequestHandler.RESOURCE_QN, resource);
+          StringBuilder url = new StringBuilder();
+          context.renderURL(params, new URIWriter(url, MimeType.PLAIN));
 
-    public String toString() {
-        return "SimpleSkin[id=" + id_ + ",module=" + module_ + ",name=" + name_ + ",cssPath=" + cssPath_ + ", priority="
-                + priority + "]";
-    }
-
-    public SkinURL createURL(final ControllerContext context) {
-        if (context == null) {
-            throw new NullPointerException("No controller context provided");
+          //
+          return url.toString();
+        } catch (IOException e) {
+          ExoLogger.getLogger(this.getClass()).error(e.getMessage(), e);
+          return null;
         }
-        return new SkinURL() {
-
-            Orientation orientation = null;
-            boolean compress = !PropertyManager.isDevelopping();
-
-            public void setOrientation(Orientation orientation) {
-                this.orientation = orientation;
-            }
-
-            @Override
-            public String toString() {
-                try {
-                    String resource = cssPath_.substring(1, cssPath_.length() - ".css".length());
-
-                    //
-                    Map<QualifiedName, String> params = new HashMap<QualifiedName, String>();
-                    params.put(ResourceRequestHandler.VERSION_QN, ResourceRequestHandler.VERSION);
-                    params.put(ResourceRequestHandler.ORIENTATION_QN, orientation == Orientation.RT ? "rt" : "lt");
-                    params.put(ResourceRequestHandler.COMPRESS_QN, compress ? "min" : "");
-                    params.put(WebAppController.HANDLER_PARAM, "skin");
-                    params.put(ResourceRequestHandler.RESOURCE_QN, resource);
-                    StringBuilder url = new StringBuilder();
-                    context.renderURL(params, new URIWriter(url, MimeType.PLAIN));
-
-                    //
-                    return url.toString();
-                } catch (IOException e) {
-              ExoLogger.getLogger(this.getClass()).error(e.getMessage(), e);
-                    return null;
-                }
-            }
-        };
-    }
+      }
+    };
+  }
 }

--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/Skin.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/Skin.java
@@ -45,4 +45,17 @@ public interface Skin {
      */
     SkinURL createURL(ControllerContext context) throws NullPointerException;
 
+    /**
+     * Returns the priority number
+     *
+     * @return the priority number
+     */
+    default int getCSSPriority() {
+      return 0;
+    }
+
+    default String getType() {
+      return "custom";
+    }
+
 }

--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/SkinConfig.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/SkinConfig.java
@@ -19,6 +19,8 @@
 
 package org.exoplatform.portal.resource;
 
+import java.util.List;
+
 /**
  * Extends a skin with additional information.
  *
@@ -48,10 +50,24 @@ public interface SkinConfig extends Skin {
     String getCSSPath();
 
     /**
-     * Returns the priority number
-     *
-     * @return the priority number
+     * @return the dependent PortalSkins to load with the current Skin
      */
-    int getCSSPriority();
+    default List<String> getAdditionalModules() {
+      return null;
+    }
+
+    /**
+     * @return true is the current PortalSkin is filtered
+     */
+    default boolean isFiltered() {
+      return false;
+    }
+
+    /**
+     * Sets Skin type
+     * 
+     * @param type
+     */
+    void setType(String type);
 
 }

--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/config/tasks/PortalSkinTask.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/config/tasks/PortalSkinTask.java
@@ -24,6 +24,10 @@ import javax.servlet.ServletContext;
 import org.exoplatform.portal.resource.SkinDependentManager;
 import org.exoplatform.portal.resource.SkinService;
 import org.exoplatform.portal.resource.config.xml.SkinConfigParser;
+
+import lombok.Getter;
+import lombok.Setter;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
@@ -41,6 +45,10 @@ public class PortalSkinTask extends AbstractSkinModule implements SkinConfigTask
 
     private String moduleName;
 
+    @Getter
+    @Setter
+    protected boolean filtered;
+
     public PortalSkinTask() {
         super(null);
         this.overwrite = true;
@@ -55,12 +63,22 @@ public class PortalSkinTask extends AbstractSkinModule implements SkinConfigTask
         moduleName = nodes.item(0).getFirstChild().getNodeValue();
     }
 
+    protected void bindingFiltered(Element element) {
+      NodeList nodes = element.getElementsByTagName(SkinConfigParser.FILTERED);
+      if (nodes == null || nodes.getLength() < 1) {
+          return;
+      }
+      String isFiltered = nodes.item(0).getFirstChild().getNodeValue();
+      setFiltered("true".equals(isFiltered));
+    }
+
     public void binding(Element elemt) {
         bindingCSSPath(elemt);
         bindingSkinName(elemt);
         bindingModuleName(elemt);
         bindingOverwrite(elemt);
         bindingCSSPriority(elemt);
+        bindingFiltered(elemt);
     }
 
     public void execute(SkinService skinService, ServletContext scontext) {
@@ -78,7 +96,7 @@ public class PortalSkinTask extends AbstractSkinModule implements SkinConfigTask
         } catch (Exception e) {
             priority = Integer.MAX_VALUE;
         }
-        skinService.addPortalSkin(moduleName, skinName, fullCSSPath, priority, overwrite);
+        skinService.addPortalSkin(moduleName, skinName, fullCSSPath, priority, overwrite, filtered);
         updateSkinDependentManager(contextPath, moduleName, skinName);
     }
 

--- a/component/web/resources/src/main/java/org/exoplatform/portal/resource/config/xml/SkinConfigParser.java
+++ b/component/web/resources/src/main/java/org/exoplatform/portal/resource/config/xml/SkinConfigParser.java
@@ -60,6 +60,9 @@ public class SkinConfigParser {
     public static final String GATEIN_RESOURCES_1_4_SYSTEM_ID = "http://www.exoplatform.org/xml/ns/gatein_resources_1_4";
 
     /** . */
+    public static final String GATEIN_RESOURCES_1_5_SYSTEM_ID = "http://www.exoplatform.org/xml/ns/gatein_resources_1_5";
+
+    /** . */
     private static final String GATEIN_RESOURCE_1_0_XSD_PATH = "gatein_resources_1_0.xsd";
 
     /** . */
@@ -70,15 +73,20 @@ public class SkinConfigParser {
 
     /** . */
     private static final String GATEIN_RESOURCE_1_3_XSD_PATH = "gatein_resources_1_3.xsd";
-
+    
     /** . */
     private static final String GATEIN_RESOURCE_1_4_XSD_PATH = "gatein_resources_1_4.xsd";
+
+    /** . */
+    private static final String GATEIN_RESOURCE_1_5_XSD_PATH = "gatein_resources_1_5.xsd";
 
     /** . */
     private static final XMLValidator VALIDATOR;
 
     /** . */
     public static final String OVERWRITE = "overwrite";
+
+    public static final String FILTERED  = "filtered";
 
     /** . */
     public static final String SKIN_NAME_TAG = "skin-name";
@@ -97,6 +105,8 @@ public class SkinConfigParser {
 
     /** . */
     public static final String APPLICATION_NAME_TAG = "application-name";
+
+    public static final String ADDITIONAL_MODULE    = "additional-module";
 
     /** . */
     public static final String CSS_PATH_TAG = "css-path";
@@ -123,6 +133,7 @@ public class SkinConfigParser {
         systemIdToResourcePath.put(GATEIN_RESOURCES_1_2_SYSTEM_ID, GATEIN_RESOURCE_1_2_XSD_PATH);
         systemIdToResourcePath.put(GATEIN_RESOURCES_1_3_SYSTEM_ID, GATEIN_RESOURCE_1_3_XSD_PATH);
         systemIdToResourcePath.put(GATEIN_RESOURCES_1_4_SYSTEM_ID, GATEIN_RESOURCE_1_4_XSD_PATH);
+        systemIdToResourcePath.put(GATEIN_RESOURCES_1_5_SYSTEM_ID, GATEIN_RESOURCE_1_5_XSD_PATH);
         VALIDATOR = new XMLValidator(SkinConfigParser.class, systemIdToResourcePath);
     }
 
@@ -139,7 +150,7 @@ public class SkinConfigParser {
         try {
             Document document = VALIDATOR.validate(source);
 
-            List<SkinConfigTask> tasks = new ArrayList<SkinConfigTask>();
+            List<SkinConfigTask> tasks = new ArrayList<>();
             Element docElement = document.getDocumentElement();
 
             fetchTasksByTagName(PORTAl_SKIN_TAG, docElement, tasks);

--- a/component/web/resources/src/main/java/org/exoplatform/web/application/JspBasedWebHandler.java
+++ b/component/web/resources/src/main/java/org/exoplatform/web/application/JspBasedWebHandler.java
@@ -176,9 +176,12 @@ public abstract class JspBasedWebHandler extends WebRequestHandler {
     skins.addAll(customSkins);
     return skins.stream().map(skin -> {
       SkinURL url = skin.createURL(controllerContext);
+      if (url == null) {
+        return null;
+      }
       url.setOrientation(orientation);
       return url.toString();
-    }).toList();
+    }).filter(Objects::nonNull).toList();
   }
 
   private Set<String> getPageScripts(JavascriptManager javascriptManager,

--- a/component/web/resources/src/main/resources/gatein_resources_1_5.xsd
+++ b/component/web/resources/src/main/resources/gatein_resources_1_5.xsd
@@ -1,0 +1,262 @@
+<?xml version="1.0"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<xs:schema
+    targetNamespace="http://www.exoplatform.org/xml/ns/gatein_resources_1_5"
+    xmlns="http://www.exoplatform.org/xml/ns/gatein_resources_1_5"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified"
+    version="1.0">
+
+  <!-- The root element type that contains the various resource declarations -->
+  <xs:element name="gatein-resources" xmlns:gt="http://www.exoplatform.org/xml/ns/gatein_resources_1_5">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="portal-skin" type="portal-skin"/>
+        <xs:element name="portlet-skin" type="portlet-skin"/>
+        <xs:element name="window-style" type="window-style"/>
+        <xs:element name="resource-bundle" type="resource-bundle"/>
+        <xs:element name="portlet" type="portlet"/>
+        <xs:element name="portal" type="portal"/>
+        <xs:element name="module" type="module"/>
+        <xs:element name="scripts" type="scripts"/>
+      </xs:choice>
+    </xs:complexType>
+
+    <xs:unique name="shared-js-uniqueness">
+      <xs:selector xpath="gt:module|gt:scripts"/>
+      <xs:field xpath="gt:name"/>
+    </xs:unique>
+    <xs:unique name="portlet-js-uniqueness">
+      <xs:selector xpath="gt:portlet"/>
+      <xs:field xpath="gt:name"/>
+    </xs:unique>
+    <xs:unique name="portal-js-uniqueness">
+      <xs:selector xpath="gt:portal"/>
+      <xs:field xpath="gt:name"/>
+    </xs:unique>
+  </xs:element>
+
+  <!-- Declares a portal skin resource -->
+  <xs:complexType name="portal-skin">
+    <xs:sequence>
+      <xs:element name="skin-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="skin-module" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="css-path" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="css-priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="overwrite" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <!-- Used to not systematically import PortalSkin in pages only when a portlet skin depends on it -->
+      <xs:element name="filtered" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Declares a portlet skin resource -->
+  <xs:complexType name="portlet-skin">
+    <xs:sequence>
+      <!-- The portlet application name -->
+      <xs:element name="application-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+
+      <!-- The portlet name -->
+      <xs:element name="portlet-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+
+      <!-- The name of the skin to load -->
+      <xs:element name="skin-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+
+      <!-- The css path of the skin relative to the application context -->
+      <xs:element name="css-path" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+      <!-- Overwrite -->
+      <xs:element name="overwrite" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+      <!-- The css priority of the skin to indicate condition for sorting -->
+      <xs:element name="css-priority" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+
+      <!-- Additional filtered Portal Skin module name(s) -->
+      <xs:element name="additional-module" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Declares a window style -->
+  <xs:complexType name="window-style" mixed="true">
+    <xs:sequence>
+
+      <!-- The window style name -->
+      <xs:element name="style-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+
+      <!-- The window style theme -->
+      <xs:element name="style-theme" type="style-theme" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- The window style theme -->
+  <xs:complexType name="style-theme">
+    <xs:sequence>
+      <!-- The theme name -->
+      <xs:element name="theme-name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="param">
+    <xs:sequence>
+      <!-- The portal name loading particular JavaScript module -->
+      <xs:element name="portal-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+      <!-- The javascript module -->
+      <xs:element name="js-module" type="xs:string" minOccurs="1" maxOccurs="1"/>
+
+      <!-- The javascript path -->
+      <xs:element name="js-path" type="xs:string" minOccurs="1" maxOccurs="1"/>
+
+      <!-- The javascript priority -->
+      <xs:element name="js-priority" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Declares a resource bundle -->
+  <xs:complexType name="resource-bundle">
+  </xs:complexType>
+
+  <xs:complexType name="module">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="as" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:choice>
+        <xs:sequence>
+          <xs:element name="load-group" type="xs:string" minOccurs="0" maxOccurs="1"/>
+          <xs:element name="supported-locale" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="script" type="script" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:element name="url" type="url" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:element name="depends" type="module-dependency" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="scripts">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:choice>
+        <xs:sequence>
+          <xs:element name="supported-locale" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="script" type="script" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:sequence>
+          <xs:element name="url" type="url" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+      </xs:choice>
+      <xs:element name="depends" type="scripts-dependency" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="resources-container" abstract="true">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:choice>
+        <xs:element name="module" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:choice>
+                <xs:sequence>
+                  <xs:element name="as" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="load-group" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="supported-locale" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element name="script" type="script" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+                <xs:sequence>
+                  <xs:element name="url" type="url" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+              </xs:choice>
+              <xs:element name="depends" type="module-dependency" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="scripts" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:choice>
+                <xs:sequence>
+                  <xs:element name="supported-locale" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element name="script" type="script" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:sequence>
+                  <xs:element name="url" type="url" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+              </xs:choice>
+              <xs:element name="depends" type="scripts-dependency" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="portlet">
+    <xs:complexContent>
+      <xs:extension base="resources-container"/>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="portal">
+    <xs:complexContent>
+      <xs:extension base="resources-container"/>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="scripts-dependency">
+    <xs:sequence>
+      <xs:element name="scripts" type="xs:string" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="module-dependency">
+    <xs:sequence>
+      <xs:element name="module" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="as" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="resource" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="script">
+    <xs:sequence>
+      <xs:element name="minify" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:choice>
+        <xs:element name="path" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        <xs:element name="adapter" type="adapter" minOccurs="1" maxOccurs="1"/>
+      </xs:choice>
+      <xs:element name="resource-bundle" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="adapter" mixed="true">
+    <xs:sequence>
+      <xs:element name="include" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="url">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="http(s)?://([a-zA-Z0-9\-\.]+/)*([a-zA-Z0-9\-\.])+"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/component/web/resources/src/test/java/org/exoplatform/portal/resource/AbstractSkinServiceTest.java
+++ b/component/web/resources/src/test/java/org/exoplatform/portal/resource/AbstractSkinServiceTest.java
@@ -220,10 +220,14 @@ public abstract class AbstractSkinServiceTest extends AbstractKernelTest {
         SkinConfig portletSkin = skinService.getSkin("mockwebapp/FirstPortlet", "TestSkin");
         String contextPath = mockServletContext.getContextPath();
         assertNotNull(portletSkin);
+        assertNotNull(portletSkin.getAdditionalModules());
+        assertEquals(1, portletSkin.getAdditionalModules().size());
+        assertEquals("AdditionalModule", portletSkin.getAdditionalModules().get(0));
         assertEquals(contextPath + "/skin/FirstPortlet.css", portletSkin.getCSSPath());
 
         portletSkin = skinService.getSkin("mockwebapp/SecondPortlet", "TestSkin");
         assertNotNull(portletSkin);
+        assertNull(portletSkin.getAdditionalModules());
         assertEquals(contextPath + "/skin/SecondPortlet.css", portletSkin.getCSSPath());
     }
 

--- a/component/web/resources/src/test/java/org/exoplatform/portal/resource/TestGateInResourceParser.java
+++ b/component/web/resources/src/test/java/org/exoplatform/portal/resource/TestGateInResourceParser.java
@@ -1,46 +1,130 @@
 package org.exoplatform.portal.resource;
 
-import java.net.MalformedURLException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.net.URL;
 import java.util.List;
 
-import junit.framework.TestCase;
+import javax.servlet.ServletContext;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.exoplatform.commons.xml.DocumentSource;
 import org.exoplatform.portal.resource.config.tasks.SkinConfigTask;
 import org.exoplatform.portal.resource.config.xml.SkinConfigParser;
 
-public class TestGateInResourceParser extends TestCase {
-    public void testResources1_0() throws MalformedURLException {
-        assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_0.xml");
-    }
+@RunWith(MockitoJUnitRunner.class)
+public class TestGateInResourceParser {
 
-    public void testResources1_0WithSkinModule() throws MalformedURLException {
-        assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_0-with-skin-module.xml");
-    }
+  private static final String SKIN_NAME    = "Default";
 
-    public void testResources1_1() throws MalformedURLException {
-        assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_1.xml");
-    }
+  private static final String CONTEXT_PATH = "portal";
 
-    public void testResources1_2() throws MalformedURLException {
-        assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_2.xml");
-    }
+  @Mock
+  private SkinService         skinService;
 
-    public void testResources1_3() throws MalformedURLException {
-        assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_3.xml");
-    }
+  @Mock
+  private ServletContext      scontext;
 
-    public void testResources1_4() throws MalformedURLException {
-        assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_4.xml");
-    }
+  public void setUp() {
+    when(scontext.getContextPath()).thenReturn(CONTEXT_PATH);
+  }
 
-    private void assertDescriptorCanBeLoaded(String descriptorPath) {
-        URL url = Thread.currentThread().getContextClassLoader().getResource(descriptorPath);
-        assertNotNull("The " + descriptorPath + " can not be found", url);
-        DocumentSource source = DocumentSource.create(url);
-        List<SkinConfigTask> tasks = SkinConfigParser.fetchTasks(source);
-        assertNotNull("There are no tasks", tasks);
-        assertEquals(8, tasks.size());
-    }
+  @Test
+  public void testResources1() {
+    assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_0.xml");
+  }
+
+  @Test
+  public void testResources1WithSkinModule() {
+    assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_0-with-skin-module.xml");
+  }
+
+  @Test
+  public void testResources11() {
+    assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_1.xml");
+  }
+
+  @Test
+  public void testResources12() {
+    assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_2.xml");
+  }
+
+  @Test
+  public void testResources13() {
+    assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_3.xml");
+  }
+
+  @Test
+  public void testResources14() {
+    assertDescriptorCanBeLoaded("org/exoplatform/portal/resource/gatein-resources-1_4.xml");
+  }
+
+  @Test
+  public void testResources15() {
+    List<SkinConfigTask> tasks = getTasks("org/exoplatform/portal/resource/gatein-resources-1_5.xml");
+    assertFalse(tasks.isEmpty());
+    assertEquals(5, tasks.size());
+    tasks.forEach(skinConfigTask -> skinConfigTask.execute(skinService, scontext));
+    verify(skinService, times(1)).addSkin(eq("web/BannerPortlet"),
+                                          eq(SKIN_NAME),
+                                          argThat(s -> s.contains("/skin/portal/webui/component/UIBannerPortlet/DefaultStylesheet.css")),
+                                          anyInt(),
+                                          eq(true),
+                                          argThat(list -> CollectionUtils.isNotEmpty(list)
+                                                          && list.size() == 1
+                                                          && list.contains("FilteredModule")));
+    verify(skinService, times(1)).addSkin(eq("web/FooterPortlet"),
+                                          eq(SKIN_NAME),
+                                          argThat(s -> s.contains("/skin/portal/webui/component/UIFooterPortlet/DefaultStylesheet.css")),
+                                          anyInt(),
+                                          eq(true),
+                                          argThat(CollectionUtils::isEmpty));
+    verify(skinService, times(1)).addSkin(eq("web/NavigationPortlet"),
+                                          eq(SKIN_NAME),
+                                          argThat(s -> s == null),
+                                          anyInt(),
+                                          eq(true),
+                                          argThat(list -> CollectionUtils.isNotEmpty(list)
+                                                  && list.size() == 1
+                                                  && list.contains("FilteredModule")));
+    verify(skinService, times(1)).addPortalSkin(eq("MyModule"),
+                                                eq(SKIN_NAME),
+                                                argThat(s -> s.contains("/skin/Stylesheet.css")),
+                                                anyInt(),
+                                                eq(true),
+                                                eq(false));
+    verify(skinService, times(1)).addPortalSkin(eq("FilteredModule"),
+                                                eq(SKIN_NAME),
+                                                argThat(s -> s.contains("/skin/FilteredStylesheet.css")),
+                                                anyInt(),
+                                                eq(true),
+                                                eq(true));
+  }
+
+  private List<SkinConfigTask> assertDescriptorCanBeLoaded(String descriptorPath) {
+    List<SkinConfigTask> tasks = getTasks(descriptorPath);
+    assertNotNull("There are no tasks", tasks);
+    assertEquals(8, tasks.size());
+    return tasks;
+  }
+
+  private List<SkinConfigTask> getTasks(String descriptorPath) {
+    URL url = Thread.currentThread().getContextClassLoader().getResource(descriptorPath);
+    assertNotNull("The " + descriptorPath + " can not be found", url);
+    DocumentSource source = DocumentSource.create(url);
+    return SkinConfigParser.fetchTasks(source);
+  }
 }

--- a/component/web/resources/src/test/java/org/gatein/portal/controller/resource/script/TestModule.java
+++ b/component/web/resources/src/test/java/org/gatein/portal/controller/resource/script/TestModule.java
@@ -56,10 +56,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 /**
  * @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
  */
-
-/**
- *
- */
 @RunWith(MockitoJUnitRunner.class)
 public class TestModule extends AbstractGateInTest {
 

--- a/component/web/resources/src/test/resources/mockwebapp/gatein-resources.xml
+++ b/component/web/resources/src/test/resources/mockwebapp/gatein-resources.xml
@@ -20,8 +20,8 @@
 
 -->
 <gatein-resources xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_resources_1_4 http://www.exoplatform.org/xml/ns/gatein_resources_1_4"
-                  xmlns="http://www.exoplatform.org/xml/ns/gatein_resources_1_4">
+                  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_resources_1_5 http://www.exoplatform.org/xml/ns/gatein_resources_1_5"
+                  xmlns="http://www.exoplatform.org/xml/ns/gatein_resources_1_5">
 
   <portal-skin>
     <skin-name>TestSkin</skin-name>
@@ -49,11 +49,19 @@
     <css-priority>1</css-priority>
   </portal-skin>
 
+  <portal-skin>
+    <skin-name>TestSkin</skin-name>
+    <skin-module>AdditionalModule</skin-module>
+    <css-path>/skin/FilteredStylesheet.css</css-path>
+    <filtered>true</filtered>
+  </portal-skin>
+
   <portlet-skin>
     <application-name>mockwebapp</application-name>
     <portlet-name>FirstPortlet</portlet-name>
     <skin-name>TestSkin</skin-name>
     <css-path>/skin/FirstPortlet.css</css-path>
+    <additional-module>AdditionalModule</additional-module>
   </portlet-skin>
 
   <portlet-skin>

--- a/component/web/resources/src/test/resources/mockwebapp/skin/FilteredStylesheet.css
+++ b/component/web/resources/src/test/resources/mockwebapp/skin/FilteredStylesheet.css
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2009 eXo Platform SAS.
+ * 
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+.CustomClass {
+  float: right;
+  /* orientation=lt */
+  float: left;
+  /* orientation=rt */
+}

--- a/component/web/resources/src/test/resources/org/exoplatform/portal/resource/gatein-resources-1_5.xml
+++ b/component/web/resources/src/test/resources/org/exoplatform/portal/resource/gatein-resources-1_5.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  -->
+<gatein-resources
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_resources_1_5 http://www.exoplatform.org/xml/ns/gatein_resources_1_5"
+    xmlns="http://www.exoplatform.org/xml/ns/gatein_resources_1_5">
+
+  <!-- Portal skins -->
+  <portal-skin>
+    <skin-name>Default</skin-name>
+    <skin-module>MyModule</skin-module>
+    <css-path>/skin/Stylesheet.css</css-path>
+    <css-priority>0</css-priority>
+  </portal-skin>
+
+  <portal-skin>
+    <skin-name>Default</skin-name>
+    <skin-module>FilteredModule</skin-module>
+    <css-path>/skin/FilteredStylesheet.css</css-path>
+    <css-priority>0</css-priority>
+    <filtered>true</filtered>
+  </portal-skin>
+
+  <!-- BannerPortlet skins -->
+  <portlet-skin>
+    <application-name>web</application-name>
+    <portlet-name>BannerPortlet</portlet-name>
+    <skin-name>Default</skin-name>
+    <css-path>/skin/portal/webui/component/UIBannerPortlet/DefaultStylesheet.css</css-path>
+    <additional-module>FilteredModule</additional-module>
+  </portlet-skin>
+
+  <portlet-skin>
+    <application-name>web</application-name>
+    <portlet-name>NavigationPortlet</portlet-name>
+    <skin-name>Default</skin-name>
+    <additional-module>FilteredModule</additional-module>
+  </portlet-skin>
+
+  <!-- FooterPortlet skins -->
+  <portlet-skin>
+    <application-name>web</application-name>
+    <portlet-name>FooterPortlet</portlet-name>
+    <skin-name>Default</skin-name>
+    <css-path>/skin/portal/webui/component/UIFooterPortlet/DefaultStylesheet.css</css-path>
+  </portlet-skin>
+
+</gatein-resources>

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -115,17 +115,17 @@
     <% for (skinConfig in portalSkins) {
          def url = skinConfig.createURL(rcontext.controllerContext);
          url.setOrientation(orientation); %>
-      <link id="${skinConfig.id}" rel="stylesheet" type="text/css" href="$url" skin-type="portal-skin" />
+      <link id="${skinConfig.id}" rel="stylesheet" type="text/css" href="$url" skin-type="${skinConfig.type}" />
     <% } %>
     <% for (portletSkin in portletSkins) {
          def url = portletSkin.createURL(rcontext.controllerContext);
          url.setOrientation(orientation); %>
-      <link id="${portletSkin.id}" rel="stylesheet" type="text/css" href= "$url" skin-type="portlet-skin" />
+      <link id="${portletSkin.id}" rel="stylesheet" type="text/css" href= "$url" skin-type="${portletSkin.type}" />
     <% } %>
     <% for (customSkin in customSkins) {
          def url = customSkin.createURL(rcontext.controllerContext);
          url.setOrientation(orientation); %>
-      <link id="${customSkin.id}" rel="stylesheet" type="text/css" href= "$url" skin-type="custom-skin" />
+      <link id="${customSkin.id}" rel="stylesheet" type="text/css" href= "$url" skin-type="${customSkin.type}" />
     <% } %>
 
     <!-- Scripts -->


### PR DESCRIPTION
This change will allow to reuse the same skin module (Client/Browser Path) in different applications. In fact, for a same framework which is used by different applications, we can only define a Portal Skin CSS that will be loaded all time in all pages even when needing it applications aren't present in the page. With this **modularity** feature, we will be able to define a reusable CSS Module that will be injected to page only when a portlet, which needs it, is present to the page.

To define a module, we will be able to use `<filtered>true</filtered>` in a regular portal skin definition to not import it systematically. And then we will be able to reference it in a portlet (multi references) using `<additional-module>NAME<additional-module>*`.