### PR TITLE
fix: avoid reusing recycled HTTP requests - Meeds-io/meeds#1565 - EXO-69030

### DIFF
--- a/webui/portal/pom.xml
+++ b/webui/portal/pom.xml
@@ -69,5 +69,9 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>exo.portal.component.api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.exoplatform.core</groupId>
+      <artifactId>exo.core.component.security.core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -299,7 +299,9 @@ public class PortalRequestContext extends WebuiRequestContext {
         String remoteUser = "";
         if (userPortalConfig == null) {
             ConversationState conversationState = ConversationState.getCurrent();
-            if(conversationState != null) {
+            if (conversationState != null
+              && conversationState.getIdentity() != null
+              && !IdentityConstants.ANONIM.equals(conversationState.getIdentity().getUserId())) {
               remoteUser = conversationState.getIdentity().getUserId();
             }
             SiteType siteType = getSiteType();

--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -42,6 +42,7 @@ import org.exoplatform.Constants;
 import org.exoplatform.commons.utils.ExpressionUtil;
 import org.exoplatform.commons.utils.PortalPrinter;
 import org.exoplatform.commons.xml.DOMSerializer;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
@@ -295,8 +296,12 @@ public class PortalRequestContext extends WebuiRequestContext {
     }
 
     public UserPortalConfig getUserPortalConfig() {
+        String remoteUser = "";
         if (userPortalConfig == null) {
-            String remoteUser = getRemoteUser();
+            ConversationState conversationState = ConversationState.getCurrent();
+            if(conversationState != null) {
+              remoteUser = conversationState.getIdentity().getUserId();
+            }
             SiteType siteType = getSiteType();
 
             String portalName = getCurrentPortalSite();

--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -66,6 +66,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.LocaleContextInfo;
 import org.exoplatform.services.resources.Orientation;
 import org.exoplatform.services.resources.ResourceBundleManager;
+import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.application.JavascriptManager;
 import org.exoplatform.web.application.URLBuilder;
@@ -296,7 +297,7 @@ public class PortalRequestContext extends WebuiRequestContext {
     }
 
     public UserPortalConfig getUserPortalConfig() {
-        String remoteUser = "";
+        String remoteUser = null;
         if (userPortalConfig == null) {
             ConversationState conversationState = ConversationState.getCurrent();
             if (conversationState != null


### PR DESCRIPTION
The issue is related to an old code that tries to get the remote user from the HTTP request, this worked for old Tomcat versions. But since the upgrade to Tomcat 10 and since there is no Security manager configured, the usage of the request object is not permitted after the timeout.
The fix will use COnversationState to get the current user identity