### PR TITLE
fix: last login time property is not updated in gatein User - EXO-68531 - Meeds-io/meeds#1493 

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UpdateLoginTimeListener.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UpdateLoginTimeListener.java
@@ -19,7 +19,6 @@ package org.exoplatform.services.organization.idm;
 import java.util.Calendar;
 
 import org.exoplatform.container.PortalContainer;
-import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.listener.Asynchronous;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
@@ -57,7 +56,6 @@ public class UpdateLoginTimeListener extends Listener<ConversationRegistry, Conv
     UserHandler userHandler = organizationService.getUserHandler();
     ConversationState state = event.getData();
     String userId = state.getIdentity().getUserId();
-    RequestLifeCycle.begin(container);
     try {
       User user = (User) state.getAttribute(USER_PROFILE);
       if (user == null) {


### PR DESCRIPTION
prior to this change, The `UpdateLoginTimeListener` doesn't correctly update the last login property of the user due to double `RequestLifeCycle.begin` that invoked in this listener. This PR fixes the listener by removing the `RequestLifeCycle.begin` of the listener and keeps the one invoked by the `@ContainerTransactional` annotation to avoid the start of two transaction lifecycles.

(cherry picked from commit e798df2f4f37f1a9a668712d8c5a7f0eae65d814)