### PR TITLE
fix: Make jsessionid tracking with cookie only - Meeds-io/meeds#2084

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/web.xml
+++ b/web/portal/src/main/webapp/WEB-INF/web.xml
@@ -24,6 +24,8 @@
 
   <display-name>portal</display-name>
 
+  <absolute-ordering/>
+
   <distributable/>
 
   <!-- ================================================================== -->
@@ -302,6 +304,8 @@
     <role-name>users</role-name>
   </security-role>
 
-  <absolute-ordering/>
+  <session-config>
+    <tracking-mode>COOKIE</tracking-mode>
+  </session-config>
 
 </web-app>


### PR DESCRIPTION
Prior to this change, the `jsessionid` is sometimes appended to URL which makes the portal interact badly with bad format of URL. This change will make the `jsessionid` tracking made exclusively with cookies.

(Resolves Meeds-io/meeds#2084)