### PR TITLE
fix: Allow to add Emoji in Group Label - MEED-6777 - Meeds-io/meeds#1946

### DIFF
--- a/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
+++ b/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
@@ -426,4 +426,10 @@
     <sql>SELECT setval('JBID_REALM_ID_SEQ', (SELECT MAX(ID) FROM JBID_REALM))</sql>
   </changeSet>
 
+  <changeSet author="idm" id="1.0.0-21" dbms="mysql">
+    <sql>
+      ALTER TABLE jbid_io_attr_text_values MODIFY COLUMN ATTR_VALUE VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this change, the Group display name doesn't allow to have emojis in MySQL. This change modifies IDM TEXT_VALUE definition to allow it.