### PR TITLE
fix: fix redirecting for global site navigation - EXO-68381 - Meeds-io/meeds#1426

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -586,10 +586,9 @@ public class UserPortalConfigService implements Startable {
         return null;
       }
       String portalPath = null;
-      int i = 0;
-      while (portalPath == null) {
-        portalPath = computePortalSitePath(portalConfigList.get(i).getName(), context);
-        i++;
+      Iterator<PortalConfig> iterator = portalConfigList.stream().iterator();
+      while (portalPath == null && iterator.hasNext()) {
+        portalPath = computePortalSitePath(iterator.next().getName(), context);
       }
       return portalPath;
     }
@@ -647,8 +646,11 @@ public class UserPortalConfigService implements Startable {
       }
       String[] pathNodesNames = nodePath.split("/");
       Iterator<String> iterator = Arrays.stream(pathNodesNames).iterator();
-      while (iterator.hasNext()) {
+      while (iterator.hasNext() && targetUserNode != null) {
         targetUserNode = targetUserNode.getChild(iterator.next());
+      }
+      if (targetUserNode == null) {
+          return nodePath;
       }
       String newPath = null;
       while (newPath == null) {

--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestHandler.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestHandler.java
@@ -305,10 +305,11 @@ public class PortalRequestHandler extends WebRequestHandler {
                                       UserPortalConfigService portalConfigService,
                                       HttpServletRequest context) throws Exception {
       if (path.isBlank()) {
-          if (SiteType.GROUP.getName().equals(requestSiteType)){
-              return path;
-          }
-        return portalConfigService.computePortalSitePath(portalName, context).substring(("/"+ requestSiteType + "/"+ portalName + "/").length());
+        if (SiteType.GROUP.getName().equals(requestSiteType)) {
+          return path;
+        }
+        String newPath = portalConfigService.computePortalSitePath(portalName, context);
+        return newPath == null ? path : newPath.substring(("/" + requestSiteType + "/" + portalName + "/").length());
       }
       return portalConfigService.getFirstAllowedPageNode(portalName, requestSiteType, path, context);
     }


### PR DESCRIPTION
Before this change, when redirecting to a global navigation NPE is thrown since the current site doesn't contain the target navigation After this change, when the target navigation is not found the redirection is for the requested path