### PR TITLE
fix: Fix filtering application after changing permissions - EXO-68546  - Meeds-io/meeds#1505 

### DIFF
--- a/component/application-registry/src/main/java/org/exoplatform/application/registry/impl/JDBCApplicationRegistryService.java
+++ b/component/application-registry/src/main/java/org/exoplatform/application/registry/impl/JDBCApplicationRegistryService.java
@@ -212,6 +212,7 @@ public class JDBCApplicationRegistryService implements ApplicationRegistryServic
     if (appEntity != null) {
       appEntity = buildAppEntity(appEntity, application);
       appDAO.update(appEntity);
+      layoutStorage.savePermissions(ApplicationEntity.class.getName(), appEntity.getId(), TYPE.ACCESS, application.getAccessPermissions());
     } else {
       throw new IllegalStateException();
     }

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIApplicationList.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIApplicationList.java
@@ -70,7 +70,7 @@ public class UIApplicationList extends UIContainer {
         }
     }
 
-    public List<Application> getApplications() {
+    public List<Application> getApplications() throws Exception {
         if (selectedCategory == null)
             return null;
 
@@ -80,8 +80,9 @@ public class UIApplicationList extends UIContainer {
         }
 
         UserACL userACL = getApplicationComponent(UserACL.class);
+        ApplicationRegistryService service = getApplicationComponent(ApplicationRegistryService.class);
 
-        List<Application> allApps = selectedCategory.getApplications();
+        List<Application> allApps = service.getApplications(selectedCategory);
         List<Application> apps = new ArrayList<Application>();
 
         for (Application app : allApps) {


### PR DESCRIPTION
Prior to this change, when updating an application permission , its permission is updated only in the UI not in the database. After this change, the permission will be saved in database and the application list will be displayed according to the permissions when selecting a category.
