### PR TITLE
fix: Avoid STO error - MEED-3400 - Meeds-io/MIPs#120

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/storage/NavigationStorageImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/storage/NavigationStorageImpl.java
@@ -246,7 +246,7 @@ public class NavigationStorageImpl implements NavigationStorage {
 
   private NodeEntity getRootNode(Long nodeId) {
     NodeEntity entity = this.nodeDAO.find(nodeId);
-    if (entity.getParent() != null) {
+    if (entity.getParent() != null && entity.getParent().getId().longValue() != entity.getId().longValue()) {
       return this.getRootNode(entity.getParent().getId());
     }
     return entity;


### PR DESCRIPTION
Prior to this change, when a node page references itself as root node, a StackOverflow Error is observed while copying node.