### PR TITLE
fix: Fix WebUI Portlet identification - MEED-5148 - Meeds-io/MIPs#120

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
@@ -164,11 +164,6 @@ public class UIPortlet<S, C extends Serializable> extends UIApplication {
     /** A field storing localized value of javax.portlet.title * */
     private String configuredTitle;
 
-    public UIPortlet() {
-        // That value will be overriden when it is mapped onto a data storage
-        storageName = UUID.randomUUID().toString();
-    }
-
     public String getStorageId() {
         return storageId;
     }
@@ -178,7 +173,10 @@ public class UIPortlet<S, C extends Serializable> extends UIApplication {
     }
 
     public String getStorageName() {
-        return storageName;
+      if (storageName == null) {
+        storageName = UUID.randomUUID().toString();
+      }
+      return storageName;
     }
 
     public void setStorageName(String storageName) {
@@ -186,7 +184,7 @@ public class UIPortlet<S, C extends Serializable> extends UIApplication {
     }
 
     public String getWindowId() {
-        return storageName;
+        return getStorageName();
     }
 
     /**
@@ -205,7 +203,7 @@ public class UIPortlet<S, C extends Serializable> extends UIApplication {
     }
 
     public String getId() {
-        return storageName;
+        return storageId == null ? getStorageName() : storageId;
     }
 
     public String getApplicationId() {
@@ -815,7 +813,7 @@ public class UIPortlet<S, C extends Serializable> extends UIApplication {
         invocation.setInstanceContext(instanceContext);
         invocation.setServerContext(new ExoServerContext(servletRequest, prc.getResponse()));
         invocation.setUserContext(new ExoUserContext(servletRequest, userProfile));
-        invocation.setWindowContext(new AbstractWindowContext(storageName));
+        invocation.setWindowContext(new AbstractWindowContext(getStorageName()));
         invocation.setPortalContext(PORTAL_CONTEXT);
         invocation.setSecurityContext(new AbstractSecurityContext(servletRequest));
 

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/page/UIPageBody.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/page/UIPageBody.java
@@ -19,31 +19,22 @@
 
 package org.exoplatform.portal.webui.page;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.portlet.WindowState;
-
-import org.apache.commons.lang3.StringUtils;
-
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.portal.config.model.Page;
-import org.exoplatform.portal.config.model.PageBody;
 import org.exoplatform.portal.mop.Visibility;
 import org.exoplatform.portal.mop.page.PageContext;
 import org.exoplatform.portal.mop.user.UserNode;
-import org.exoplatform.portal.webui.application.UIPortlet;
 import org.exoplatform.portal.webui.portal.UIPortal;
 import org.exoplatform.portal.webui.util.PortalDataMapper;
 import org.exoplatform.portal.webui.util.Util;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.core.UIComponentDecorator;
-import org.exoplatform.services.log.Log;
-import org.exoplatform.services.log.ExoLogger;
 
 /**
  * May 19, 2006
@@ -56,7 +47,7 @@ public class UIPageBody extends UIComponentDecorator {
     /** . */
     private final Log log = ExoLogger.getLogger(UIPageBody.class);
 
-    public UIPageBody(PageBody model) {
+    public UIPageBody() {
         setId("UIPageBody");
     }
 
@@ -66,14 +57,6 @@ public class UIPageBody extends UIComponentDecorator {
 
     public void setStorageId(String storageId) {
         this.storageId = storageId;
-    }
-
-    public UIPageBody() {
-        setId("UIPageBody");
-    }
-
-    public void init(PageBody model) {
-        setId("UIPageBody");
     }
 
     public String getPageName() {
@@ -137,8 +120,7 @@ public class UIPageBody extends UIComponentDecorator {
         PageContext pageContext = null;
         String pageReference = null;
         ExoContainer appContainer = context.getApplication().getApplicationServiceContainer();
-        UserPortalConfigService userPortalConfigService = (UserPortalConfigService) appContainer
-                .getComponentInstanceOfType(UserPortalConfigService.class);
+        UserPortalConfigService userPortalConfigService = appContainer.getComponentInstanceOfType(UserPortalConfigService.class);
 
         if (pageNode != null && pageNode.getPageRef() != null) {
             pageReference = pageNode.getPageRef().format();
@@ -172,6 +154,6 @@ public class UIPageBody extends UIComponentDecorator {
     }
 
     private PortalRequestContext getRequestContext() {
-      return (PortalRequestContext) PortalRequestContext.getCurrentInstance();
+      return PortalRequestContext.getCurrentInstance();
     }
 }

--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
@@ -357,7 +357,9 @@ public class PortalDataMapper {
             UIPortlet uiPortlet = uiContainer.createUIComponent(context, UIPortlet.class, null, null);
             uiPortlet.setStorageId(application.getStorageId());
             if (application.getStorageName() != null) {
-                uiPortlet.setStorageName(application.getStorageName());
+              uiPortlet.setStorageName(application.getStorageName());
+            } else {
+              uiPortlet.setStorageName(application.getStorageId());
             }
             toUIPortlet(uiPortlet, application);
             uiComponent = uiPortlet;


### PR DESCRIPTION
Prior to this change, when requesting a portlet using direct access url to retrieve a resource, the Portlet instance isn't found due to the usage of a randomly generated identifier for Portlet regerated on each instanciation. This change will ensure the use the storage identifier for a WebUI portlet to ensure coherence of Request queries and expected responses.