### PR TITLE
fix: Containers only acccept pixel or % numeric value for width and height - EXO-66580 - meeds-io/meeds#1527

### DIFF
--- a/web/portal/src/main/resources/locale/portal/webui_en.properties
+++ b/web/portal/src/main/resources/locale/portal/webui_en.properties
@@ -254,15 +254,15 @@ UIContainerForm.tab.label.ContainerSetting=Container Setting
 UIContainerForm.tab.label.UIContainerPermission=Permissions
 UIContainerForm.tab.label.Template=Template
 UIContainerForm.tab.label.Icon=#{word.icon}
-UIContainerForm.msg.InvalidWidthHeight=You must enter a pixel or a percentage value in field "{0}".
+UIContainerForm.msg.InvalidWidthHeight=You must enter a valid css rule in field "{0}".
 UIContainerForm.msg.InvalidContainerTitle=Container title is invalid, it should not contain < or >.
 #############################################################################
 #              org.exoplatform.portal.component.customization.UIPortletForm#
 #############################################################################
 UIPortletForm.title=View/Edit Portlet
 UIPortletForm.label.title=Portlet Title :
-UIPortletForm.label.width=#{word.width} (px):
-UIPortletForm.label.height=#{word.height} (px):
+UIPortletForm.label.width=#{word.width}:
+UIPortletForm.label.height=#{word.height}:
 UIPortletForm.label.showInfoBar=Show Info Bar :
 UIPortletForm.label.windowId=Window Id :
 UIPortletForm.label.showPortletMode=Show Portlet Mode :
@@ -284,7 +284,7 @@ UIPortletForm.tab.label.PortletPermission=#{word.accessPermission}
 UIPortletForm.Theme.title.Preview=Themes Preview
 UIPortletForm.Theme.title.SetDefault=Get Default
 UIPortletForm.Icon.title.SetDefault=Get Default
-UIPortletForm.msg.InvalidWidthHeight=You must enter a pixel value in field "{0}".
+UIPortletForm.msg.InvalidWidthHeight=You must enter a valid css rule in field "{0}".
 UIPortletForm.msg.InvalidPortletTitle=Portlet title is invalid, it should not contain < or >.
 UIPortletForm.msg.InvalidPortletDescription=Portlet description is invalid, it should not contain < or >.
 #############################################################################

--- a/web/portal/src/main/resources/locale/portal/webui_fr.properties
+++ b/web/portal/src/main/resources/locale/portal/webui_fr.properties
@@ -254,15 +254,15 @@ UIContainerForm.tab.label.ContainerSetting=Param\u00E8tres
 UIContainerForm.tab.label.UIContainerPermission=Permissions
 UIContainerForm.tab.label.Template=Gabarit
 UIContainerForm.tab.label.Icon=#{word.icon}
-UIContainerForm.msg.InvalidWidthHeight=Le champ "{0}" doit \u00EAtre une valeur en pixel ou un pourcentage.
+UIContainerForm.msg.InvalidWidthHeight=Le champ "{0}" doit \u00EAtre une r\u00E8gle css valide.
 UIContainerForm.msg.InvalidContainerTitle=Le titre de conteneur n'est pas valide, il ne doit pas contenir < ou >.
 #############################################################################
 #              org.exoplatform.portal.component.customization.UIPortletForm#
 #############################################################################
 UIPortletForm.title=Voir / Modifier la Portlet
 UIPortletForm.label.title=Titre :
-UIPortletForm.label.width=#{word.width} (px):
-UIPortletForm.label.height=#{word.height} (px):
+UIPortletForm.label.width=#{word.width}:
+UIPortletForm.label.height=#{word.height}:
 UIPortletForm.label.showInfoBar=Afficher la Bordure :
 UIPortletForm.label.windowId=Identifiant Fen\u00EAtre :
 UIPortletForm.label.showPortletMode=Afficher le Mode :
@@ -284,7 +284,7 @@ UIPortletForm.tab.label.PortletPermission=#{word.accessPermission}
 UIPortletForm.Theme.title.Preview=Aper\u00E7u des Th\u00E8mes
 UIPortletForm.Theme.title.SetDefault=Utiliser la valeur par d\u00E9faut
 UIPortletForm.Icon.title.SetDefault=Utiliser l'ic\u00F4ne par d\u00E9faut
