### PR TITLE
feat: allow to create users with @ in username if pattern allow it - EXO-70576

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserFieldValidator.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserFieldValidator.java
@@ -194,13 +194,12 @@ public class UserFieldValidator {
     String label = getLabel(locale, "UIRegisterForm.label." + field);
     return label == null ? null : label.replace(" :", "").replace(":", "");
   }
-
   private static boolean isLowerCaseLetterOrDigit(char character) {
     return Character.isDigit(character) || (character >= 'a' && character <= 'z');
   }
 
   private static boolean isSymbol(char c) {
-    return c == '_' || c == '.' || c == '-' ;
+    return c == '_' || c == '.' || c == '-' || c == '@' ;
   }
 
   private static String getLabel(Locale locale, String key, Object... values) {

--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -266,21 +266,20 @@ public class LoginHandler extends JspBasedWebHandler {
     }
   }
 
-  private String getUserNameByEmail(String email,
+  private String getUserNameByEmail(String identifier,
                                     ControllerContext context,
                                     StringBuilder loginPath) throws Exception {
     UserHandler userHandler = organizationService.getUserHandler();
     if (userHandler != null) {
       Query emailQuery = new Query();
-      emailQuery.setEmail(email);
+      emailQuery.setEmail(identifier);
       ListAccess<User> users;
       try {
         users = userHandler.findUsersByQuery(emailQuery);
         if (users != null && users.getSize() > 0) {
           return users.load(0, 1)[0].getUserName();
         } else {
-          LOG.debug("Can not get users by email");
-          dispatch(context, loginPath.toString(), LoginStatus.FAILED);
+          return identifier;
         }
       } catch (RuntimeException e) {
         LOG.warn("Can not login with an email associated to many users");


### PR DESCRIPTION
Before this fix, event if username pattern is configured to accept arobase character, it is not possible to create a user with @, because the char is explicitly excluded

This commit remove the exclusion, and allow this char if it is present in username pattern

Resolves https://github.com/Meeds-io/meeds/issues/1806