### PR TITLE
fix: Allow adminstrators to set/get GLOBAL scoped settings - EXO-69904 - Meeds-io/MIPs#112

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/settings/rest/SettingResource.java
+++ b/component/portal/src/main/java/org/exoplatform/settings/rest/SettingResource.java
@@ -120,7 +120,7 @@ public class SettingResource implements ResourceContainer {
     if(currentUser != null) {
       return (context.getName().toUpperCase().equals(Context.USER.getName())
               && (context.getId() == null || currentUser.equals(context.getId())))
-                || (currentUser.equals(userACL.getSuperUser()));
+                || (userACL.isSuperUser() || userACL.isUserInGroup(userACL.getAdminGroups()));
     }
     return false;
   }


### PR DESCRIPTION
prior to this change, only super admin can set/get GLOBAL scoped settings which prevents the update of global settings for admins.
This PR makes sure to allow the admins to execute such action