### PR TITLE
fix: Fix access to site navigation having deleted pages - MEED-6510 - Meeds-io/meeds#1921

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -621,7 +621,7 @@ public class UserPortalConfigService implements Startable {
         return Collections.emptyList();
       }
       UserNodeFilterConfig builder = UserNodeFilterConfig.builder()
-                                                         .withReadWriteCheck()
+                                                         .withReadCheck()
                                                          .withVisibility(Visibility.DISPLAYED, Visibility.TEMPORAL)
                                                          .withTemporalCheck()
                                                          .build();
@@ -648,7 +648,7 @@ public class UserPortalConfigService implements Startable {
     public UserNode getFirstAllowedPageNode(Collection<UserNode> userNodes) {
       UserNode userNode = null;
       for (UserNode node : userNodes) {
-        if (node.getPageRef() != null) {
+        if (node.getPageRef() != null && layoutService.getPage(node.getPageRef()) != null) {
           userNode = node;
           break;
         } else if (node.getChildren() != null && !node.getChildren().isEmpty()) {

--- a/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/test2/navigation.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/test2/navigation.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<node-navigation
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_6 http://www.gatein.org/xml/ns/gatein_objects_1_6"
+    xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_6">
+  <priority>1</priority>
+
+  <page-nodes>
+    <node>
+      <uri>test</uri>
+      <name>test</name>
+      <label>Test</label>
+      <page-reference>portal::test2::test</page-reference>
+    </node>
+    <node>
+      <uri>home</uri>
+      <name>home</name>
+      <label>Home</label>
+      <node>
+        <uri>page</uri>
+        <name>page</name>
+        <label>Page</label>
+        <page-reference>portal::test2::homepage</page-reference>
+      </node>
+    </node>
+  </page-nodes>
+</node-navigation>

--- a/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/test2/pages.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/test2/pages.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<page-set
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_6 http://www.gatein.org/xml/ns/gatein_objects_1_6"
+    xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_6">
+
+  <page>
+    <name>homepage</name>
+    <title>Home Page</title>
+    <access-permissions>Everyone</access-permissions>
+    <edit-permission>*:/platform/administrators</edit-permission>
+  </page>
+
+  <page>
+    <name>test</name>
+    <title>test</title>
+    <access-permissions>*:/platform/users</access-permissions>
+    <edit-permission>*:/platform/administrators</edit-permission>
+  </page>
+
+</page-set>

--- a/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/test2/portal.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/test2/portal.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<portal-config
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_10 http://www.gatein.org/xml/ns/gatein_objects_1_10"
+    xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_10">
+  <portal-name>test2</portal-name>
+  <label>test2</label>
+  <locale>en</locale>
+  <access-permissions>Everyone</access-permissions>
+  <edit-permission>*:/platform/administrators</edit-permission>
+  <portal-layout>
+    <page-body></page-body>
+  </portal-layout>
+</portal-config>


### PR DESCRIPTION
Prior to this change, when the administration has the node navigation which references a non existing page, then the administration link isn't displayed and an NPE is thrown. This change will ensure to not consider the navigations which doesn't have an accessible page in the list of available navigation nodes of user.