### PR TITLE
fix: Too many redirect when login - EXO-68055 - Meeds-io/meeds#1423

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -594,7 +594,13 @@ public class UserPortalConfigService implements Startable {
       if (CollectionUtils.isEmpty(portalConfigList)) {
         return null;
       }
-      return computePortalSitePath(portalConfigList.get(0).getName(), context);
+      String portalPath = null;
+      int i = 0;
+      while (portalPath == null) {
+        portalPath = computePortalSitePath(portalConfigList.get(i).getName(), context);
+        i++;
+      }
+      return portalPath;
     }
 
     public Collection<UserNode> getPortalSiteNavigations(String siteName, HttpServletRequest context) throws Exception {


### PR DESCRIPTION
Before this change, when login the redirection path is computed from the first accessible site event if its root node is not accessible (restricted navigation) which leads to blank page with too many redirect.
After this commit, after login the redirection path will be computed from the accessible site and navigation nodes with access permission in order to fix the redirection for restricted navigation.