### PR TITLE
fix:Navigation redirection for group navigation - EXO-68058 - Meeds-io/meeds#1426

### DIFF
--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.exoplatform.portal.mop.SiteFilter;
+import org.exoplatform.services.test.mock.MockHttpServletRequest;
 import org.gatein.common.util.Tools;
 
 import org.exoplatform.component.test.ConfigurationUnit;
@@ -67,6 +68,8 @@ import org.exoplatform.services.security.Authenticator;
 import org.exoplatform.services.security.ConversationState;
 
 import junit.framework.AssertionFailedError;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
@@ -863,6 +866,28 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
     }.execute(null);
   }
 
+  public void testGetPortalSiteRootNodeAndFirstAllowedPageNode(){
+    new UnitTest() {
+      public void execute() throws Exception {
+        String siteName = "classic";
+        HttpServletRequest httpRequest = new MockHttpServletRequest("/portal/classic", null, 0, "GET", null);
+        UserNode rootNode = userPortalConfigSer_.getPortalSiteRootNode(siteName, SiteType.PORTAL.getName(), httpRequest);
+        assertNotNull(rootNode);
+      }
+    }.execute(null);
+
+  }
+  public void testGetFirstAllowedPageNode(){
+    new UnitTest() {
+      public void execute() throws Exception {
+        String siteName = "classic";
+        HttpServletRequest httpRequest = new MockHttpServletRequest("/portal/classic", null, 0, null, null);
+        String path = userPortalConfigSer_.getFirstAllowedPageNode(siteName, SiteType.PORTAL.getName(), "home", httpRequest);
+        assertNotNull(path);
+      }
+    }.execute(null);
+
+  }
   private abstract class UnitTest {
 
     /** . */

--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -246,7 +246,7 @@ public class PortalRequestContext extends WebuiRequestContext {
             cacheLevel_ = cache;
         }
 
-        requestURI_ = request_.getRequestURI();
+        requestURI_ = requestPath;
         /*
          * String decodedURI = URLDecoder.decode(requestURI_, "UTF-8");
          *
@@ -267,7 +267,7 @@ public class PortalRequestContext extends WebuiRequestContext {
 
         //
         NodeURL url = createURL(NodeURL.TYPE);
-        url.setResource(new NavigationResource(siteKey, ""));
+        url.setResource(new NavigationResource(siteKey, requestPath));
         portalURI = url.toString();
 
         //


### PR DESCRIPTION
before this change, when redirecting to the navigation node of group type (navigation without page) a blank page with Page not found message is displayed
after this change, check for the redirection navigation if it is a group then will be redirected to the first available allowed page