### PR TITLE
fix: Add Test Conf to ignore Hibernate warnings - MEED-1580 - Meeds-io/meeds#1428

### DIFF
--- a/component/test/core/src/main/resources/logback-test.xml
+++ b/component/test/core/src/main/resources/logback-test.xml
@@ -26,6 +26,7 @@
       <pattern>%date{ISO8601} | %highlight(%-5level) | %msg %green([%logger{40}){}%cyan(&lt;%thread&gt;){}%green(]){} %n%xEx</pattern>
     </encoder>
   </appender>
+  <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="ERROR"/>
   <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>


### PR DESCRIPTION
This change will add in test scope a logger to delete useless hibernate warnings about empty result while executing updates.