### PR TITLE
fix: Fix Emoji usage in Settings Service Value fields - MEED-2896 - Meeds-io/meeds#1271

### DIFF
--- a/component/common/src/main/resources/db/changelog/settings.db.changelog-1.0.0.xml
+++ b/component/common/src/main/resources/db/changelog/settings.db.changelog-1.0.0.xml
@@ -124,4 +124,10 @@
     <createSequence sequenceName="SEQ_STG_SCOPE_COMMON_ID" startValue="1"/>
   </changeSet>
 
+  <changeSet author="settings" id="1.0.0-14" dbms="mysql">
+    <sql>
+      ALTER TABLE STG_SETTINGS MODIFY COLUMN VALUE longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
This change will allow to add Emojis in SettingsService Values in **MySQL**.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
