### PR TITLE
feat: Allow to add Emoji in spaces - MEED-4267 - Meeds-io/MIPs#1777

### DIFF
--- a/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
+++ b/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
@@ -452,4 +452,10 @@
     </addColumn>
   </changeSet>
 
+  <changeSet author="portal" id="1.0.0-41" dbms="mysql">
+      <sql>
+          ALTER TABLE PORTAL_PAGES MODIFY COLUMN DISPLAY_NAME varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+      </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
This change will allow to add emojis in Page Name, especially when the space name defines emojis. A special SQL modification is needed to make it possible on MySQL.