### PR TITLE
fix: Delete useless ResourceRequestFilter on portal context - MEED-7004 - Meeds-io/meeds#2109

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/web.xml
+++ b/web/portal/src/main/webapp/WEB-INF/web.xml
@@ -39,10 +39,6 @@
     <filter-name>GenericFilter</filter-name>
     <filter-class>org.exoplatform.web.filter.GenericFilter</filter-class>
   </filter>
-  <filter>
-    <filter-name>ResourceRequestFilter</filter-name>
-    <filter-class>org.exoplatform.portal.application.ResourceRequestFilter</filter-class>
-  </filter>
 
   <filter>
     <filter-name>SetCurrentIdentityFilter</filter-name>
@@ -128,26 +124,6 @@
   <filter-mapping>
     <filter-name>RememberMeFilter</filter-name>
     <url-pattern>/*</url-pattern>
-  </filter-mapping>
-
-  <filter-mapping>
-    <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>*.gif</url-pattern>
-  </filter-mapping>
-
-  <filter-mapping>
-    <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>*.png</url-pattern>
-  </filter-mapping>
-
-  <filter-mapping>
-    <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>*.jpg</url-pattern>
-  </filter-mapping>
-
-  <filter-mapping>
-    <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>/javascript/*</url-pattern>
   </filter-mapping>
 
   <filter-mapping>


### PR DESCRIPTION
Prior to this change, some requests caching Header are managed by a dummy Filter which should be applied on static resources only. Knowing that `portal` context doesn't server static resources, the usage of this filter isn't needed anymore.

(Resolves Meeds-io/meeds#2109)