### PR TITLE
fix: login with unexisting user lead to a white page - EXO-70765

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -200,7 +200,7 @@ public class LoginHandler extends JspBasedWebHandler {
               username = realUsername;
             }
           }
-        } else if (caseInsensitive) {
+        } else if (caseInsensitive && realUsername != null) {
           username = realUsername;
         }
 


### PR DESCRIPTION
Before this fix, when the user logs with a non existing user, a white page is displayed instead of the login page with the classic error message This problem is due to a test when caseInsensitive is true, which set the username to a null value This commit add an additional test to not set the username to null

Resolves meeds-io/meeds#1826

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
