### PR TITLE
fix: fix container display to respect width css rules - EXO-68837 - Meeds-io/meeds#1769

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIAddOnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIAddOnContainer.gtmpl
@@ -14,7 +14,12 @@
 	String uiComponentWidth = uicomponent.getWidth();
 	String uiComponentHeight = uicomponent.getHeight();
 	if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-	if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+	if(uiComponentWidth != null) {
+	  cssStyle += "width: "+uiComponentWidth+";"
+	  if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+        cssStyle += "min-width: "+uiComponentWidth+";"
+      }
+	}
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIContainer.gtmpl
@@ -16,7 +16,12 @@
 	String uiComponentWidth = uicomponent.getWidth();
 	String uiComponentHeight = uicomponent.getHeight();
 	if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-	if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+	if(uiComponentWidth != null) {
+	  cssStyle += "width: "+uiComponentWidth+";"
+	  if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+        cssStyle += "min-width: "+uiComponentWidth+";"
+      }
+	}
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIMobileSwipeContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIMobileSwipeContainer.gtmpl
@@ -16,7 +16,12 @@
 	String uiComponentWidth = uicomponent.getWidth();
 	String uiComponentHeight = uicomponent.getHeight();
 	if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-	if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+	if(uiComponentWidth != null) {
+	  cssStyle += "width: "+uiComponentWidth+";"
+	  if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+        cssStyle += "min-width: "+uiComponentWidth+";"
+      }
+	}
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveColumnGroupContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveColumnGroupContainer.gtmpl
@@ -16,8 +16,13 @@
 	String uiComponentWidth = uicomponent.getWidth();
 	String uiComponentHeight = uicomponent.getHeight();
 	if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-	if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
-	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
+	if(uiComponentWidth != null) {
+	  cssStyle += "width: "+uiComponentWidth+";"
+	  if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+        cssStyle += "min-width: "+uiComponentWidth+";"
+      }
+	}
+    if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveContainer.gtmpl
@@ -14,7 +14,12 @@
 	String uiComponentWidth = uicomponent.getWidth();
 	String uiComponentHeight = uicomponent.getHeight();
 	if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-	if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+	if(uiComponentWidth != null) {
+	  cssStyle += "width: "+uiComponentWidth+";"
+	  if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+        cssStyle += "min-width: "+uiComponentWidth+";"
+      }
+	}
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableBigSmallColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableBigSmallColumnContainer.gtmpl
@@ -43,8 +43,13 @@
 			String style = "";
 			String width	= uicomponent.getWidth();
 			String height	= uicomponent.getHeight();
