### PR TITLE
fix : Unable to create a user with a username starting with digit - EXO-69012

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserFieldValidator.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserFieldValidator.java
@@ -112,7 +112,7 @@ public class UserFieldValidator {
         }
       }
     } else if (usernameValidation) {
-      if (!Character.isLowerCase(buff[0])) {
+      if (!isLowerCaseLetterOrDigit(buff[0])) {
         String label = getFieldLabel(locale);
         return getLabel(locale, "FirstCharacterUsernameValidator.msg", label);
       }

--- a/component/portal/src/test/java/org/exoplatform/portal/rest/UserFieldValidatorTest.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/rest/UserFieldValidatorTest.java
@@ -41,8 +41,9 @@ public class UserFieldValidatorTest {
   @Test
   public void testValidateUsername() {
     UserFieldValidator fieldValidator = new UserFieldValidator("field", true, false);
-    assertNotNull(fieldValidator.validate(Locale.ENGLISH, "123"));
-    assertNotNull(fieldValidator.validate(Locale.ENGLISH, "1aa"));
+    assertNull(fieldValidator.validate(Locale.ENGLISH, "123"));
+    assertNull(fieldValidator.validate(Locale.ENGLISH, "1aa"));
+    assertNull(fieldValidator.validate(Locale.ENGLISH, "a1aa"));
     assertNotNull(fieldValidator.validate(Locale.ENGLISH, "aaA"));
     assertNull(fieldValidator.validate(Locale.ENGLISH, "aaa"));
   }

--- a/web/portal/src/main/resources/locale/portal/webui_en.properties
+++ b/web/portal/src/main/resources/locale/portal/webui_en.properties
@@ -175,7 +175,7 @@ FirstAndSpecialCharacterNameValidator.msg=The "{0}" field must start with a lett
 LastCharacterUsernameValidator.msg=The field "{0}" must end with a lowercase letter or digit instead of "{1}".
 ConsecutiveSymbolValidator.msg=The field "{0}" cannot contain consecutive symbols. Allowed symbols are: {1}.
 UsernameValidator.msg.Invalid-char=Only lowercase letters, digits, dot and underscore characters are allowed for the field "{0}".
-FirstCharacterUsernameValidator.msg=The "{0}" field must start with a lowercase letter.
+FirstCharacterUsernameValidator.msg=The "{0}" field must start with a lowercase letter or digit.
 ##############################################################################
 #Natural language Validator
 ##############################################################################

--- a/web/portal/src/main/resources/locale/portal/webui_fr.properties
+++ b/web/portal/src/main/resources/locale/portal/webui_fr.properties
@@ -175,7 +175,7 @@ FirstAndSpecialCharacterNameValidator.msg=Le champ "{0}" doit commencer par une 
 LastCharacterUsernameValidator.msg=Le champ "{0}" doit se terminer par une lettre minuscule ou un chiffre au lieu de "{1}".
 ConsecutiveSymbolValidator.msg=Le champ "{0}" ne peut pas contenir des symboles cons\u00E9cutifs. Les symboles autoris\u00E9s sont: {1}.
 UsernameValidator.msg.Invalid-char=Seuls les caract\u00E8res "a..z", "0..9", "." et "_" sont autoris\u00E9s dans le champ "{0}".
-FirstCharacterUsernameValidator.msg=Le champ "{0}" doit commencer par une lettre minuscule.
+FirstCharacterUsernameValidator.msg=Le champ "{0}" doit commencer par une lettre minuscule ou un chiffre.
 ##############################################################################
 #Natural language Validator
 ##############################################################################


### PR DESCRIPTION
Before this fix, the platform refuse to create a user with a username starting with a digit. As there is no technical limitation, this commit change the check about the first char by testing lowerOrDigit instead of just lower

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
