### PR TITLE
fix: Provide the portal default language in a js variable - EXO-68280  - meeds-io/meeds#1463

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -23,6 +23,7 @@
   import org.exoplatform.services.resources.ResourceBundleService;
   import org.exoplatform.portal.branding.BrandingService;
   import java.util.ResourceBundle;
+  import org.exoplatform.services.resources.LocaleConfigService;
 
   def rcontext = _ctx.getRequestContext() ;
   def session = rcontext.getRequest().getSession();
@@ -87,6 +88,11 @@
   }
   PortalConfig sitePortalConfig = rcontext.getDynamicPortalConfig();
   String siteId = sitePortalConfig.getStorageId().split("_")[1];
+
+
+  LocaleConfigService localeConfigService = uicomponent.getApplicationComponent(LocaleConfigService.class);
+  def defaultLocaleTag = localeConfigService.getDefaultLocaleConfig().getLocale().toLanguageTag();
+
 %>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="$language" lang="$language" dir="$dir">
   <head id="head">
@@ -154,6 +160,7 @@
      eXo.env.portal.containerName = "<%=PortalContainer.getInstance().getName()%>";
      eXo.env.portal.userName='<%= userName == null ? "" : userName %>';
      eXo.env.portal.language='<%= language %>';
+     eXo.env.portal.defaultLanguage='<%= defaultLocaleTag %>';
      eXo.env.portal.orientation='<%= orientation == Orientation.RT ? "rtl" : "ltr" %>';
      eXo.env.portal.selectedNodeUri = '<%= selectedNodeUri %>';
      eXo.env.portal.previousURI = '<%= previousURI %>';


### PR DESCRIPTION
Before this fix, the portal default language is not provided as a js variable, and we need it for applications like LinkPortlet. This commit add the default locale as js variable

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
