### PR TITLE
fix: Fix displaying page access permissions and page edit permission after update - EXO-68000 - Meeds-io/meeds#1429

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/rest/model/UserNodeRestEntity.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/rest/model/UserNodeRestEntity.java
@@ -150,6 +150,8 @@ public class UserNodeRestEntity {
     int result = 17;
     result = 31 * result + (int) getUpdatedDate();
     result = 31 * result + (subNodes != null ? Objects.hash(subNodes) : 0);
+    result = 31 * result + (pageAccessPermissions != null ? Objects.hash(pageAccessPermissions) : 0);
+    result = 31 * result + (pageEditPermission != null ? pageEditPermission.hashCode() : 0);
     return result;
   }
 }


### PR DESCRIPTION

Prior to this change when modifying page access permissions or page edit permission, the new modified permissions values are not displayed even after refresh. This is due to the cached site nodes returned from the getSiteById method of SiteRest service based on etag not based on page access permissions and edit permission values. After this modification, we have included page access permissions and edit permission values into UserNodeRestEntity hashCode in order to bring site nodes pages permissions from the server and not from cache when they are modified.