### PR TITLE
feat: Enhance parallel Requests processing on Portal and introduce DRAFT Nav visibility - MEED-3411 - Meeds-io/MIPs#120

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/mop/Visibility.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/Visibility.java
@@ -43,6 +43,19 @@ public enum Visibility {
     /**
      * The object visibility is system.
      */
-    SYSTEM
+    SYSTEM,
+
+    /**
+     * The object visibility is system.
+     */
+    DRAFT;
+
+    // Exclude Draft since it shouldn't be visible
+    public static final Visibility[] DEFAULT_VISIBILITIES = new Visibility[] { // NOSONAR
+      DISPLAYED,
+      HIDDEN,
+      TEMPORAL,
+      SYSTEM
+    };
 
 }

--- a/component/api/src/main/java/org/exoplatform/portal/mop/navigation/TreeUpdate.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/navigation/TreeUpdate.java
@@ -19,6 +19,8 @@
 
 package org.exoplatform.portal.mop.navigation;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.exoplatform.portal.mop.Utils;
 import org.exoplatform.portal.tree.diff.*;
 
@@ -201,7 +203,7 @@ class TreeUpdate<N1, N2> {
             }
 
             //
-            if (!parent.data.name.equals(data.name)) {
+            if (!StringUtils.equals(parent.data.name, data.name)) {
                 parent.name = data.name;
                 if (listener != null) {
                     listener.onRename(parent, parent.getParent(), data.name);

--- a/component/identity/src/test/java/org/exoplatform/services/organization/AbstractTestOrganizationService.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/AbstractTestOrganizationService.java
@@ -600,14 +600,12 @@ public abstract class AbstractTestOrganizationService {
 
     @Test
     public void testUserProfileListener() throws Exception {
-        System.out.println("Trigger testUserProfileListener");
         UserProfileListener l = new UserProfileListener();
         profileHandler_.addUserProfileEventListener(l);
         User user = createUser(USER);
         assertNotNull(user);
         UserProfile profile = profileHandler_.createUserProfileInstance(user.getUserName());
         profile.setAttribute("blah", "blah");
-        System.out.println("Going to save userProfiel");
         profileHandler_.saveUserProfile(profile, true);
         assertTrue(l.preSave && l.postSave);
         assertEquals(l.preSaveCreations, 1);

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/rest/NavigationRest.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/rest/NavigationRest.java
@@ -55,7 +55,7 @@ public class NavigationRest implements ResourceContainer {
 
   private static final Log          LOG                  = ExoLogger.getLogger(NavigationRest.class);
 
-  private static final Visibility[] DEFAULT_VISIBILITIES = Visibility.values();
+  private static final Visibility[] DEFAULT_VISIBILITIES = Visibility.DEFAULT_VISIBILITIES;
 
   private UserPortalConfigService   portalConfigService;
 

--- a/component/scripting/src/test/java/org/exoplatform/groovyscript/TestTemplateRendering.java
+++ b/component/scripting/src/test/java/org/exoplatform/groovyscript/TestTemplateRendering.java
@@ -73,7 +73,6 @@ public class TestTemplateRendering extends AbstractGateInTest {
     public void testDate2() throws Exception {
         Date dateToTest = new Date(0);
         GroovyTemplate template = new GroovyTemplate("<% def date = new Date(0) %>$date");
-        System.out.println("template.getGroovy() = " + template.getGroovy());
         assertEquals(dateFormatFR.format(dateToTest), template.render(Locale.FRENCH));
         assertEquals(dateFormatEN.format(dateToTest), template.render(Locale.ENGLISH));
         assertEquals(dateToTest.toString(), template.render());
@@ -82,7 +81,6 @@ public class TestTemplateRendering extends AbstractGateInTest {
     public void testDate3() throws Exception {
         Date dateToTest = new Date(0);
         GroovyTemplate template = new GroovyTemplate("<%= new Date(0) %>");
-        System.out.println("template.getGroovy() = " + template.getGroovy());
         assertEquals(dateFormatFR.format(dateToTest), template.render(Locale.FRENCH));
         assertEquals(dateFormatEN.format(dateToTest), template.render(Locale.ENGLISH));
         assertEquals(dateToTest.toString(), template.render());

--- a/component/test/core/src/main/java/org/exoplatform/test/mocks/servlet/MockServletRequest.java
+++ b/component/test/core/src/main/java/org/exoplatform/test/mocks/servlet/MockServletRequest.java
@@ -347,7 +347,6 @@ public class MockServletRequest implements HttpServletRequest {
   }
 
   public Enumeration getLocales() {
-    System.out.println("MOCK get Locale : " + locale);
     Vector v = new Vector();
     v.add(locale);
     return v.elements();

--- a/component/web/controller/src/main/java/org/exoplatform/web/application/RequestContext.java
+++ b/component/web/controller/src/main/java/org/exoplatform/web/application/RequestContext.java
@@ -175,7 +175,11 @@ public abstract class RequestContext {
     }
 
     public static void setCurrentInstance(RequestContext ctx) {
-        tlocal_.set(ctx);
+        if (ctx == null) {
+          tlocal_.remove();
+        } else {
+          tlocal_.set(ctx);
+        }
     }
 
 }

--- a/component/web/security/src/test/java/org/exoplatform/web/security/hash/TestJCASaltedHashService.java
+++ b/component/web/security/src/test/java/org/exoplatform/web/security/hash/TestJCASaltedHashService.java
@@ -50,9 +50,7 @@ public class TestJCASaltedHashService extends AbstractKernelTest {
 //        AutoReseedRandom random = new AutoReseedRandom(AutoReseedRandom.DEFAULT_RANDOM_ALGORITHM, AutoReseedRandom.DEFAULT_RANDOM_ALGORITHM_PROVIDER,
 //                AutoReseedRandom.DEFAULT_SEED_LENGTH, 500);
         for (String password : PASSWORDS) {
-            // System.out.println(password);
             String saltedHash = sh.getSaltedHash(password);
-            // System.out.println("h="+saltedHash);
             assertTrue(sh.validate(password, saltedHash));
         }
     }

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -99,7 +99,7 @@
   <head id="head">
     <title><%=HTMLEntityEncoder.getInstance().encode(title)%></title>
 
-    <!-- Metadatas -->
+    <%/* Metadatas */%>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="theme-color" content="#476A9C"/>
@@ -120,7 +120,7 @@
 
     <link rel="shortcut icon" href="<%= org.exoplatform.portal.branding.Utils.getFaviconPath() %>" />
 
-    <!-- Styles -->
+    <%/* Styles */%>
     <link id="brandingSkin" rel="stylesheet" type="text/css" href="<%=uicomponent.getBrandingUrl()%>">
     <% for (skinConfig in portalSkins) {
          def url = skinConfig.createURL(rcontext.controllerContext);
@@ -138,16 +138,16 @@
       <link id="${customSkin.id}" rel="stylesheet" type="text/css" href= "$url" skin-type="${customSkin.type}" />
     <% } %>
 
-    <!-- Scripts -->
-    <script type="text/javascript">
+    <%/* Scripts */%>
+    <script type="text/javascript" id="jsConfig">
       var require = <%=jsConfig%>;
     </script>
 
     <% for (url in headerScripts) { %>
-      <script type="text/javascript" src="<%= url %>"></script>
+      <script type="text/javascript" src="<%= url %>" data-id="header-script"></script>
     <% } %>
 
-   <script type="text/javascript">
+   <script type="text/javascript" id="remoteScripts">
      eXo.env.addLoadedRemoteScripts(<%=remoteScripts%>);
      <% if (org.exoplatform.commons.utils.PropertyManager.isDevelopping()) { %>
           eXo.developing = true ;
@@ -210,8 +210,8 @@
      }
    %>
 
-   <!-- 508 Compliancy -->
-   <style type="text/css">
+   <%/* 508 Compliancy */%>
+   <style type="text/css" id="Compliancy508Style">
      .skipHidden {
        position:absolute !important;
        left:-10000px !important;
@@ -225,10 +225,10 @@
        left: auto !important;
      }
    </style>
-   <!-- The android browser on 2.3.x doesn't properly handle rtl so we need to handle this special situation.
+   <%/* The android browser on 2.3.x doesn't properly handle rtl so we need to handle this special situation.
         This old browser it expects right to be positive instead of negative in order to hide the content instead of displaying it.
-        If the page is over 10000px wide and rtl we assume this situation. -->
-   <script type="text/javascript">
+        If the page is over 10000px wide and rtl we assume this situation.  */%>
+   <script type="text/javascript" id="Compliancy508Script">
      if (window.onload) {
        var currentOnLoad = window.onload;
        window.onload = function() { currentOnLoad(); checkRTLWidth() };
@@ -242,14 +242,14 @@
        }
      }
    </script>
-   <!-- /508 Compliancy -->
+   <%/* 508 Compliancy */%>
 
-   <!-- Include extensible templates configured by Kernel configuration to be imported in Page Header -->
+   <%/* Include extensible templates configured by Kernel configuration to be imported in Page Header */%>
    <% _ctx.includeTemplates("UIPortalApplication-head") %>
  </head>
 
  <body style="height: 100%;" class="$bodyClasses" onload="eXo.env.portal.onLoad()">
-   <!-- Include extensible templates configured by Kernel configuration to be imported in the beginning of the body section of the Page -->
+   <%/* Include extensible templates configured by Kernel configuration to be imported in the beginning of the body section of the Page */%>
    <% _ctx.includeTemplates("UIPortalApplication-Start-body") %>
    <div class="visible-tablet"></div>
    <div class="visible-tabletL"></div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
@@ -8,7 +8,7 @@
    <% /* Include extensible templates configured by Kernel configuration to be imported in Page Header */ %>
    <% _ctx.includeTemplates("UIPortalApplication-End-Body") %>
 
-  <script type="text/javascript">
+  <script type="text/javascript" id="jsManager">
     <%=jsManager.getJavaScripts()%>
   </script>
 </body>

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalPreloadResources.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalPreloadResources.gtmpl
@@ -4,14 +4,12 @@ def rcontext = _ctx.getRequestContext() ;
 <%
 /* Loading needed Fonts files in top of the page as a 'preload' resource to include it in response when using HTTP/2 */
 %>
-  <!-- Fonts Preload -->
+  <%/* Fonts Preload */%>
   <link rel="preload" href="/platform-ui/skin/fonts/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/platform-ui/skin/fonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/platform-ui/skin/fonts/fa-regular-400.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="/platform-ui/skin/fonts/materialdesignicons-webfont.woff2?v=5.9.55" as="font" type="font/woff2" crossorigin>
-<%
-// Loading needed stylesheets in top of the page as a 'preload' resource to include it in response
-%>
+  <%/* Loading needed stylesheets in top of the page as a 'preload' resource to include it in response*/%>
   <link rel="preload" as="style" type="text/css" href="<%=uicomponent.getBrandingUrl()%>">
 <%
 // Loading needed stylesheets in top of the page as a 'preload' resource to include it in response

--- a/webui/core/src/main/java/org/exoplatform/webui/form/UIFormInputItemSelector.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/UIFormInputItemSelector.java
@@ -129,7 +129,6 @@ public class UIFormInputItemSelector<T> extends UIFormInputBase<T> {
     }
 
     public void decode(Object input, WebuiRequestContext context) {
-        // System.out.println("\n\n\n == > current input value is "+input+"\n\n");
         if (input == null || String.valueOf(input).length() < 1)
             return;
         setValue(input);

--- a/webui/framework/src/main/java/org/exoplatform/webui/core/UIComponentDecorator.java
+++ b/webui/framework/src/main/java/org/exoplatform/webui/core/UIComponentDecorator.java
@@ -44,49 +44,53 @@ public class UIComponentDecorator extends UIComponent {
     }
 
     public UIComponent setUIComponent(UIComponent uicomponent) {
-        UIComponent oldOne = uicomponent_;
-        if (uicomponent_ != null)
-            uicomponent_.setParent(null);
-        uicomponent_ = uicomponent;
-        if (uicomponent_ != null) {
-            UIComponent oldParent = uicomponent_.getParent();
+        UIComponent oldOne = getUIComponent();
+        if (oldOne != null)
+            oldOne.setParent(null);
+        setChildComponent(uicomponent);
+        if (uicomponent != null) {
+            UIComponent oldParent = uicomponent.getParent();
             if (oldParent != null && oldParent != this && oldParent instanceof UIComponentDecorator) {
                 ((UIComponentDecorator) oldParent).setUIComponent(null);
             }
-            uicomponent_.setParent(this);
+            uicomponent.setParent(this);
         }
         return oldOne;
+    }
+
+    protected void setChildComponent(UIComponent uicomponent) {
+        uicomponent_ = uicomponent;
     }
 
     @SuppressWarnings("unchecked")
     public <T extends UIComponent> T findComponentById(String id) {
         if (getId().equals(id))
             return (T) this;
-        if (uicomponent_ == null)
+        if (getUIComponent() == null)
             return null;
-        return (T) uicomponent_.findComponentById(id);
+        return (T) getUIComponent().findComponentById(id);
     }
 
     public <T extends UIComponent> T findFirstComponentOfType(Class<T> type) {
         if (type.isInstance(this))
             return type.cast(this);
-        if (uicomponent_ == null)
+        if (getUIComponent() == null)
             return null;
-        return uicomponent_.findFirstComponentOfType(type);
+        return getUIComponent().findFirstComponentOfType(type);
     }
 
     public <T> void findComponentOfType(List<T> list, Class<T> type) {
         if (type.isInstance(this))
             list.add(type.cast(this));
-        if (uicomponent_ == null)
+        if (getUIComponent() == null)
             return;
-        uicomponent_.findComponentOfType(list, type);
+        getUIComponent().findComponentOfType(list, type);
     }
 
     public void renderChildren() throws Exception {
-        if (uicomponent_ == null)
+        if (getUIComponent() == null)
             return;
-        uicomponent_.processRender((WebuiRequestContext) WebuiRequestContext.getCurrentInstance());
+        getUIComponent().processRender((WebuiRequestContext) WebuiRequestContext.getCurrentInstance());
     }
 
     public static class UIComponentDecoratorLifecycle extends Lifecycle<UIComponentDecorator> {
@@ -94,8 +98,8 @@ public class UIComponentDecorator extends UIComponent {
         public void processRender(UIComponentDecorator uicomponent, WebuiRequestContext context) throws Exception {
             context.getWriter().append("<div class=\"").append(uicomponent.getId()).append("\" id=\"")
                     .append(uicomponent.getId()).append("\">");
-            if (uicomponent.uicomponent_ != null) {
-                uicomponent.uicomponent_.processRender(context);
+            if (uicomponent.getUIComponent() != null) {
+                uicomponent.getUIComponent().processRender(context);
             }
             context.getWriter().append("</div>");
         }

--- a/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -50,14 +50,19 @@ import org.exoplatform.portal.config.*;
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.mop.Visibility;
 import org.exoplatform.portal.mop.page.PageContext;
 import org.exoplatform.portal.mop.page.PageKey;
 import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.portal.mop.user.UserNavigation;
 import org.exoplatform.portal.mop.user.UserNode;
+import org.exoplatform.portal.mop.user.UserNodeFilterConfig;
+import org.exoplatform.portal.mop.user.UserNodeFilterConfig.Builder;
 import org.exoplatform.portal.mop.user.UserPortal;
 import org.exoplatform.portal.mop.user.UserPortalContext;
 import org.exoplatform.portal.url.PortalURLContext;
+import org.exoplatform.portal.webui.page.UIPage;
+import org.exoplatform.portal.webui.page.UIPageBody;
 import org.exoplatform.portal.webui.portal.UIPortal;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.portal.webui.workspace.UIPortalApplication;
@@ -69,6 +74,7 @@ import org.exoplatform.services.resources.ResourceBundleManager;
 import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.application.JavascriptManager;
+import org.exoplatform.web.application.RequestContext;
 import org.exoplatform.web.application.URLBuilder;
 import org.exoplatform.web.security.sso.SSOHelper;
 import org.exoplatform.web.url.PortalURL;
@@ -151,6 +157,9 @@ public class PortalRequestContext extends WebuiRequestContext {
     @Setter
     private boolean hideSharedLayout;
 
+    @Setter
+    private Boolean draftPage;
+
     private boolean forceFullUpdate = false;
 
     private Writer writer_;
@@ -181,6 +190,18 @@ public class PortalRequestContext extends WebuiRequestContext {
     private UserPortalConfig userPortalConfig;
 
     private PortalConfig currentPortalConfig;
+
+    @Getter
+    @Setter
+    private UIPortal                       uiPortal;
+
+    @Getter
+    @Setter
+    private UIPage                         uiPage;
+
+    @Getter
+    @Setter
+    private UserNode                       userNode;
 
     public JavascriptManager getJavascriptManager() {
         return jsmanager_;
@@ -294,6 +315,27 @@ public class PortalRequestContext extends WebuiRequestContext {
         }
     }
 
+    public boolean isDraftPage() {
+      if (draftPage == null) {
+        UserNode navigationNode = getNavigationNode();
+        draftPage = navigationNode != null && navigationNode.getVisibility() == Visibility.DRAFT;
+      }
+      return draftPage.booleanValue();
+    }
+
+    public UserNode getNavigationNode() {
+      if (userNode != null) {
+        return userNode;
+      }
+      UserPortal userPortal = getUserPortalConfig().getUserPortal();
+      UserNavigation navigation = userPortal.getNavigation(siteKey);
+      if (navigation != null) {
+        Builder builder = UserNodeFilterConfig.builder().withReadCheck();
+        userNode = userPortal.resolvePath(navigation, builder.build(), nodePath_);
+      }
+      return userNode;
+    }
+
     public UserPortalConfig getUserPortalConfig() {
         String remoteUser = null;
         if (userPortalConfig == null) {
@@ -401,7 +443,7 @@ public class PortalRequestContext extends WebuiRequestContext {
 
         //
         if (title == null) {
-            UIPortal uiportal = Util.getUIPortal();
+            UIPortal uiportal = getUiPortal();
 
             //
             UserNode node = uiportal.getSelectedUserNode();
@@ -717,4 +759,10 @@ public class PortalRequestContext extends WebuiRequestContext {
                 controllerContext.getParameter(RequestNavigationData.REQUEST_SITE_NAME),
                 controllerContext.getParameter(RequestNavigationData.REQUEST_PATH));
     }
+
+    @SuppressWarnings("unchecked")
+    public static PortalRequestContext getCurrentInstance() {
+        return (PortalRequestContext) RequestContext.getCurrentInstance();
+    }
+
 }

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
@@ -960,7 +960,7 @@ public class UIPortlet<S, C extends Serializable> extends UIApplication {
         try {
             return portletInvoker.invoke(invocation);
         } finally {
-            currentPortlet.remove();;
+            currentPortlet.remove();
         }
     }
 

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UIContainer.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/container/UIContainer.java
@@ -19,6 +19,7 @@
 
 package org.exoplatform.portal.webui.container;
 
+
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.portal.config.UserACL;
@@ -49,9 +50,6 @@ public class UIContainer extends UIPortalComponent {
     protected String[] moveContainersPermissions;
 
     protected String[] moveAppsPermissions;
-
-    public UIContainer() {
-    }
 
     public String getStorageId() {
         return storageId;
@@ -103,7 +101,7 @@ public class UIContainer extends UIPortalComponent {
 
     public boolean hasMoveContainersPermission() {
         ExoContainer exoContainer = ExoContainerContext.getCurrentContainer();
-        UserACL acl = (UserACL) exoContainer.getComponentInstanceOfType(UserACL.class);
+        UserACL acl = exoContainer.getComponentInstanceOfType(UserACL.class);
         return acl.hasPermission(moveContainersPermissions);
     }
 

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/page/UISiteBody.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/page/UISiteBody.java
@@ -22,10 +22,12 @@ package org.exoplatform.portal.webui.page;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.portal.webui.portal.UIPortal;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.web.application.RequestContext;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
+import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.core.UIComponentDecorator;
 
 /**
@@ -62,6 +64,20 @@ public class UISiteBody extends UIComponentDecorator {
       } else {
         return portalOwner.toUpperCase() + "Site";
       }
+    }
+
+    @Override
+    public UIComponent getUIComponent() {
+      return PortalRequestContext.getCurrentInstance().getUiPortal();
+    }
+
+    public UIPortal getUIPortal() {
+      return (UIPortal) getUIComponent();
+    }
+
+    @Override
+    protected void setChildComponent(UIComponent uicomponent) {
+      PortalRequestContext.getCurrentInstance().setUiPortal((UIPortal) uicomponent);
     }
 
     protected boolean isShowSiteBody(PortalRequestContext requestContext) {

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortal.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/portal/UIPortal.java
@@ -38,6 +38,7 @@ import org.exoplatform.portal.webui.portal.UIPortalComponentActionListener.EditP
 import org.exoplatform.portal.webui.portal.UIPortalComponentActionListener.MoveChildActionListener;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.listener.*;
+import org.exoplatform.web.application.RequestContext;
 import org.exoplatform.web.login.LoginUtils;
 import org.exoplatform.web.login.LogoutControl;
 import org.exoplatform.web.security.GateInToken;
@@ -66,6 +67,7 @@ import java.util.Map;
   @EventConfig(listeners = ChangeSkinActionListener.class, csrfCheck = false)
 })
 public class UIPortal extends UIContainer {
+
     private SiteKey siteKey;
 
     private String locale;
@@ -78,11 +80,9 @@ public class UIPortal extends UIContainer {
 
     private Properties properties;
 
-    private UserNode navPath;
+    private Map<String, UIPage> allUiPages = new HashMap<>();
 
-    private Map<String, UIPage> all_UIPages;
-
-    private Map<String, String[]> publicParameters_ = new HashMap<String, String[]>();
+    private Map<String, String[]> publicParameters = new HashMap<>();
 
     private UIComponent maximizedUIComponent;
 
@@ -151,23 +151,23 @@ public class UIPortal extends UIContainer {
     }
 
     public Map<String, String[]> getPublicParameters() {
-        return publicParameters_;
+        return publicParameters;
     }
 
     public void setPublicParameters(Map<String, String[]> publicParams) {
-        publicParameters_ = publicParams;
+        publicParameters = publicParams;
     }
 
     public UserNode getNavPath() {
-        if (navPath == null) {
-            PortalRequestContext prc = Util.getPortalRequestContext();
-            navPath = prc.getUserPortalConfig().getUserPortal().getDefaultPath(null);
-        }
-        return navPath;
+      PortalRequestContext prc = PortalRequestContext.getCurrentInstance();
+      if (prc.getNavigationNode() == null) {
+        setNavPath(prc.getUserPortalConfig().getUserPortal().getDefaultPath(null));
+      }
+      return prc.getNavigationNode();
     }
 
     public void setNavPath(UserNode nav) {
-        this.navPath = nav;
+      PortalRequestContext.getCurrentInstance().setUserNode(nav);
     }
 
     /**
@@ -177,22 +177,26 @@ public class UIPortal extends UIContainer {
      * @return the UIPage associated to the specified pageReference or null if not any
      */
     public UIPage getUIPage(String pageReference) {
-        if (all_UIPages == null) {
-            return null;
-        }
-        return this.all_UIPages.get(pageReference);
+      if (isDraftPage()) {
+        return null;
+      } else {
+        return this.allUiPages.get(pageReference);
+      }
     }
 
     public void setUIPage(String pageReference, UIPage uiPage) {
-        if (this.all_UIPages == null) {
-            this.all_UIPages = new HashMap<String, UIPage>(5);
-        }
-        this.all_UIPages.put(pageReference, uiPage);
+      if (!isDraftPage()) {
+        this.allUiPages.put(pageReference, uiPage);
+      }
+    }
+
+    public boolean isDraftPage() {
+      return ((PortalRequestContext) RequestContext.getCurrentInstance()).isDraftPage();
     }
 
     public void clearUIPage(String pageReference) {
-        if (this.all_UIPages != null)
-            this.all_UIPages.remove(pageReference);
+        if (this.allUiPages != null)
+            this.allUiPages.remove(pageReference);
     }
 
     public UserNavigation getUserNavigation() {
@@ -415,8 +419,8 @@ public class UIPortal extends UIContainer {
           return;
         }
         String pageReference = pageKey.format();
-        if (all_UIPages != null && all_UIPages.containsKey(pageReference)) {
-          all_UIPages.remove(pageReference);
+        if (allUiPages != null && allUiPages.containsKey(pageReference)) {
+          allUiPages.remove(pageReference);
         }
       }
     }

--- a/webui/portal/src/test/java/org/exoplatform/portal/webui/test/PortalRequestContextTest.java
+++ b/webui/portal/src/test/java/org/exoplatform/portal/webui/test/PortalRequestContextTest.java
@@ -54,18 +54,14 @@ public class PortalRequestContextTest extends TestCase {
 
   private static MockedStatic<ExpressionUtil> EXPRESSION_UTIL;
 
-  private static MockedStatic<Util>           UTIL;
-
   @BeforeClass
   public static void beforeClass() {
     EXPRESSION_UTIL = mockStatic(ExpressionUtil.class);
-    UTIL = mockStatic(Util.class);
   }
 
   @AfterClass
   public static void afterClass() {
     EXPRESSION_UTIL.close();
-    UTIL.close();
   }
 
   @Test
@@ -83,7 +79,7 @@ public class PortalRequestContextTest extends TestCase {
 
     ResourceBundle bundle = ResourceBundle.getBundle("test");
 
-    UTIL.when(() -> Util.getUIPortal()).thenReturn(uiPortal);
+    when(prc.getUiPortal()).thenReturn(uiPortal);
     EXPRESSION_UTIL.when(() -> ExpressionUtil.getExpressionValue(bundle, "title")).thenCallRealMethod();
 
     doCallRealMethod().when(prc).setPageTitle(anyString());


### PR DESCRIPTION
Prior to this change, when requesting multiple pages at the same time from portal, the same page is displayed in all requested pages. This change will move the selection of current site and page into a contextual object `PortalRequestContext` that is built for each HTTP Request, instead to add it in a statefull mode inside the same `WebUI` Component which is shared between all pages. In addition, this change will allow to request a single application inside a page to be displayed in a standalone way (whithout having to use the `StandaloneAppRequestHandler` and `UIStandaloneApplication` which duplicates the code and makes it unmaintainable and not tested continuously).