### PR TITLE
fix: Fix Display of portal when not cached - MEED-5279 - Meeds-io/MIPs#120

### DIFF
--- a/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/portal/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -1210,7 +1210,10 @@ public class UIPortalApplication extends UIApplication {
     }
 
     private boolean isRefreshPage(RequestNavigationData requestNavData) {
-      return !requestNavData.equals(lastRequestNavData) || isDraftPage() || isMaximizePortlet();
+      return !requestNavData.equals(lastRequestNavData)
+          || getCurrentSite() == null
+          || isDraftPage()
+          || isMaximizePortlet();
     }
 
     private boolean isDraftPage() {


### PR DESCRIPTION
Prior to this change, when creating new portal and it's not cached in WebUI, this may lead to a 404 page. This change will ensure to force the refresh of WebUI components when the UIPortal wasn't cached.