### PR TITLE
fix: Update to jdk21 - EXO-71474 - Meeds-io/MIPs#91

### DIFF
--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -93,6 +93,12 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>@{argLine} ${env.MAVEN_OPTS} --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/webui/core/src/main/java/org/exoplatform/webui/form/UIFormDateTimeInput.java
+++ b/webui/core/src/main/java/org/exoplatform/webui/form/UIFormDateTimeInput.java
@@ -145,8 +145,8 @@ public class UIFormDateTimeInput extends UIFormInputBase<String> {
         if (!getDatePattern_().contains("HH")) {
             setDatePattern_(getDatePattern_().replaceAll("H", "HH"));
         }
-        if (getDatePattern_().contains(" a")) {
-            setDatePattern_(getDatePattern_().replaceAll(" a", ""));
+        if (getDatePattern_().contains(" a") || getDatePattern_().contains(" a")) {
+            setDatePattern_(getDatePattern_().replaceAll(" a", "").replaceAll(" a", ""));
         }
 
         dateFormat_ = new SimpleDateFormat(getDatePattern_());


### PR DESCRIPTION
Before this fix, the simpleDateFormat for locale en is MM/dd/yyyy, HH:mm:ss a
In jdk17 and under, the space between 'ss' and 'a' is a simple space In JDK 21, the space was changed to '[NNBSP]a' ([OpenJDK information](https://bugs.openjdk.org/browse/JDK-8324665)) : , so the .contains(" a") returns always false

This commit add the test on '[NNBSP]a' in addition of ' a' in order to make it work on both jdk version

Resolves Meeds-io/MIPs#91

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
