### PR TITLE
feat: Move Hidden flag of Portlet - MEED-6202 - Meeds-io/MIPs#120

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
@@ -46,6 +46,10 @@
 		<%} %>
 <%
 	}
+  String hiddenClass = "";
+  if(editMode == EditMode.NO_EDIT && (portletContent == null || org.apache.commons.lang3.StringUtils.isBlank(portletContent.toString()))) {
+    hiddenClass = "hidden";
+  }
 
 	if (editMode != EditMode.BLOCK) {
 		if(uicomponent.getShowInfoBar()) {
@@ -165,13 +169,9 @@
 			{
 				cssStyle += "height: "+ windowHeight +";";
 			}
-			String hiddenClass = "";
-			if(portletContent == null || org.apache.commons.lang3.StringUtils.isBlank(portletContent.toString())) {
-			  hiddenClass = "hidden";
-			}
  %>
- 				<div id="<%=editMode == EditMode.NO_EDIT ? portletId : "EditMode-"+ portletId%>">
-					<div class="PORTLET-FRAGMENT $hiddenClass" style="${cssStyle}">
+ 				<div id="<%=editMode == EditMode.NO_EDIT ? portletId : "EditMode-"+ portletId%>" class="$hiddenClass">
+					<div class="PORTLET-FRAGMENT" style="${cssStyle}">
  						<% 
 							if(hasAccessPermission)
               {


### PR DESCRIPTION
This change will move the 'hidden' class to parent element of portlet instead of the child element to ensure to not have grid gap applied when the application is added in a dynamic of fixed section.