### PR TITLE
feat: Add the possibitily to not authorize the login against the external store - EXO-68030 - meeds-io/meeds#1417 (#772)

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
@@ -55,6 +55,7 @@ public class PicketLinkIDMExternalStoreService implements IDMExternalStoreServic
   private ExoFallbackIdentityStoreRepository                     fallbackStoreRepository       = null;
 
   private boolean                                                updateInformationOnLogin      = true;
+  private boolean                                                authorizeLogin      = true;
 
   private Set<IDMEntityType<?>>                                  entityTypes                   = Collections.emptySet();
 
@@ -97,6 +98,9 @@ public class PicketLinkIDMExternalStoreService implements IDMExternalStoreServic
     if (params != null) {
       if (params.containsKey(UPDATE_USER_ON_LOGIN_PARAM)) {
         updateInformationOnLogin = Boolean.parseBoolean(params.getValueParam(UPDATE_USER_ON_LOGIN_PARAM).getValue());
+      }
+      if (params.containsKey(AUTHORIZE_LOGIN_PARAM)) {
+        authorizeLogin = Boolean.parseBoolean(params.getValueParam(AUTHORIZE_LOGIN_PARAM).getValue());
       }
     }
   }
@@ -151,6 +155,9 @@ public class PicketLinkIDMExternalStoreService implements IDMExternalStoreServic
   @Override
   public boolean authenticate(String username, String password) throws Exception {
     checkEnabled();
+    if (!authorizeLogin) {
+      throw new IllegalStateException("LDAP Store does not authorize login");
+    }
 
     checkManagedType(IDMEntityType.USER);
 

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-externalstore-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-externalstore-configuration.xml
@@ -38,6 +38,11 @@
         <description>Cron expression used to schedule the job that will import periodically data from external store</description>
         <value>${exo.idm.externalStore.import.cronExpression:0 59 23 ? * *}</value>
       </value-param>
+			<value-param>
+				<name>exo.idm.externalStore.authorizelogin</name>
+				<description>Does the authentication against the externalStore is authorized ?</description>
+				<value>${exo.idm.externalStore.authorizelogin:true}</value>
+			</value-param>
     </init-params>
   </component>
 


### PR DESCRIPTION
In some case, when the platform is configured with an external user store AND SSO like OIDC, the IDP have security rules for the login like MFA. But, as the user is present in the external store, he can logs with the eXo login form, bypassing security rules This commit add a property to refused the connection for a user in the external store by the exo login form. He have to use the IDP login form

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
