### PR TITLE
fix: avoid reusing recycled HTTP requests - Meeds-io/meeds#1565 - EXO-69030

### DIFF
--- a/webui/portal/pom.xml
+++ b/webui/portal/pom.xml
@@ -69,5 +69,9 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>exo.portal.component.api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.exoplatform.core</groupId>
+      <artifactId>exo.core.component.security.core</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The issue is related to an old code that tries to get the remote user from the HTTP request, this worked for old Tomcat versions. But since the upgrade to Tomcat 10 and since there is no Security manager configured, the usage of the request object is not permitted after the timeout.
The fix will use ConversationState to get the current user identity
