### PR TITLE
feat: Adapt ListenerService Overrides to new implementation - MEED-7009 - Meeds-io/meeds#2116

### DIFF
--- a/component/common/src/main/java/org/exoplatform/commons/api/event/EventManager.java
+++ b/component/common/src/main/java/org/exoplatform/commons/api/event/EventManager.java
@@ -19,6 +19,7 @@ package org.exoplatform.commons.api.event;
 
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerBase;
 
 import java.util.List;
 
@@ -38,11 +39,11 @@ public interface EventManager<S, D> {
     
     /**
      * Registers a listener for a given event group in the event system.
-     * @param listener An instance of <code>Listener</code> object.
+     * @param listener An instance of <code>ListenerBase</code> object.
      * @param eventName Name of the event group.
      * @LevelAPI Experimental
      */
-    public void addEventListener(String eventName, Listener<S, D> listener);    
+    public void addEventListener(String eventName, ListenerBase<S, D> listener);    
 
     /**
      * Unregisters a listener out of the event system.  
@@ -53,11 +54,11 @@ public interface EventManager<S, D> {
     
     /**
      * Unregisters a listener out of a given event group in the event system.  
-     * @param listener An instance of <code>Listener</code> object.
+     * @param listener An instance of <code>ListenerBase</code> object.
      * @param eventName Name of the event group.
      * @LevelAPI Experimental
      */
-    public void removeEventListener(String eventName, Listener<S, D> listener);    
+    public void removeEventListener(String eventName, ListenerBase<S, D> listener);    
 
     /**
      * Broadcasts an event to a dedicated listener 
@@ -76,6 +77,6 @@ public interface EventManager<S, D> {
      * @return The list of listeners which are registered.
      * @LevelAPI Experimental
      */
-    public List<Listener<S, D>> getEventListeners(String type);
+    public List<ListenerBase<S, D>> getEventListeners(String type);
 
 }

