### PR TITLE
fix: Fix breadcrumb portlet redirection in spaces - EXO-70408 - Meeds-io/meeds#1789

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/rest/EntityBuilder.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/rest/EntityBuilder.java
@@ -151,6 +151,9 @@ public class EntityBuilder {
       if (PageType.LINK.equals(PageType.valueOf(userNodePage.getType()))) {
         nodeUri = userNodePage.getLink();
       } else {
+        if (siteName.contains(("/spaces/"))) {
+          siteName = "g/" + siteName.replaceAll("/",":");
+        }
         nodeUri = new StringBuilder("/").append(portalName)
                                         .append("/")
                                         .append(siteName)


### PR DESCRIPTION
Before this change, when clicking on a breadcrumb item of a space we have a wrong redirection since the URL is computed with the wrong space.
After this change, the URL is computed with the right space node URL and the redirection is done successfully.