### PR TITLE
fix: Add Test Conf to ignore Hibernate warnings - MEED-1580 - Meeds-i…

### DIFF
--- a/component/test/core/src/main/resources/logback-test.xml
+++ b/component/test/core/src/main/resources/logback-test.xml
@@ -26,6 +26,7 @@
       <pattern>%date{ISO8601} | %highlight(%-5level) | %msg %green([%logger{40}){}%cyan(&lt;%thread&gt;){}%green(]){} %n%xEx</pattern>
     </encoder>
   </appender>
+  <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="ERROR"/>
   <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>


### PR DESCRIPTION
…o/meeds#1428 (#779)

This change will add in test scope a logger to delete useless hibernate warnings about empty result while executing updates.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
