### PR TITLE
feat: Implement Spring Cache Integration with ExoCache Strategy - Meeds-io/MIPs#132

### DIFF
--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -28,7 +28,7 @@
   <name>GateIn Portal Component Common</name>
 
   <properties>
-    <exo.test.coverage.ratio>0.41</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.42</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/component/common/src/main/java/io/meeds/spring/kernel/CacheManagerImpl.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/CacheManagerImpl.java
@@ -1,0 +1,107 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.spring.kernel;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.support.AbstractValueAdaptingCache;
+
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
+
+import lombok.Setter;
+
+public class CacheManagerImpl implements CacheManager {
+
+  @Setter
+  private CacheService       cacheService;
+
+  private Map<String, Cache> cacheInstances = new ConcurrentHashMap<>();
+
+  public CacheManagerImpl(CacheService cacheService) {
+    this.cacheService = cacheService;
+  }
+
+  @Override
+  public Collection<String> getCacheNames() {
+    return cacheService.getAllCacheInstances().stream().map(ExoCache::getName).toList();
+  }
+
+  @Override
+  public Cache getCache(String name) {
+    return cacheInstances.computeIfAbsent(name, k -> {
+      ExoCache<Serializable, Object> cacheInstance = cacheService.getCacheInstance(name);
+      return new AbstractValueAdaptingCache(false) {
+
+        @Override
+        public String getName() {
+          return cacheInstance.getName();
+        }
+
+        @Override
+        public Object getNativeCache() {
+          return cacheInstance;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T get(Object key, Callable<T> valueLoader) {
+          T value = (T) cacheInstance.get((Serializable) key);
+          if (value == null) {
+            try {
+              value = valueLoader.call();
+              cacheInstance.put((Serializable) key, value);
+            } catch (Exception e) {
+              throw new ValueRetrievalException(key, valueLoader, e);
+            }
+          }
+          return value;
+        }
+
+        @Override
+        public void put(Object key, Object value) {
+          cacheInstance.put((Serializable) key, value);
+        }
+
+        @Override
+        public void evict(Object key) {
+          cacheInstance.remove((Serializable) key);
+        }
+
+        @Override
+        public void clear() {
+          cacheInstance.clearCache();
+        }
+
+        @Override
+        protected Object lookup(Object key) {
+          return cacheInstance.get((Serializable) key);
+        }
+
+      };
+    });
+  }
+
+}

--- a/component/common/src/main/java/io/meeds/spring/kernel/KernelCacheConfiguration.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/KernelCacheConfiguration.java
@@ -1,0 +1,41 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.spring.kernel;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.exoplatform.services.cache.CacheService;
+
+/**
+ * A configuration setting to integrate Spring Caching to use
+ * {@link CacheService}
+ */
+@Configuration
+@EnableCaching
+public class KernelCacheConfiguration {
+
+  @Bean
+  public CacheManager cacheManager(CacheService cacheService) {
+    return new CacheManagerImpl(cacheService);
+  }
+
+}

--- a/component/common/src/test/java/io/meeds/spring/integration/test/KernelIntegrationTest.java
+++ b/component/common/src/test/java/io/meeds/spring/integration/test/KernelIntegrationTest.java
@@ -18,32 +18,16 @@
 package io.meeds.spring.integration.test;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import org.exoplatform.jpa.CommonsDAOJPAImplTest;
 
-import io.meeds.kernel.test.KernelExtension;
-import io.meeds.spring.AvailableIntegration;
 import io.meeds.spring.module.dao.TestDao;
 import io.meeds.spring.module.service.TestExcludedService;
 import io.meeds.spring.module.service.TestService;
 import io.meeds.spring.module.storage.TestStorage;
 
-@ExtendWith({ SpringExtension.class, KernelExtension.class })
-@SpringBootApplication(scanBasePackages = {
-  KernelIntegrationTest.MODULE_NAME,
-  AvailableIntegration.KERNEL_TEST_MODULE,
-  AvailableIntegration.JPA_MODULE,
-  AvailableIntegration.LIQUIBASE_MODULE,
-})
-@EnableJpaRepositories(basePackages = KernelIntegrationTest.MODULE_NAME)
-@TestPropertySource(properties = {
-  "spring.liquibase.change-log=" + KernelIntegrationTest.CHANGELOG_PATH,
-})
+@SpringJUnitConfig(CommonsDAOJPAImplTest.class)
 public class KernelIntegrationTest extends CommonsDAOJPAImplTest { // NOSONAR
 
   static final String MODULE_NAME    = "io.meeds.spring.module";

--- a/component/common/src/test/java/io/meeds/spring/integration/test/SpringCacheManagerTest.java
+++ b/component/common/src/test/java/io/meeds/spring/integration/test/SpringCacheManagerTest.java
@@ -1,0 +1,74 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.spring.integration.test;
+
+import java.io.Serializable;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.jpa.CommonsDAOJPAImplTest;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
+
+import io.meeds.spring.module.service.TestCacheService;
+
+@SpringJUnitConfig(CommonsDAOJPAImplTest.class)
+public class SpringCacheManagerTest extends CommonsDAOJPAImplTest { // NOSONAR
+
+  @Autowired
+  private CacheManager     cacheManager;
+
+  @Autowired
+  private CacheService     cacheService;
+
+  @Autowired
+  private TestCacheService testCacheService;
+
+  @Test
+  public void beansInjected() {
+    assertNotNull(PortalContainer.getInstance().getComponentInstanceOfType(CacheService.class));
+    assertNotNull(testCacheService);
+    assertNotNull(cacheService);
+    assertNotNull(cacheManager);
+  }
+
+  @Test
+  public void cacheBehavior() {
+    assertEquals(5, testCacheService.get(5));
+    assertEquals(14, testCacheService.update(7));
+
+    ExoCache<Serializable, Object> cacheInstance = cacheService.getCacheInstance(TestCacheService.CACHE_NAME);
+    assertNotNull(cacheInstance);
+
+    assertEquals(5, cacheInstance.get(5));
+    assertEquals(14, cacheInstance.get(7));
+
+    testCacheService.remove(5);
+    assertNull(cacheInstance.get(5));
+    assertEquals(14, cacheInstance.get(7));
+
+    testCacheService.remove(7);
+    assertNull(cacheInstance.get(5));
+    assertNull(cacheInstance.get(7));
+  }
+
+}

--- a/component/common/src/test/java/io/meeds/spring/integration/test/SpringIntegrationTest.java
+++ b/component/common/src/test/java/io/meeds/spring/integration/test/SpringIntegrationTest.java
@@ -18,18 +18,12 @@
 package io.meeds.spring.integration.test;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.jpa.CommonsDAOJPAImplTest;
 
-import io.meeds.kernel.test.KernelExtension;
-import io.meeds.spring.AvailableIntegration;
 import io.meeds.spring.module.dao.TestDao;
 import io.meeds.spring.module.entity.TestEntity;
 import io.meeds.spring.module.model.TestModel;
@@ -37,17 +31,7 @@ import io.meeds.spring.module.service.TestExcludedService;
 import io.meeds.spring.module.service.TestService;
 import io.meeds.spring.module.storage.TestStorage;
 
-@ExtendWith({ SpringExtension.class, KernelExtension.class })
-@SpringBootApplication(scanBasePackages = {
-  SpringIntegrationTest.MODULE_NAME,
-  AvailableIntegration.KERNEL_TEST_MODULE,
-  AvailableIntegration.JPA_MODULE,
-  AvailableIntegration.LIQUIBASE_MODULE,
-})
-@EnableJpaRepositories(basePackages = SpringIntegrationTest.MODULE_NAME)
-@TestPropertySource(properties = {
-  "spring.liquibase.change-log=" + SpringIntegrationTest.CHANGELOG_PATH,
-})
+@SpringJUnitConfig(CommonsDAOJPAImplTest.class)
 public class SpringIntegrationTest extends CommonsDAOJPAImplTest { // NOSONAR
 
   static final String         MODULE_NAME    = "io.meeds.spring.module";

--- a/component/common/src/test/java/io/meeds/spring/module/service/TestCacheService.java
+++ b/component/common/src/test/java/io/meeds/spring/module/service/TestCacheService.java
@@ -1,0 +1,46 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.spring.module.service;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TestCacheService {
+
+  public static final String CACHE_NAME = "cache-test";
+
+  @Cacheable(CACHE_NAME)
+  public int get(int i) {
+    return i;
+  }
+
+  @CacheEvict(CACHE_NAME)
+  public void remove(int i) {
+    // Nothing just cache clear
+  }
+
+  @CachePut(CACHE_NAME)
+  public int update(int i) {
+    return i * 2;
+  }
+
+}

--- a/component/common/src/test/java/org/exoplatform/jpa/CommonsDAOJPAImplTest.java
+++ b/component/common/src/test/java/org/exoplatform/jpa/CommonsDAOJPAImplTest.java
@@ -6,22 +6,50 @@ import org.exoplatform.component.test.ContainerScope;
 import org.exoplatform.settings.jpa.SettingContextDAO;
 import org.exoplatform.settings.jpa.SettingScopeDAO;
 import org.exoplatform.settings.jpa.SettingsDAO;
+
+import io.meeds.kernel.test.KernelExtension;
+import io.meeds.spring.AvailableIntegration;
+import io.meeds.spring.kernel.KernelCacheConfiguration;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@ExtendWith({ SpringExtension.class, KernelExtension.class })
+@SpringBootApplication(scanBasePackages = {
+  CommonsDAOJPAImplTest.MODULE_NAME,
+  AvailableIntegration.KERNEL_TEST_MODULE,
+  AvailableIntegration.JPA_MODULE,
+  AvailableIntegration.LIQUIBASE_MODULE,
+})
+@EnableJpaRepositories(basePackages = CommonsDAOJPAImplTest.MODULE_NAME)
+@ContextConfiguration(classes = { KernelCacheConfiguration.class })
+@TestPropertySource(properties = {
+  "spring.liquibase.change-log=" + CommonsDAOJPAImplTest.CHANGELOG_PATH,
+})
 @ConfiguredBy({
   @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
   @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.portal.component.settings-configuration-local.xml")
 })
-public class CommonsDAOJPAImplTest extends BaseTest {
+public class CommonsDAOJPAImplTest extends BaseTest { // NOSONAR
+
+  protected static final String MODULE_NAME    = "io.meeds.spring.module";
+
+  protected static final String CHANGELOG_PATH = "classpath:db/changelog/test-rdbms.db.changelog.xml";
+
   protected SettingContextDAO settingContextDAO;
 
   protected SettingScopeDAO   settingScopeDAO;
 
   protected SettingsDAO       settingsDAO;
 
-
+  @Override
   public void setUp() {
     super.setUp();
 
@@ -36,12 +64,7 @@ public class CommonsDAOJPAImplTest extends BaseTest {
     cleanDB();
   }
 
-  public void testInit() {
-    assertNotNull(settingContextDAO);
-    assertNotNull(settingScopeDAO);
-    assertNotNull(settingsDAO);
-  }
-
+  @Override
   public void tearDown() {
     // Clean Data
     cleanDB();
@@ -61,6 +84,12 @@ public class CommonsDAOJPAImplTest extends BaseTest {
   @Override
   protected void afterRunBare() {
     super.afterRunBare();
+  }
+
+  public void testInit() {
+    assertNotNull(settingContextDAO);
+    assertNotNull(settingScopeDAO);
+    assertNotNull(settingsDAO);
   }
 
   private void cleanDB() {


### PR DESCRIPTION
This change will allow to reuse the cnfiguration and base framework defined into CacheService defined in Kernel. This will allow to unify the definition of Base framework of caching with a centralized way to manage caches.