-UIPortletForm.msg.InvalidWidthHeight=Le champ "{0}" doit \u00EAtre une valeur en pixel.
+UIPortletForm.msg.InvalidWidthHeight=Le champ "{0}" doit \u00EAtre une r\u00E8gle css valide.
 UIPortletForm.msg.InvalidPortletTitle=Le titre de la portlet est invalide, il ne doit pas contenir < ni >.
 UIPortletForm.msg.InvalidPortletDescription=La description de la portlet est invalide, elle ne doit pas contenir < ni >.
 #############################################################################

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/application/UIPortletForm.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/application/UIPortletForm.java
@@ -96,10 +96,10 @@ public class UIPortletForm extends UIFormTabPane {
                                 .addValidator(NotHTMLTagValidator.class, "UIPortletForm.msg.InvalidPortletTitle"))
                 .addUIFormInput(
                         new UIFormStringInput("width", "width", null).addValidator(ExpressionValidator.class,
-                                "(^([1-9]\\d*)(?:px)?$)?", "UIPortletForm.msg.InvalidWidthHeight"))
+                                "^(\\d+(\\.\\d+)?(px|%|em|rem|vw|vh)|auto|calc\\(.*\\))$", "UIPortletForm.msg.InvalidWidthHeight"))
                 .addUIFormInput(
                         new UIFormStringInput("height", "height", null).addValidator(ExpressionValidator.class,
-                                "(^([1-9]\\d*)(?:px)?$)?", "UIPortletForm.msg.InvalidWidthHeight"))
+                                "^(\\d+(\\.\\d+)?(px|%|em|rem|vw|vh)|auto|calc\\(.*\\))$", "UIPortletForm.msg.InvalidWidthHeight"))
                 .addUIFormInput(new UICheckBoxInput("showInfoBar", "showInfoBar", false))
                 .addUIFormInput(new UICheckBoxInput("showPortletMode", "showPortletMode", false))
                 .addUIFormInput(new UICheckBoxInput("showWindowState", "showWindowState", false))
@@ -247,9 +247,6 @@ public class UIPortletForm extends UIFormTabPane {
             if (width == null || width.length() == 0) {
                 uiPortlet.setWidth(null);
             } else {
-                if (!width.endsWith("px")) {
-                    width = width.concat("px");
-                }
                 uiPortlet.setWidth(width);
             }
 
@@ -257,9 +254,6 @@ public class UIPortletForm extends UIFormTabPane {
             if (height == null || height.length() == 0) {
                 uiPortlet.setHeight(null);
             } else {
-                if (!height.endsWith("px")) {
-                    height = height.concat("px");
-                }
                 uiPortlet.setHeight(height);
             }
 

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UIContainerForm.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UIContainerForm.java
@@ -84,10 +84,10 @@ public class UIContainerForm extends UIFormTabPane {
                                 .addValidator(NotHTMLTagValidator.class, "UIContainerForm.msg.InvalidContainerTitle"))
                 .addUIFormInput(
                         new UIFormStringInput("width", "width", null).addValidator(ExpressionValidator.class,
-                                "(^([1-9]\\d*)(px|%)$)?", "UIContainerForm.msg.InvalidWidthHeight"))
+                                "^(\\d+(\\.\\d+)?(px|%|em|rem|vw|vh)|auto|calc\\(.*\\))$", "UIContainerForm.msg.InvalidWidthHeight"))
                 .addUIFormInput(
                         new UIFormStringInput("height", "height", null).addValidator(ExpressionValidator.class,
-                                "(^([1-9]\\d*)(px|%)$)?", "UIContainerForm.msg.InvalidWidthHeight"));
+                                "^(\\d+(\\.\\d+)?(px|%|em|rem|vw|vh)|auto|calc\\(.*\\))$", "UIContainerForm.msg.InvalidWidthHeight"));
         addChild(infoInputSet);
         setSelectedTab(infoInputSet.getId());
 


### PR DESCRIPTION
Prior to this fix, Containers only acccept pixel or % numeric value for width and height, but in sone cases we need to have dynamic container's width as auto or setting a calc expression.
This commit changes the width and height fields validator to allow having more css rules possibilities.