### PR TITLE
fix: Allow to store Estimated Content Length Before Parsing Uploaded File - MEED-3137 - Meeds-io/meeds#1506

### DIFF
--- a/component/common/src/main/java/org/exoplatform/upload/UploadService.java
+++ b/component/common/src/main/java/org/exoplatform/upload/UploadService.java
@@ -121,10 +121,12 @@ public class UploadService {
     putToStackInSession(request.getSession(true), uploadId);
 
     double requestContentLength = request.getContentLength();
+    upResource.setEstimatedSize(requestContentLength);
     if (isLimited(upResource, requestContentLength)) {
       upResource.setStatus(UploadResource.FAILED_STATUS);
       return;
     }
+
     File uploadRootPath = new File(uploadLocation_);
     if (!uploadRootPath.exists()) {
       uploadRootPath.mkdirs();
@@ -132,7 +134,6 @@ public class UploadService {
 
     DiskFileItem fileItem = getFileItem(request, upResource);
     upResource.setFileName(fileItem.getName());
-    upResource.setEstimatedSize(requestContentLength);
     upResource.setMimeType(fileItem.getContentType());
     if (upResource.getStatus() == UploadResource.UPLOADED_STATUS) {
       writeFile(upResource, fileItem);


### PR DESCRIPTION
Prior to this change, when uploading a file, its content is completely uploaded before setting estimated size which make the upload percentage computing wrong. This change will ensure to set the estimated content length before parsing HTTP Request file size.

(Resolves Meeds-io/meeds#1506)