### PR TITLE
fix : fill cache of InMemoryGroupDaoHandler with a Modifiable Map - EXO-72017

### DIFF
--- a/component/identity/src/test/java/org/exoplatform/services/organization/mock/InMemoryGroupHandler.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/mock/InMemoryGroupHandler.java
@@ -175,7 +175,7 @@ public class InMemoryGroupHandler implements GroupHandler {
 
   @Override
   public ListAccess<Group> findGroupChildren(Group parent, String keyword) {
-    List<Group> childGroups = groupChildsById.computeIfAbsent(parent.getId(), key -> Collections.emptyMap())
+    List<Group> childGroups = groupChildsById.computeIfAbsent(parent.getId(), key -> new HashMap<>())
                                              .values()
                                              .stream()
                                              .filter(group -> StringUtils.contains(group.getLabel(), keyword)
@@ -185,7 +185,7 @@ public class InMemoryGroupHandler implements GroupHandler {
   }
 
   public Collection<Group> findGroups(Group parent) {
-    return groupChildsById.computeIfAbsent(parent.getId(), key -> Collections.emptyMap())
+    return groupChildsById.computeIfAbsent(parent.getId(), key -> new HashMap<>())
                           .values()
                           .stream()
                           .map(ObjectUtils::clone)


### PR DESCRIPTION
Before this fix, when we call computeIfAbsent in InMemoryGroupDaoHandler, and when the item is not in cache, then the create map is done with Collections.emptyMap(). As this map is a non modifiable map, it is not possible to create a group in a test after that as it throws a UnsupportedExecption

This commit change the map to a classic empty Hashmap, so that it can be updated in the future

Resolves meeds-io/meeds#2068

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
