### PR TITLE
fix: [SAML] Some properties cannot be modified by configuration - EXO-70965

### DIFF
--- a/web/portal/src/main/webapp/META-INF/context.xml
+++ b/web/portal/src/main/webapp/META-INF/context.xml
@@ -30,7 +30,7 @@
       className='org.gatein.sso.integration.SSODelegateValve'
       ssoDelegationEnabled="${gatein.sso.valve.enabled}"
       delegateValveClassName="${gatein.sso.valve.class}"
-      samlSPConfigFile="${exo.conf.dir}/saml2/picketlink-sp.xml" />
+      samlSPConfigFile="${gatein.sso.saml.config.file}" />
   <Valve
       className='org.apache.catalina.authenticator.FormAuthenticator'
       characterEncoding='UTF-8'/>


### PR DESCRIPTION
Before this fix, property gatein.sso.saml.config.file is not taken in account, the value used was always ${exo.conf.dir}/saml2/picketlink-sp.xml This is due to a default value in context.xml, which not use the property This fix modifies this file to correctly use the property

Resolves meeds-io/meeds#1856

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
