### PR TITLE
fix: Containers only acccept pixel or % numeric value for width and height - EXO-66580 - meeds-io/meeds#1527

### DIFF
--- a/web/portal/src/main/resources/locale/portal/webui_en.properties
+++ b/web/portal/src/main/resources/locale/portal/webui_en.properties
@@ -254,7 +254,7 @@ UIContainerForm.tab.label.ContainerSetting=Container Setting
 UIContainerForm.tab.label.UIContainerPermission=Permissions
 UIContainerForm.tab.label.Template=Template
 UIContainerForm.tab.label.Icon=#{word.icon}
-UIContainerForm.msg.InvalidWidthHeight=You must enter a pixel or a percentage value in field "{0}".
+UIContainerForm.msg.InvalidWidthHeight=You must enter a valid css rule in field "{0}".
 UIContainerForm.msg.InvalidContainerTitle=Container title is invalid, it should not contain < or >.
 #############################################################################
 #              org.exoplatform.portal.component.customization.UIPortletForm#

--- a/web/portal/src/main/resources/locale/portal/webui_fr.properties
+++ b/web/portal/src/main/resources/locale/portal/webui_fr.properties
@@ -254,7 +254,7 @@ UIContainerForm.tab.label.ContainerSetting=Param\u00E8tres
 UIContainerForm.tab.label.UIContainerPermission=Permissions
 UIContainerForm.tab.label.Template=Gabarit
 UIContainerForm.tab.label.Icon=#{word.icon}
-UIContainerForm.msg.InvalidWidthHeight=Le champ "{0}" doit \u00EAtre une valeur en pixel ou un pourcentage.
+UIContainerForm.msg.InvalidWidthHeight=Le champ "{0}" doit \u00EAtre une r\u00E8gle css valide.
 UIContainerForm.msg.InvalidContainerTitle=Le titre de conteneur n'est pas valide, il ne doit pas contenir < ou >.
 #############################################################################
 #              org.exoplatform.portal.component.customization.UIPortletForm#

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UIContainerForm.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UIContainerForm.java
@@ -84,10 +84,10 @@ public class UIContainerForm extends UIFormTabPane {
                                 .addValidator(NotHTMLTagValidator.class, "UIContainerForm.msg.InvalidContainerTitle"))
                 .addUIFormInput(
                         new UIFormStringInput("width", "width", null).addValidator(ExpressionValidator.class,
-                                "(^([1-9]\\d*)(px|%)$)?", "UIContainerForm.msg.InvalidWidthHeight"))
+                                "^(\\d+(\\.\\d+)?(px|%|em|rem|vw|vh)|auto|calc\\(.*\\))$", "UIContainerForm.msg.InvalidWidthHeight"))
                 .addUIFormInput(
                         new UIFormStringInput("height", "height", null).addValidator(ExpressionValidator.class,
-                                "(^([1-9]\\d*)(px|%)$)?", "UIContainerForm.msg.InvalidWidthHeight"));
+                                "^(\\d+(\\.\\d+)?(px|%|em|rem|vw|vh)|auto|calc\\(.*\\))$", "UIContainerForm.msg.InvalidWidthHeight"));
         addChild(infoInputSet);
         setSelectedTab(infoInputSet.getId());
 


### PR DESCRIPTION
Prior to this fix,  Containers only acccept pixel or % numeric value for width and height, but in sone cases we need to have dynamic container's width as auto or setting a calc expression.
This commit changes the width and height fields validator to allow having more css rules possibilities.
