### PR TITLE
fix: Fix displaying spaces layout - EXO-67454 - Meeds-io/meeds#1334

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -390,11 +390,14 @@ public class PortalRequestContext extends WebuiRequestContext {
     public PortalConfig getDynamicPortalConfig() throws Exception {
       if (this.currentPortalConfig == null) {
         SiteKey displayingSiteKey = getSiteKey();
-
+        this.currentPortalConfig = layoutService.getPortalConfig(displayingSiteKey.getTypeName(), displayingSiteKey.getName());
         if (portalLayoutService == null) {
-          this.currentPortalConfig = layoutService.getPortalConfig(displayingSiteKey.getTypeName(), displayingSiteKey.getName());
+          return this.currentPortalConfig;
         } else {
-          this.currentPortalConfig = portalLayoutService.getPortalConfigWithDynamicLayout(displayingSiteKey, getCurrentPortalSite());
+          this.currentPortalConfig =
+                                   portalLayoutService.getPortalConfigWithDynamicLayout(displayingSiteKey,
+                                                                                        currentPortalConfig.isDisplayed() ? portalConfigService.getDefaultPortal()
+                                                                                                                          : getCurrentPortalSite());
         }
       }
       return this.currentPortalConfig;

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UISharedLayout.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UISharedLayout.java
@@ -42,10 +42,10 @@ public class UISharedLayout extends UIContainer {
     }
   }
 
-  protected boolean isShowSharedLayout(PortalRequestContext requestContext) {
+  protected boolean isShowSharedLayout(PortalRequestContext requestContext) throws Exception {
     boolean showSharedLayout = !requestContext.isHideSharedLayout() && (Util.getUIPage() == null || !Util.getUIPage().isHideSharedLayout());
     if (requestContext.getUserPortalConfig() != null && requestContext.getUserPortalConfig().getPortalConfig() != null) {
-      showSharedLayout = showSharedLayout && requestContext.getUserPortalConfig().getPortalConfig().isDisplayed();
+      showSharedLayout = showSharedLayout && requestContext.getDynamicPortalConfig().isDisplayed();
     }
     return showSharedLayout;
   }


### PR DESCRIPTION
prior to this change, when opening in two tabs a space and administration site, the space page acted like it was a standalone site since the previous site was administrator which is a standalone
after this change, the layout of the space takes the layout of the meta-site after retrieving the dynamicPortalconfig  with the meta-site layout if it is an aggregated site