-			if(width != null) style += "width:"+width+";";
-			if(height != null) style += "height:"+height+";";
+            if(width != null) {
+              style += "width: "+width+";"
+              if (!width.contains("calc") && !width.contains("Calc")) {
+                style += "min-width: "+width+";"
+              }
+            }
+            if(height != null) style += "height:"+height+";";
 			if(portalMode == uiPortalApp.CONTAINER_BLOCK_EDIT_MODE || portalMode == uiPortalApp.APP_BLOCK_EDIT_MODE){
 		%>
 		<div class="LAYOUT-CONTAINER LAYOUT-BLOCK">

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableColumnContainer.gtmpl
@@ -45,8 +45,13 @@
 			String style = "";
 			String width	= uicomponent.getWidth();
 			String height	= uicomponent.getHeight();
-			if(width != null) style += "width:"+width+";";
-			if(height != null) style += "height:"+height+";";
+            if(width != null) {
+              style += "width: "+width+";"
+              if (!width.contains("calc") && !width.contains("Calc")) {
+                style += "min-width: "+width+";"
+              }
+            }
+            if(height != null) style += "height:"+height+";";
 			if(portalMode == uiPortalApp.CONTAINER_BLOCK_EDIT_MODE || portalMode == uiPortalApp.APP_BLOCK_EDIT_MODE){
 		%>
 		<div class="LAYOUT-CONTAINER LAYOUT-BLOCK">

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableFourColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableFourColumnContainer.gtmpl
@@ -43,8 +43,13 @@
 			String style = "";
 			String width	= uicomponent.getWidth();
 			String height	= uicomponent.getHeight();
-			if(width != null) style += "width:"+width+";";
-			if(height != null) style += "height:"+height+";";
+            if(width != null) {
+              style += "width: "+width+";"
+              if (!width.contains("calc") && !width.contains("Calc")) {
+                style += "min-width: "+width+";"
+              }
+            }
+            if(height != null) style += "height:"+height+";";
 			if(portalMode == uiPortalApp.CONTAINER_BLOCK_EDIT_MODE || portalMode == uiPortalApp.APP_BLOCK_EDIT_MODE){
 		%>
 		<div class="LAYOUT-CONTAINER LAYOUT-BLOCK">

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableSmallBigColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableSmallBigColumnContainer.gtmpl
@@ -42,7 +42,12 @@
 			String style = "";
 			String width	= uicomponent.getWidth();
 			String height	= uicomponent.getHeight();
-			if(width != null) style += "width:"+width+";";
+            if(width != null) {
+              style += "width: "+width+";"
+              if (!width.contains("calc") && !width.contains("Calc")) {
+                style += "min-width: "+width+";"
+              }
+            }
 			if(height != null) style += "height:"+height+";";
 			if(portalMode == uiPortalApp.CONTAINER_BLOCK_EDIT_MODE || portalMode == uiPortalApp.APP_BLOCK_EDIT_MODE){
 		%>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableThreeColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableThreeColumnContainer.gtmpl
@@ -44,8 +44,13 @@
 			String style = "";
 			String width	= uicomponent.getWidth();
 			String height	= uicomponent.getHeight();
-			if(width != null) style += "width:"+width+";";
-			if(height != null) style += "height:"+height+";";
+            if(width != null) {
+              style += "width: "+width+";"
+              if (!width.contains("calc") && !width.contains("Calc")) {
+                style += "min-width: "+width+";"
+              }
+            }
+            if(height != null) style += "height:"+height+";";
 			if(portalMode == uiPortalApp.CONTAINER_BLOCK_EDIT_MODE || portalMode == uiPortalApp.APP_BLOCK_EDIT_MODE){
 		%>
 		<div class="LAYOUT-CONTAINER LAYOUT-BLOCK">

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableTwoColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableTwoColumnContainer.gtmpl
@@ -44,8 +44,13 @@
 			String style = "";
 			String width	= uicomponent.getWidth();
 			String height	= uicomponent.getHeight();
-			if(width != null) style += "width:"+width+";";
-			if(height != null) style += "height:"+height+";";
+            if(width != null) {
+              style += "width: "+width+";"
+              if (!width.contains("calc") && !width.contains("Calc")) {
+                style += "min-width: "+width+";"
+              }
+            }
+            if(height != null) style += "height:"+height+";";
 			if(portalMode == uiPortalApp.CONTAINER_BLOCK_EDIT_MODE || portalMode == uiPortalApp.APP_BLOCK_EDIT_MODE){
 		%>
 		<div class="LAYOUT-CONTAINER LAYOUT-BLOCK">

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl
@@ -15,7 +15,12 @@
   String uiComponentWidth = uicomponent.getWidth();
   String uiComponentHeight = uicomponent.getHeight();
   if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-  if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+  if(uiComponentWidth != null) {
+    cssStyle += "width: "+uiComponentWidth+";"
+    if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+      cssStyle += "min-width: "+uiComponentWidth+";"
+    }
+  }
   if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
   if(cssStyle.length() > 0) cssStyle += "\"";
 

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UISimpleRowContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UISimpleRowContainer.gtmpl
@@ -16,7 +16,12 @@
 	String uiComponentWidth = uicomponent.getWidth();
 	String uiComponentHeight = uicomponent.getHeight();
 	if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-	if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+	if(uiComponentWidth != null) {
+	  cssStyle += "width: "+uiComponentWidth+";"
+	  if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+        cssStyle += "min-width: "+uiComponentWidth+";"
+      }
+	}
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UISimpleTableContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UISimpleTableContainer.gtmpl
@@ -16,7 +16,12 @@
 	String uiComponentWidth = uicomponent.getWidth();
 	String uiComponentHeight = uicomponent.getHeight();
 	if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-	if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+	if(uiComponentWidth != null) {
+	  cssStyle += "width: "+uiComponentWidth+";"
+	  if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+        cssStyle += "min-width: "+uiComponentWidth+";"
+      }
+	}
 	if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
 	if(cssStyle.length() > 0) cssStyle += "\"";
 	

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITabContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITabContainer.gtmpl
@@ -129,7 +129,12 @@
      String width = uicomponent.getWidth();
      String height  = uicomponent.getHeight();
      if(width != null || height != null) style="style=\"";
-     if(width != null) style += "width: "+width+"px;"
+     if(width != null) {
+       style += "width: "+width+";"
+       if (!width.contains("calc") && !width.contains("Calc")) {
+         style += "min-width: "+width+";"
+       }
+     }
      if(height != null) style += "height: "+height+"px;"
      if(style.length() > 0) style += "\"";
   %>            

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITableAutofitColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITableAutofitColumnContainer.gtmpl
@@ -44,9 +44,14 @@
 			String style = "";
 		   String width = uicomponent.getWidth();
 		   String height = uicomponent.getHeight();
-		   if (width != null) style += "width:"+width+";";
-		   if (height != null) style += "height:"+height+";";
-			if (editMode == EditMode.BLOCK) {
+           if(width != null) {
+             style += "width: "+width+";"
+             if (!width.contains("calc") && !width.contains("Calc")) {
+               style += "min-width: "+width+";"
+             }
+           }
+           if (height != null) style += "height:"+height+";";
+		   if (editMode == EditMode.BLOCK) {
 		%>
 		<div class="LAYOUT-CONTAINER LAYOUT-BLOCK">
 		<%} else {%>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITableColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITableColumnContainer.gtmpl
@@ -45,7 +45,12 @@
 			String style = "";
 			String width = uicomponent.getWidth();
 			String height = uicomponent.getHeight();
-			if (width != null) style += "width:"+width+";";
+            if(width != null) {
+              style += "width: "+width+";"
+              if (!width.contains("calc") && !width.contains("Calc")) {
+                style += "min-width: "+width+";"
+              }
+            }
 			if (height != null) style += "height:"+height+";";
 			if (editMode == EditMode.BLOCK) {
 		%>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITopBarContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITopBarContainer.gtmpl
@@ -22,7 +22,12 @@
   		String style = "";
   		String width	= uicomponent.getWidth();
   		String height	= uicomponent.getHeight();
-  		if(width != null) style += "width:"+width+";";
+        if(width != null) {
+          style += "width: "+width+";"
+          if (!width.contains("calc") && !width.contains("Calc")) {
+            style += "min-width: "+width+";"
+          }
+        }
   		if(height != null) style += "height:"+height+";";
   		if(portalMode == uiPortalApp.CONTAINER_BLOCK_EDIT_MODE || portalMode == uiPortalApp.APP_BLOCK_EDIT_MODE){
   	%>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIVColContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIVColContainer.gtmpl
@@ -16,7 +16,12 @@
   String uiComponentWidth = uicomponent.getWidth();
   String uiComponentHeight = uicomponent.getHeight();
   if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-  if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+  if(uiComponentWidth != null) {
+    cssStyle += "width: "+uiComponentWidth+";"
+    if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+      cssStyle += "min-width: "+uiComponentWidth+";"
+    }
+  }
   if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
   if(cssStyle.length() > 0) cssStyle += "\"";
   

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIVRowContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIVRowContainer.gtmpl
@@ -16,7 +16,12 @@
   String uiComponentWidth = uicomponent.getWidth();
   String uiComponentHeight = uicomponent.getHeight();
   if(uiComponentWidth != null || uiComponentHeight != null) cssStyle = "style=\"";
-  if(uiComponentWidth != null) cssStyle += "width: "+uiComponentWidth+";"
+  if(uiComponentWidth != null) {
+    cssStyle += "width: "+uiComponentWidth+";"
+    if (!uiComponentWidth.contains("calc") && !uiComponentWidth.contains("Calc")) {
+      cssStyle += "min-width: "+uiComponentWidth+";"
+    }
+  }
   if(uiComponentHeight != null) cssStyle += "height: "+uiComponentHeight+";"
   if(cssStyle.length() > 0) cssStyle += "\"";
   


### PR DESCRIPTION
before this change, when adding a container that one of its sub-containers  having a width with "calc" the sub-containers do not respect the width CSS rules when containing a portlet with a huge width
After this change, when setting the with as the min-width for the container it respects the CSS rules and its width do not change