--- a/component/common/src/main/java/org/exoplatform/commons/event/impl/EventManagerImpl.java
+++ b/component/common/src/main/java/org/exoplatform/commons/event/impl/EventManagerImpl.java
@@ -23,6 +23,7 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.listener.Asynchronous;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerBase;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -33,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
 /**
  * Created by The eXo Platform SARL
  * Author : Dang Van Minh
@@ -43,7 +43,7 @@ import java.util.Map;
  */
 public class EventManagerImpl<S, D> extends ListenerService implements EventManager<S, D> {
 
-    private Map<String, List<Listener<S, D>>> listenerMap = new HashMap<String, List<Listener<S, D>>>();
+    private Map<String, List<ListenerBase<S, D>>> listenerMap = new HashMap<>();
 
     private static final Log LOG = ExoLogger.getLogger(EventManagerImpl.class);
 
@@ -67,19 +67,19 @@ public class EventManagerImpl<S, D> extends ListenerService implements EventMana
      * {@inheritDoc}
      */
     @Override
-    public void addEventListener(String eventName, Listener<S, D> listener) {
+    public void addEventListener(String eventName, ListenerBase<S, D> listener) {
         // Check is Listener or its superclass asynchronous, if so - wrap it in AsynchronousListener.
         Class<?> listenerClass = listener.getClass();
         do {
             if (listenerClass.isAnnotationPresent(Asynchronous.class)) {
-                listener = new AsynchronousListener<S, D>(listener);
+                listener = new AsynchronousListener<>(listener);
                 break;
             }
             listenerClass = listenerClass.getSuperclass();
         } while (listenerClass != null);
-        List<Listener<S, D>> list = listenerMap.get(eventName);
+        List<ListenerBase<S, D>> list = listenerMap.get(eventName);
         if (list == null) {
-            list = new ArrayList<Listener<S, D>>();
+            list = new ArrayList<>();
         }
         list.add(listener);
         listenerMap.put(eventName, list);
@@ -97,8 +97,8 @@ public class EventManagerImpl<S, D> extends ListenerService implements EventMana
      * {@inheritDoc}
      */
     @Override
-    public void removeEventListener(String eventName, Listener<S, D> listener) {
-        List<Listener<S, D>> listeners = getEventListeners(eventName);
+    public void removeEventListener(String eventName, ListenerBase<S, D> listener) {
+        List<ListenerBase<S, D>> listeners = getEventListeners(eventName);
         listeners.remove(listener);
         if(listeners.size() == 0) listenerMap.remove(eventName);
         listenerMap.put(eventName, listeners);
@@ -109,9 +109,9 @@ public class EventManagerImpl<S, D> extends ListenerService implements EventMana
      */
     @Override
     public void broadcastEvent(Event<S, D> event) {
-        List<Listener<S, D>> listeners = getEventListeners(event.getEventName());
+        List<ListenerBase<S, D>> listeners = getEventListeners(event.getEventName());
         if (listeners.size() == 0) return;
-        for (Listener<S, D> listener : listeners) {
+        for (ListenerBase<S, D> listener : listeners) {
             try {
                 listener.onEvent(event);
             } catch (Exception e) {
@@ -124,9 +124,9 @@ public class EventManagerImpl<S, D> extends ListenerService implements EventMana
      * {@inheritDoc}
      */
     @Override
-    public List<Listener<S, D>> getEventListeners(String type) {
+    public List<ListenerBase<S, D>> getEventListeners(String type) {
     	if(!listenerMap.containsKey(type)) {
-    		return new ArrayList<Listener<S, D>>();
+    		return new ArrayList<>();
     	}
         return listenerMap.get(type);
     }

--- a/component/portal/src/test/java/org/exoplatform/mock/ListenerServiceMock.java
+++ b/component/portal/src/test/java/org/exoplatform/mock/ListenerServiceMock.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerBase;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -39,7 +40,7 @@ public class ListenerServiceMock extends ListenerService {
 
   private static final Log                  LOG       = ExoLogger.getLogger("exo.kernel.component.common.ListenerService");
 
-  private final Map<String, List<Listener>> listeners = new ConcurrentHashMap<>();
+  private final Map<String, List<ListenerBase>> listeners = new ConcurrentHashMap<>();
 
   public ListenerServiceMock(ExoContainerContext ctx) {
     super(ctx, null, null);
@@ -51,18 +52,18 @@ public class ListenerServiceMock extends ListenerService {
   }
 
   @Override
-  public synchronized void addListener(String eventName, Listener listener) {
-    listeners.computeIfAbsent(eventName, key -> new Vector<Listener>())
+  public synchronized void addListener(String eventName, ListenerBase listener) {
+    listeners.computeIfAbsent(eventName, key -> new Vector<ListenerBase>())
              .add(listener);
   }
 
   @Override
-  public <S, D> void broadcast(String name, S source, D data) throws Exception {
-    List<Listener> list = listeners.get(name);
+  public <S, D> void broadcast(String name, S source, D data) {
+    List<ListenerBase> list = listeners.get(name);
     if (list == null) {
       return;
     }
-    for (Listener<S, D> listener : list) {
+    for (ListenerBase<S, D> listener : list) {
       try {
         listener.onEvent(new Event<>(name, source, data));
       } catch (Exception e) {
@@ -72,12 +73,12 @@ public class ListenerServiceMock extends ListenerService {
   }
 
   @Override
-  public <T extends Event> void broadcast(T event) throws Exception {
-    List<Listener> list = listeners.get(event.getEventName());
+  public <T extends Event> void broadcast(T event) {
+    List<ListenerBase> list = listeners.get(event.getEventName());
     if (list == null) {
       return;
     }
-    for (Listener listener : list) {
+    for (ListenerBase listener : list) {
       try {
         listener.onEvent(event);
       } catch (Exception e) {


### PR DESCRIPTION
This change will make some adaptations to allow using a `@functionalInterface` interface to use Lambda expression while defining a new listener using java source code instead of injecting it using xml kernel configuration file.

(Resolves https://github.com/Meeds-io/meeds/issues/2116)