### PR TITLE
feat: Allow to store additional css properties on layout UI components - Meeds-io/MIPs#143

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/config/model/Application.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/Application.java
@@ -25,9 +25,6 @@ import org.exoplatform.portal.pom.config.Utils;
 import org.exoplatform.portal.pom.data.ApplicationData;
 import org.exoplatform.portal.pom.spi.portlet.Portlet;
 
-import lombok.Getter;
-import lombok.Setter;
-
 /**
  * May 13, 2004
  *
@@ -64,10 +61,6 @@ public class Application<S> extends ModelObject implements Cloneable {
     /** We cannot allow the type to change once the object is created. */
     private final ApplicationType<S> type;
 
-    @Getter
-    @Setter
-    private ModelStyle             cssStyle;
-
     public Application(ApplicationData<S> data) {
         super(data.getStorageId());
 
@@ -88,7 +81,7 @@ public class Application<S> extends ModelObject implements Cloneable {
         this.width = data.getWidth();
         this.height = data.getHeight();
         this.cssClass = data.getCssClass();
-        this.borderColor = data.getBorderColor();
+        this.cssStyle = data.getCssStyle();
         this.properties = new Properties(data.getProperties());
         this.accessPermissions = data.getAccessPermissions().toArray(new String[data.getAccessPermissions().size()]);
         this.type = data.getType();
@@ -244,15 +237,6 @@ public class Application<S> extends ModelObject implements Cloneable {
     }
 
     @Override
-    public String getBorderColor() {
-      if (cssStyle != null && cssStyle.getBorderColor() != null) {
-        return cssStyle.getBorderColor();
-      } else {
-        return super.getBorderColor();
-      }
-    }
-
-    @Override
     public ApplicationData build() {
       return new ApplicationData<S>(getStorageId(),
                                     getStorageName(),
@@ -269,7 +253,7 @@ public class Application<S> extends ModelObject implements Cloneable {
                                     getWidth(),
                                     getHeight(),
                                     getCssClass(),
-                                    getBorderColor(),
+                                    getCssStyle(),
                                     Utils.safeImmutableMap(properties),
                                     Utils.safeImmutableList(accessPermissions));
     }

--- a/component/api/src/main/java/org/exoplatform/portal/config/model/Container.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/Container.java
@@ -91,7 +91,7 @@ public class Container extends ModelObject implements Cloneable {
     this.width = data.getWidth();
     this.height = data.getHeight();
     this.cssClass = data.getCssClass();
-    this.borderColor = data.getBorderColor();
+    this.cssStyle = data.getCssStyle();
     this.profiles = data.getProfiles();
     this.accessPermissions = data.getAccessPermissions().toArray(new String[data.getAccessPermissions().size()]);
     List<String> permisssions = data.getMoveAppsPermissions();
@@ -223,8 +223,8 @@ public class Container extends ModelObject implements Cloneable {
                              getWidth(),
                              getHeight(),
                              getCssClass(),
-                             getBorderColor(),
                              getProfiles(),
+                             getCssStyle(),
                              Utils.safeImmutableList(accessPermissions),
                              Utils.safeImmutableList(moveAppsPermissions),
                              Utils.safeImmutableList(moveContainersPermissions),

--- a/component/api/src/main/java/org/exoplatform/portal/config/model/ModelObject.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/ModelObject.java
@@ -55,7 +55,7 @@ public abstract class ModelObject {
 
     @Getter
     @Setter
-    protected String borderColor;
+    protected ModelStyle cssStyle;
 
     /**
      * Create a new object.

--- a/component/api/src/main/java/org/exoplatform/portal/config/model/ModelStyle.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/ModelStyle.java
@@ -18,32 +18,52 @@
  */
 package org.exoplatform.portal.config.model;
 
+import java.io.Serializable;
+
 import lombok.Getter;
 import lombok.Setter;
 
 @Setter
 @Getter
-public class ModelStyle {
+public class ModelStyle implements Serializable {
 
-  private Integer marginTop;
+  private static final long serialVersionUID = 3688402796115766370L;
 
-  private Integer marginBottom;
+  private Integer           marginTop;
 
-  private Integer marginRight;
+  private Integer           marginBottom;
 
-  private Integer marginLeft;
+  private Integer           marginRight;
 
-  private Integer radiusTopRight;
+  private Integer           marginLeft;
 
-  private Integer radiusTopLeft;
+  private Integer           radiusTopRight;
 
-  private Integer radiusBottomRight;
+  private Integer           radiusTopLeft;
 
-  private Integer radiusBottomLeft;
+  private Integer           radiusBottomRight;
 
-  private Boolean mobileHidden;
+  private Integer           radiusBottomLeft;
 
-  private String  borderColor;
+  private Boolean           mobileHidden;
+
+  private String            borderColor;
+
+  private String            borderSize;
+
+  private String            boxShadow;
+
+  private String            backgroundColor;
+
+  private String            backgroundImage;
+
+  private String            backgroundEffect;
+
+  private String            backgroundPosition;
+
+  private String            backgroundSize;
+
+  private String            backgroundRepeat;
 
   public String getCssClass() { // NOSONAR
     StringBuilder cssClass = new StringBuilder();

--- a/component/api/src/main/java/org/exoplatform/portal/config/model/Page.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/Page.java
@@ -174,7 +174,7 @@ public class Page extends Container {
         List<ComponentData> children = buildChildren();
         return new PageData(storageId, id, name, icon, template, factoryId, title, description, width, height, cssClass, profiles,
                 Utils.safeImmutableList(accessPermissions), children, ownerType, ownerId, editPermission, showMaxWindow, hideSharedLayout,
-                Utils.safeImmutableList(moveAppsPermissions), Utils.safeImmutableList(moveContainersPermissions), type, link);
+                cssStyle, Utils.safeImmutableList(moveAppsPermissions), Utils.safeImmutableList(moveContainersPermissions), type, link);
     }
 
     public static class PageSet {

--- a/component/api/src/main/java/org/exoplatform/portal/config/model/PageBody.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/PageBody.java
@@ -37,6 +37,6 @@ public class PageBody extends ModelObject {
 
     @Override
     public ModelData build() {
-        return new BodyData(storageId, BodyType.PAGE);
+        return new BodyData(storageId, BodyType.PAGE, cssStyle);
     }
 }

--- a/component/api/src/main/java/org/exoplatform/portal/config/model/SiteBody.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/SiteBody.java
@@ -34,6 +34,6 @@ public class SiteBody extends ModelObject {
 
     @Override
     public ModelData build() {
-        return new BodyData(storageId, BodyType.SITE);
+        return new BodyData(storageId, BodyType.SITE, null);
     }
 }

--- a/component/api/src/main/java/org/exoplatform/portal/config/serialize/model/Cell.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/serialize/model/Cell.java
@@ -19,7 +19,6 @@
 package org.exoplatform.portal.config.serialize.model;
 
 import org.exoplatform.portal.config.model.Container;
-import org.exoplatform.portal.config.model.ModelStyle;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -34,8 +33,6 @@ public class Cell extends Container {
   private int        colSpan = 1;
 
   private int        rowSpan = 1;
-
-  private ModelStyle cssStyle;
 
   @Override
   public String getCssClass() {
@@ -55,15 +52,6 @@ public class Cell extends Container {
       cssClasses.append(cssStyle.getCssClass());
     }
     return cssClasses.toString();
-  }
-
-  @Override
-  public String getBorderColor() {
-    if (cssStyle != null && cssStyle.getBorderColor() != null) {
-      return cssStyle.getBorderColor();
-    } else {
-      return super.getBorderColor();
-    }
   }
 
   @Override

--- a/component/api/src/main/java/org/exoplatform/portal/mop/Utils.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/Utils.java
@@ -71,7 +71,7 @@ public class Utils {
     }
 
     public static PageState toPageState(Page page) {
-      return new PageState(page.getTitle(),
+      PageState pageState = new PageState(page.getTitle(),
                            page.getDescription(),
                            page.isShowMaxWindow(),
                            page.isHideSharedLayout(),
@@ -83,10 +83,12 @@ public class Utils {
                            page.getMoveContainersPermissions() != null ? Arrays.asList(page.getMoveContainersPermissions())                                                                       : null,
                            page.getType(),
                            page.getLink());
+      pageState.setStorageId(page.getStorageId());
+      return pageState;
     }
 
     public static PageState toPageState(PageData page) {
-      return new PageState(page.getTitle(),
+      PageState pageState = new PageState(page.getTitle(),
                            page.getDescription(),
                            page.isShowMaxWindow(),
                            page.isHideSharedLayout(),
@@ -98,6 +100,8 @@ public class Utils {
                            page.getMoveContainersPermissions(),
                            page.getType(),
                            page.getLink());
+      pageState.setStorageId(page.getStorageId());
+      return pageState;
     }
 
     private static class ComparableComparator<T extends Comparable<T>> implements Comparator<T> {

--- a/component/api/src/main/java/org/exoplatform/portal/mop/page/PageState.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/page/PageState.java
@@ -6,6 +6,8 @@ import java.util.*;
 import org.exoplatform.commons.utils.Safe;
 
 import lombok.Getter;
+import lombok.Setter;
+
 import org.exoplatform.portal.mop.PageType;
 
 /**
@@ -17,6 +19,11 @@ import org.exoplatform.portal.mop.PageType;
 public class PageState implements Serializable {
 
   private static final long serialVersionUID = 7874166775312871923L;
+
+  /** . */
+  @Getter
+  @Setter
+  private String            storageId;
 
   /** . */
   final String              editPermission;

--- a/component/api/src/main/java/org/exoplatform/portal/mop/service/LayoutService.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/service/LayoutService.java
@@ -134,6 +134,15 @@ public interface LayoutService extends DataStorage {
   Page getPage(String pageId);
 
   /**
+   * This method should load the Page object from the database according to the
+   * technical identifier of the page
+   *
+   * @param id - UUID of page
+   * @return {@link Page}
+   */
+  Page getPage(long id);
+
+  /**
    * Retrieves Page designated by its key
    * 
    * @param  pageKey {@link PageKey}

--- a/component/api/src/main/java/org/exoplatform/portal/mop/storage/PageStorage.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/storage/PageStorage.java
@@ -118,4 +118,6 @@ public interface PageStorage extends PageService {
 
   Page getPage(PageKey pageKey);
 
+  Page getPage(long id);
+
 }

--- a/component/api/src/main/java/org/exoplatform/portal/pom/data/ApplicationData.java
+++ b/component/api/src/main/java/org/exoplatform/portal/pom/data/ApplicationData.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.exoplatform.portal.config.model.ApplicationState;
 import org.exoplatform.portal.config.model.ApplicationType;
+import org.exoplatform.portal.config.model.ModelStyle;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -30,98 +31,95 @@ import lombok.EqualsAndHashCode;
 /**
  * @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
  * @version $Revision$
- * @param <S> can be of type org.exoplatform.portal.pom.spi.portlet.Portlet only, see {@link ApplicationType}
+ * @param <S> can be of type org.exoplatform.portal.pom.spi.portlet.Portlet
+ *          only, see {@link ApplicationType}
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class ApplicationData<S> extends ComponentData {
 
-    private static final long serialVersionUID = -9136595444062927185L;
+  private static final long         serialVersionUID = -9136595444062927185L;
 
-    /** . */
-    private final ApplicationType<S> type;
+  /** . */
+  private final ApplicationType<S>  type;
 
-    /** . */
-    private final ApplicationState<S> state;
+  /** . */
+  private final ApplicationState<S> state;
 
-    /** . */
-    private final String id;
+  /** . */
+  private final String              id;
 
-    /** . */
-    private final String title;
+  /** . */
+  private final String              title;
 
-    /** . */
-    private final String icon;
+  /** . */
+  private final String              icon;
 
-    /** . */
-    private final String description;
+  /** . */
+  private final String              description;
 
-    /** . */
-    private final boolean showInfoBar;
+  /** . */
+  private final boolean             showInfoBar;
 
-    /** . */
-    private final boolean showApplicationState;
+  /** . */
+  private final boolean             showApplicationState;
 
-    /** . */
-    private final boolean showApplicationMode;
+  /** . */
+  private final boolean             showApplicationMode;
 
-    /** . */
-    private final String theme;
+  /** . */
+  private final String              theme;
 
-    /** . */
-    private final String width;
+  /** . */
+  private final String              width;
 
-    /** . */
-    private final String height;
+  /** . */
+  private final String              height;
 
-    /** . */
-    private final String cssClass;
+  /** . */
+  private final String              cssClass;
 
-    /** . */
-    private final String borderColor;
+  /** . */
+  private final Map<String, String> properties;
 
-    /** . */
-    private final Map<String, String> properties;
+  /** . */
+  private final List<String>        accessPermissions;
 
-    /** . */
-    private final List<String> accessPermissions;
+  public ApplicationData(String storageId,
+                         String storageName,
+                         ApplicationType<S> type,
+                         ApplicationState<S> state,
+                         String id,
+                         String title,
+                         String icon,
+                         String description,
+                         boolean showInfoBar,
+                         boolean showApplicationState,
+                         boolean showApplicationMode,
+                         String theme,
+                         String width,
+                         String height,
+                         String cssClass,
+                         ModelStyle cssStyle,
+                         Map<String, String> properties,
+                         List<String> accessPermissions) {
+    super(storageId, storageName, cssStyle);
 
-    public ApplicationData(String storageId,
-                           String storageName,
-                           ApplicationType<S> type,
-                           ApplicationState<S> state,
-                           String id,
-                           String title,
-                           String icon,
-                           String description,
-                           boolean showInfoBar,
-                           boolean showApplicationState,
-                           boolean showApplicationMode,
-                           String theme,
-                           String width,
-                           String height,
-                           String cssClass,
-                           String borderColor,
-                           Map<String, String> properties,
-                           List<String> accessPermissions) {
-        super(storageId, storageName);
-
-        //
-        this.type = type;
-        this.state = state;
-        this.id = id;
-        this.title = title;
-        this.icon = icon;
-        this.description = description;
-        this.showInfoBar = showInfoBar;
-        this.showApplicationState = showApplicationState;
-        this.showApplicationMode = showApplicationMode;
-        this.theme = theme;
-        this.width = width;
-        this.height = height;
-        this.cssClass = cssClass;
-        this.borderColor = borderColor;
-        this.properties = properties;
-        this.accessPermissions = accessPermissions;
-    }
+    //
+    this.type = type;
+    this.state = state;
+    this.id = id;
+    this.title = title;
+    this.icon = icon;
+    this.description = description;
+    this.showInfoBar = showInfoBar;
+    this.showApplicationState = showApplicationState;
+    this.showApplicationMode = showApplicationMode;
+    this.theme = theme;
+    this.width = width;
+    this.height = height;
+    this.cssClass = cssClass;
+    this.properties = properties;
+    this.accessPermissions = accessPermissions;
+  }
 }

--- a/component/api/src/main/java/org/exoplatform/portal/pom/data/BodyData.java
+++ b/component/api/src/main/java/org/exoplatform/portal/pom/data/BodyData.java
@@ -18,6 +18,8 @@
  */
 package org.exoplatform.portal.pom.data;
 
+import org.exoplatform.portal.config.model.ModelStyle;
+
 /**
  * @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
  * @version $Revision$
@@ -27,8 +29,8 @@ public class BodyData extends ComponentData {
     /** . */
     private final BodyType type;
 
-    public BodyData(String storageId, BodyType type) {
-        super(storageId, null);
+    public BodyData(String storageId, BodyType type, ModelStyle cssStyle) {
+        super(storageId, null, cssStyle);
 
         //
         this.type = type;

--- a/component/api/src/main/java/org/exoplatform/portal/pom/data/ComponentData.java
+++ b/component/api/src/main/java/org/exoplatform/portal/pom/data/ComponentData.java
@@ -18,6 +18,8 @@
  */
 package org.exoplatform.portal.pom.data;
 
+import org.exoplatform.portal.config.model.ModelStyle;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -31,9 +33,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public abstract class ComponentData extends ModelData {
 
-    private static final long serialVersionUID = 7604813006448463333L;
+  private static final long serialVersionUID = 7604813006448463333L;
 
-    ComponentData(String storageId, String storageName) {
-        super(storageId, storageName);
-    }
+  private ModelStyle        cssStyle;
+
+  ComponentData(String storageId, String storageName, ModelStyle cssStyle) {
+    super(storageId, storageName);
+    this.cssStyle = cssStyle;
+  }
 }

--- a/component/api/src/main/java/org/exoplatform/portal/pom/data/ContainerData.java
+++ b/component/api/src/main/java/org/exoplatform/portal/pom/data/ContainerData.java
@@ -20,6 +20,8 @@ package org.exoplatform.portal.pom.data;
 
 import java.util.List;
 
+import org.exoplatform.portal.config.model.ModelStyle;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -67,9 +69,6 @@ public class ContainerData extends ComponentData {
     private final String cssClass;
 
     /** . */
-    private final String borderColor;
-
-    /** . */
     private final String profiles;
 
     /** . */
@@ -93,13 +92,13 @@ public class ContainerData extends ComponentData {
                          String width,
                          String height,
                          String cssClass,
-                         String borderColor,
                          String profiles,
+                         ModelStyle cssStyle,
                          List<String> accessPermissions,
                          List<String> moveAppsPermissions,
                          List<String> moveContainersPermissions,
                          List<ComponentData> children) {
-        super(storageId, null);
+        super(storageId, null, cssStyle);
 
         //
         this.id = id;
@@ -112,7 +111,6 @@ public class ContainerData extends ComponentData {
         this.width = width;
         this.height = height;
         this.cssClass = cssClass;
-        this.borderColor = borderColor;
         this.profiles = profiles;
         this.accessPermissions = accessPermissions;
         this.moveAppsPermissions = moveAppsPermissions;

--- a/component/api/src/main/java/org/exoplatform/portal/pom/data/MappedAttributes.java
+++ b/component/api/src/main/java/org/exoplatform/portal/pom/data/MappedAttributes.java
@@ -35,63 +35,79 @@ public class MappedAttributes {
   }
 
   /** . */
-  public static final Key<String>  ID                 = Key.create("id", ValueType.STRING);
+  public static final Key<String>  ID                  = Key.create("id", ValueType.STRING);
 
   /** . */
-  public static final Key<String>  NAME               = Key.create("name", ValueType.STRING);
+  public static final Key<String>  NAME                = Key.create("name", ValueType.STRING);
 
   /** . */
-  public static final Key<Boolean> SHOW_MAX_WINDOW    = Key.create("show-max-window", ValueType.BOOLEAN);
+  public static final Key<Boolean> SHOW_MAX_WINDOW     = Key.create("show-max-window", ValueType.BOOLEAN);
 
-  public static final Key<Boolean> HIDE_SHARED_LAYOUT = Key.create("hide-shared-layout", ValueType.BOOLEAN);
-
-  /** . */
-  public static final Key<String>  FACTORY_ID         = Key.create("factory-id", ValueType.STRING);
+  public static final Key<Boolean> HIDE_SHARED_LAYOUT  = Key.create("hide-shared-layout", ValueType.BOOLEAN);
 
   /** . */
-  public static final Key<String>  CSS_CLASS          = Key.create("css-class", ValueType.STRING);
-
-  public static final Key<String>  BORDER_COLOR       = Key.create("border-color", ValueType.STRING);
+  public static final Key<String>  FACTORY_ID          = Key.create("factory-id", ValueType.STRING);
 
   /** . */
-  public static final Key<String>  PROFILES           = Key.create("profiles", ValueType.STRING);
+  public static final Key<String>  CSS_CLASS           = Key.create("css-class", ValueType.STRING);
+
+  public static final Key<String>  BORDER_COLOR        = Key.create("border-color", ValueType.STRING);
+
+  public static final Key<String>  BACKGROUND_COLOR    = Key.create("background-color", ValueType.STRING);
+
+  public static final Key<String>  BACKGROUND_IMAGE    = Key.create("background-image", ValueType.STRING);
+
+  public static final Key<String>  BACKGROUND_EFFECT   = Key.create("background-effect", ValueType.STRING);
+
+  public static final Key<String>  BACKGROUND_POSITION = Key.create("background-position", ValueType.STRING);
+
+  public static final Key<String>  BACKGROUND_REPEAT   = Key.create("background-repeat", ValueType.STRING);
+
+  public static final Key<String>  BACKGROUND_SIZE     = Key.create("background-size", ValueType.STRING);
+
+  public static final Key<String>  BORDER_SIZE         = Key.create("border-size", ValueType.STRING);
+
+  public static final Key<String>  BOX_SHADOW          = Key.create("box-shadow", ValueType.STRING);
 
   /** . */
-  public static final Key<Integer> PRIORITY           = Key.create("priority", ValueType.INTEGER);
+  public static final Key<String>  PROFILES            = Key.create("profiles", ValueType.STRING);
 
   /** . */
-  public static final Key<String>  ICON               = Key.create("icon", ValueType.STRING);
+  public static final Key<Integer> PRIORITY            = Key.create("priority", ValueType.INTEGER);
 
   /** . */
-  public static final Key<String>  URI                = Key.create("uri", ValueType.STRING);
+  public static final Key<String>  ICON                = Key.create("icon", ValueType.STRING);
 
   /** . */
-  public static final Key<String>  TEMPLATE           = Key.create("template", ValueType.STRING);
+  public static final Key<String>  URI                 = Key.create("uri", ValueType.STRING);
 
   /** . */
-  public static final Key<String>  LOCALE             = Key.create("locale", ValueType.STRING);
+  public static final Key<String>  TEMPLATE            = Key.create("template", ValueType.STRING);
 
   /** . */
-  public static final Key<String>  SKIN               = Key.create("skin", ValueType.STRING);
+  public static final Key<String>  LOCALE              = Key.create("locale", ValueType.STRING);
 
   /** . */
-  public static final Key<String>  WIDTH              = Key.create("width", ValueType.STRING);
+  public static final Key<String>  SKIN                = Key.create("skin", ValueType.STRING);
 
   /** . */
-  public static final Key<String>  HEIGHT             = Key.create("height", ValueType.STRING);
+  public static final Key<String>  WIDTH               = Key.create("width", ValueType.STRING);
 
   /** . */
-  public static final Key<String>  TYPE               = Key.create("type", ValueType.STRING);
+  public static final Key<String>  HEIGHT              = Key.create("height", ValueType.STRING);
 
   /** . */
-  public static final Key<Boolean> SHOW_INFO_BAR      = Key.create("showinfobar", ValueType.BOOLEAN);
+  public static final Key<String>  TYPE                = Key.create("type", ValueType.STRING);
 
   /** . */
-  public static final Key<Boolean> SHOW_MODE          = Key.create("showmode", ValueType.BOOLEAN);
+  public static final Key<Boolean> SHOW_INFO_BAR       = Key.create("showinfobar", ValueType.BOOLEAN);
 
   /** . */
-  public static final Key<Boolean> SHOW_WINDOW_STATE  = Key.create("showwindowstate", ValueType.BOOLEAN);
+  public static final Key<Boolean> SHOW_MODE           = Key.create("showmode", ValueType.BOOLEAN);
 
   /** . */
-  public static final Key<String>  THEME              = Key.create("theme", ValueType.STRING);
+  public static final Key<Boolean> SHOW_WINDOW_STATE   = Key.create("showwindowstate", ValueType.BOOLEAN);
+
+  /** . */
+  public static final Key<String>  THEME               = Key.create("theme", ValueType.STRING);
 }

--- a/component/api/src/main/java/org/exoplatform/portal/pom/data/PageData.java
+++ b/component/api/src/main/java/org/exoplatform/portal/pom/data/PageData.java
@@ -20,6 +20,8 @@ package org.exoplatform.portal.pom.data;
 
 import java.util.List;
 
+import org.exoplatform.portal.config.model.ModelStyle;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -75,6 +77,7 @@ public class PageData extends ContainerData {
                     String editPermission,
                     boolean showMaxWindow,
                     boolean hideSharedLayout,
+                    ModelStyle cssStyle,
                     List<String> moveAppsPermissions,
                     List<String> moveContainersPermissions,
                     String type,
@@ -90,8 +93,8 @@ public class PageData extends ContainerData {
             width,
             height,
             cssClass,
-            null,
             profiles,
+            cssStyle,
             accessPermissions,
             moveAppsPermissions,
             moveContainersPermissions,

--- a/component/api/src/test/java/io/meeds/portal/mop/PageParsingTest.java
+++ b/component/api/src/test/java/io/meeds/portal/mop/PageParsingTest.java
@@ -61,7 +61,6 @@ public class PageParsingTest extends TestCase {
       Container column = (Container) columnsSection.getChildren().get(0);
       assertEquals(2, column.getChildren().size());
       assertEquals("CellContainer", column.getTemplate());
-      assertNull(column.getBorderColor());
       assertNotNull(column.getCssClass());
       assertTrue("'flex-cell' not found", column.getCssClass().contains("flex-cell"));
       assertTrue("'grid-cell-colspan-md-9' not found", column.getCssClass().contains("grid-cell-colspan-md-9"));
@@ -73,7 +72,6 @@ public class PageParsingTest extends TestCase {
       assertTrue("'TEST-column-class' custom class not found", column.getCssClass().contains("TEST-column-class"));
 
       Application<Portlet> columnApplication = (Application<Portlet>) column.getChildren().get(0);
-      assertEquals("#CCAABB", columnApplication.getBorderColor());
       assertNotNull(columnApplication.getCssClass());
       assertTrue("'mt-n1' not found in: " + columnApplication.getCssClass(), columnApplication.getCssClass().contains("mt-n1"));
       assertTrue("'mb-n3' not found in: " + columnApplication.getCssClass(), columnApplication.getCssClass().contains("mb-n3"));
@@ -102,7 +100,6 @@ public class PageParsingTest extends TestCase {
       Container cell = (Container) gridSection.getChildren().get(0);
       assertEquals(1, cell.getChildren().size());
       assertEquals("CellContainer", cell.getTemplate());
-      assertEquals("#EE3355", cell.getBorderColor());
       assertNotNull(cell.getCssClass());
       assertTrue("'grid-cell' not found", cell.getCssClass().contains("grid-cell"));
       assertTrue("'grid-cell-colspan-md-2' not found", cell.getCssClass().contains("grid-cell-colspan-md-2"));

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/service/LayoutServiceImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/service/LayoutServiceImpl.java
@@ -71,8 +71,8 @@ import org.exoplatform.services.log.Log;
 
 public class LayoutServiceImpl implements LayoutService {
 
-  private static final Log       LOG           = ExoLogger.getLogger(LayoutServiceImpl.class);
-  
+  private static final Log       LOG                     = ExoLogger.getLogger(LayoutServiceImpl.class);
+
   private static final String    SITE_DEAULT_BANNER_PATH = "site.default.banner.path";
 
   private ListenerService        listenerService;
@@ -83,14 +83,14 @@ public class LayoutServiceImpl implements LayoutService {
 
   private LayoutStorage          layoutStorage;
 
-  private Map<String, Container> sharedLayouts = new HashMap<>();
+  private Map<String, Container> sharedLayouts           = new HashMap<>();
 
-  private FileService fileService;
-  
+  private FileService            fileService;
+
   private PortalContainer        portalContainer;
 
   private InitParams             initParams;
-  
+
   public LayoutServiceImpl(ListenerService listenerService,
                            SiteStorage siteStorage,
                            PageStorage pageStorage,
@@ -202,6 +202,11 @@ public class LayoutServiceImpl implements LayoutService {
   }
 
   @Override
+  public Page getPage(long id) {
+    return pageStorage.getPage(id);
+  }
+
+  @Override
   public Page getPage(PageKey pageKey) {
     return pageStorage.getPage(pageKey);
   }
@@ -309,7 +314,7 @@ public class LayoutServiceImpl implements LayoutService {
   }
 
   @SuppressWarnings({
-      "unchecked", "rawtypes"
+                      "unchecked", "rawtypes"
   })
   public <T> LazyPageList<T> findLazyPageList(Query<T> q) { // NOSONAR
     Class<T> type = q.getClassType();
@@ -340,7 +345,8 @@ public class LayoutServiceImpl implements LayoutService {
         public PortalData[] load(int offset, int limit) throws Exception {
           SiteType siteType = ownerType == null ? SiteType.PORTAL : SiteType.valueOf(ownerType.toUpperCase());
           return getSiteNames(offset, limit).stream()
-                                            .map(siteName -> siteStorage.getPortalConfig(new SiteKey(siteType.getName(), siteName)))
+                                            .map(siteName -> siteStorage.getPortalConfig(new SiteKey(siteType.getName(),
+                                                                                                     siteName)))
                                             .toList()
                                             .toArray(new PortalData[siteNames.size()]);
         }
@@ -396,8 +402,10 @@ public class LayoutServiceImpl implements LayoutService {
   @Override
   public List<PortalConfig> getSites(SiteFilter filter) {
     List<SiteKey> portalKeysList = siteStorage.getSitesKeys(filter);
-    return portalKeysList.isEmpty() ? Collections.emptyList()
-                                                            : portalKeysList.stream().map(siteKey -> new PortalConfig(siteStorage.getPortalConfig(siteKey))).toList();
+    return portalKeysList.isEmpty() ? Collections.emptyList() :
+                                    portalKeysList.stream()
+                                                  .map(siteKey -> new PortalConfig(siteStorage.getPortalConfig(siteKey)))
+                                                  .toList();
   }
 
   @Override
@@ -413,15 +421,17 @@ public class LayoutServiceImpl implements LayoutService {
       FileItem fileItem = fileService.getFile(portalConfig.getBannerFileId());
       return fileItem == null || fileItem.getFileInfo() == null ? null : fileItem.getAsStream();
     } catch (FileStorageException | IOException e) {
-      return null ;
+      return null;
     }
   }
-  
+
   @Override
   public InputStream getDefaultSiteBannerStream(String siteName) {
     InputStream defaultSiteBanner = portalContainer.getPortalContext()
-                                    .getResourceAsStream(System.getProperty("sites." + siteName
-                                        + ".defaultBannerPath", "/images/sites/banner/" + siteName.toLowerCase() + ".png"));
+                                                   .getResourceAsStream(System.getProperty("sites." + siteName +
+                                                       ".defaultBannerPath",
+                                                                                           "/images/sites/banner/" +
+                                                                                               siteName.toLowerCase() + ".png"));
     if (defaultSiteBanner == null && initParams != null) {
       ValueParam siteDefaultBannerPath = initParams.getValueParam(SITE_DEAULT_BANNER_PATH);
       if (siteDefaultBannerPath != null && siteDefaultBannerPath.getValue() != null) {

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/storage/AbstractPageStorage.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/storage/AbstractPageStorage.java
@@ -128,6 +128,7 @@ public abstract class AbstractPageStorage implements PageStorage {
                         editPermission, // editPermission
                         entity.isShowMaxWindow(), // showMaxWindow
                         entity.isHideSharedLayout(),
+                        null, // cssStyle
                         moveAppsPermissions,
                         moveContainersPermissions,
                         entity.getPageType() != null ? entity.getPageType().name() : null,

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/storage/LayoutStorage.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/storage/LayoutStorage.java
@@ -45,6 +45,7 @@ import org.exoplatform.portal.config.model.Application;
 import org.exoplatform.portal.config.model.ApplicationState;
 import org.exoplatform.portal.config.model.ApplicationType;
 import org.exoplatform.portal.config.model.CloneApplicationState;
+import org.exoplatform.portal.config.model.ModelStyle;
 import org.exoplatform.portal.config.model.PersistentApplicationState;
 import org.exoplatform.portal.config.model.TransientApplicationState;
 import org.exoplatform.portal.jdbc.entity.ComponentEntity;
@@ -408,23 +409,44 @@ public class LayoutStorage {
     dst.setTitle(src.getTitle());
     dst.setWidth(src.getWidth());
 
-    boolean hasProfiles = StringUtils.isNotBlank(src.getProfiles());
-    boolean hasCssClass = StringUtils.isNotBlank(src.getCssClass());
-    boolean hasBorderColor = StringUtils.isNotBlank(src.getBorderColor());
-    if (hasProfiles || hasCssClass || hasBorderColor) {
-      JSONObject properties = new JSONObject();
-      if (hasProfiles) {
-        properties.put(MappedAttributes.PROFILES.getName(), src.getProfiles());
-      }
-      if (hasCssClass) {
-        properties.put(MappedAttributes.CSS_CLASS.getName(), src.getCssClass());
-      }
-      if (hasBorderColor) {
-        properties.put(MappedAttributes.BORDER_COLOR.getName(), src.getBorderColor());
-      }
-      dst.setProperties(properties.toJSONString());
+    JSONObject properties = new JSONObject();
+    if (StringUtils.isNotBlank(src.getProfiles())) {
+      properties.put(MappedAttributes.PROFILES.getName(), src.getProfiles());
     }
-
+    if (StringUtils.isNotBlank(src.getCssClass())) {
+      properties.put(MappedAttributes.CSS_CLASS.getName(), src.getCssClass());
+    }
+    ModelStyle cssStyle = src.getCssStyle();
+    if (cssStyle != null) {
+      if (StringUtils.isNotBlank(cssStyle.getBorderColor())) {
+        properties.put(MappedAttributes.BORDER_COLOR.getName(), cssStyle.getBorderColor());
+      }
+      if (StringUtils.isNotBlank(cssStyle.getBackgroundColor())) {
+        properties.put(MappedAttributes.BACKGROUND_COLOR.getName(), cssStyle.getBackgroundColor());
+      }
+      if (StringUtils.isNotBlank(cssStyle.getBackgroundImage())) {
+        properties.put(MappedAttributes.BACKGROUND_IMAGE.getName(), cssStyle.getBackgroundImage());
+      }
+      if (StringUtils.isNotBlank(cssStyle.getBackgroundEffect())) {
+        properties.put(MappedAttributes.BACKGROUND_EFFECT.getName(), cssStyle.getBackgroundEffect());
+      }
+      if (StringUtils.isNotBlank(cssStyle.getBackgroundPosition())) {
+        properties.put(MappedAttributes.BACKGROUND_POSITION.getName(), cssStyle.getBackgroundPosition());
+      }
+      if (StringUtils.isNotBlank(cssStyle.getBackgroundSize())) {
+        properties.put(MappedAttributes.BACKGROUND_SIZE.getName(), cssStyle.getBackgroundSize());
+      }
+      if (StringUtils.isNotBlank(cssStyle.getBackgroundRepeat())) {
+        properties.put(MappedAttributes.BACKGROUND_REPEAT.getName(), cssStyle.getBackgroundRepeat());
+      }
+      if (StringUtils.isNotBlank(cssStyle.getBorderSize())) {
+        properties.put(MappedAttributes.BORDER_SIZE.getName(), cssStyle.getBorderSize());
+      }
+      if (StringUtils.isNotBlank(cssStyle.getBoxShadow())) {
+        properties.put(MappedAttributes.BOX_SHADOW.getName(), cssStyle.getBoxShadow());
+      }
+    }
+    dst.setProperties(properties.toJSONString());
     return dst;
   }
 
@@ -463,14 +485,40 @@ public class LayoutStorage {
     dst.setWidth(srcChild.getWidth());
 
     boolean hasCssClass = StringUtils.isNotBlank(srcChild.getCssClass());
-    boolean hasBorderColor = StringUtils.isNotBlank(srcChild.getBorderColor());
-    if (hasCssClass || hasBorderColor) {
+    if (hasCssClass || srcChild.getCssStyle() != null) {
       JSONObject properties = srcChild.getProperties() == null ? new JSONObject() : new JSONObject(srcChild.getProperties());
       if (hasCssClass) {
         properties.put(MappedAttributes.CSS_CLASS.getName(), srcChild.getCssClass());
       }
-      if (hasBorderColor) {
-        properties.put(MappedAttributes.BORDER_COLOR.getName(), srcChild.getBorderColor());
+      ModelStyle cssStyle = srcChild.getCssStyle();
+      if (cssStyle != null) {
+        if (StringUtils.isNotBlank(cssStyle.getBorderColor())) {
+          properties.put(MappedAttributes.BORDER_COLOR.getName(), cssStyle.getBorderColor());
+        }
+        if (StringUtils.isNotBlank(cssStyle.getBackgroundColor())) {
+          properties.put(MappedAttributes.BACKGROUND_COLOR.getName(), cssStyle.getBackgroundColor());
+        }
+        if (StringUtils.isNotBlank(cssStyle.getBackgroundImage())) {
+          properties.put(MappedAttributes.BACKGROUND_IMAGE.getName(), cssStyle.getBackgroundImage());
+        }
+        if (StringUtils.isNotBlank(cssStyle.getBackgroundEffect())) {
+          properties.put(MappedAttributes.BACKGROUND_EFFECT.getName(), cssStyle.getBackgroundEffect());
+        }
+        if (StringUtils.isNotBlank(cssStyle.getBackgroundPosition())) {
+          properties.put(MappedAttributes.BACKGROUND_POSITION.getName(), cssStyle.getBackgroundPosition());
+        }
+        if (StringUtils.isNotBlank(cssStyle.getBackgroundSize())) {
+          properties.put(MappedAttributes.BACKGROUND_SIZE.getName(), cssStyle.getBackgroundSize());
+        }
+        if (StringUtils.isNotBlank(cssStyle.getBackgroundRepeat())) {
+          properties.put(MappedAttributes.BACKGROUND_REPEAT.getName(), cssStyle.getBackgroundRepeat());
+        }
+        if (StringUtils.isNotBlank(cssStyle.getBorderSize())) {
+          properties.put(MappedAttributes.BORDER_SIZE.getName(), cssStyle.getBorderSize());
+        }
+        if (StringUtils.isNotBlank(cssStyle.getBoxShadow())) {
+          properties.put(MappedAttributes.BOX_SHADOW.getName(), cssStyle.getBoxShadow());
+        }
       }
       dst.setProperties(properties.toJSONString());
     } else {
@@ -509,7 +557,7 @@ public class LayoutStorage {
   }
 
   @SuppressWarnings({
-      "unchecked", "rawtypes"
+                      "unchecked", "rawtypes"
   })
   private ApplicationData buildWindow(WindowEntity windowEntity) {
     ApplicationType<?> appType = convertAppType(windowEntity.getAppType());
@@ -530,15 +578,40 @@ public class LayoutStorage {
                                                                  windowEntity.getId(),
                                                                  PermissionEntity.TYPE.ACCESS);
 
-    String cssClass = null;
-    String borderColor = null;
     JSONObject attrs = windowEntity.getProperties() == null ? null : parseJsonObject(windowEntity.getProperties());
+    ModelStyle cssStyle = null;
+    String cssClass = null;
     if (attrs != null) {
+      cssStyle = new ModelStyle();
       if (attrs.containsKey(MappedAttributes.CSS_CLASS.getName())) {
         cssClass = (String) attrs.get(MappedAttributes.CSS_CLASS.getName());
       }
       if (attrs.containsKey(MappedAttributes.BORDER_COLOR.getName())) {
-        borderColor = (String) attrs.get(MappedAttributes.BORDER_COLOR.getName());
+        cssStyle.setBorderColor((String) attrs.get(MappedAttributes.BORDER_COLOR.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BORDER_SIZE.getName())) {
+        cssStyle.setBorderSize((String) attrs.get(MappedAttributes.BORDER_SIZE.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BOX_SHADOW.getName())) {
+        cssStyle.setBoxShadow((String) attrs.get(MappedAttributes.BOX_SHADOW.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_COLOR.getName())) {
+        cssStyle.setBackgroundColor((String) attrs.get(MappedAttributes.BACKGROUND_COLOR.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_IMAGE.getName())) {
+        cssStyle.setBackgroundImage((String) attrs.get(MappedAttributes.BACKGROUND_IMAGE.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_EFFECT.getName())) {
+        cssStyle.setBackgroundEffect((String) attrs.get(MappedAttributes.BACKGROUND_EFFECT.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_POSITION.getName())) {
+        cssStyle.setBackgroundPosition((String) attrs.get(MappedAttributes.BACKGROUND_POSITION.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_SIZE.getName())) {
+        cssStyle.setBackgroundSize((String) attrs.get(MappedAttributes.BACKGROUND_SIZE.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_REPEAT.getName())) {
+        cssStyle.setBackgroundRepeat((String) attrs.get(MappedAttributes.BACKGROUND_REPEAT.getName()));
       }
     }
 
@@ -557,7 +630,7 @@ public class LayoutStorage {
                                windowEntity.getWidth(),
                                windowEntity.getHeight(),
                                cssClass,
-                               borderColor,
+                               cssStyle,
                                properties,
                                buildPermission(access));
   }
@@ -584,14 +657,39 @@ public class LayoutStorage {
                                                                   PermissionEntity.TYPE.MOVE_CONTAINER);
 
     String cssClass = null;
-    String borderColor = null;
     String profiles = null;
+    ModelStyle cssStyle = null;
     if (attrs != null) {
+      cssStyle = new ModelStyle();
       if (attrs.containsKey(MappedAttributes.CSS_CLASS.getName())) {
         cssClass = (String) attrs.get(MappedAttributes.CSS_CLASS.getName());
       }
       if (attrs.containsKey(MappedAttributes.BORDER_COLOR.getName())) {
-        borderColor = (String) attrs.get(MappedAttributes.BORDER_COLOR.getName());
+        cssStyle.setBorderColor((String) attrs.get(MappedAttributes.BORDER_COLOR.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BORDER_SIZE.getName())) {
+        cssStyle.setBorderSize((String) attrs.get(MappedAttributes.BORDER_SIZE.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BOX_SHADOW.getName())) {
+        cssStyle.setBoxShadow((String) attrs.get(MappedAttributes.BOX_SHADOW.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_COLOR.getName())) {
+        cssStyle.setBackgroundColor((String) attrs.get(MappedAttributes.BACKGROUND_COLOR.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_IMAGE.getName())) {
+        cssStyle.setBackgroundImage((String) attrs.get(MappedAttributes.BACKGROUND_IMAGE.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_EFFECT.getName())) {
+        cssStyle.setBackgroundEffect((String) attrs.get(MappedAttributes.BACKGROUND_EFFECT.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_POSITION.getName())) {
+        cssStyle.setBackgroundPosition((String) attrs.get(MappedAttributes.BACKGROUND_POSITION.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_SIZE.getName())) {
+        cssStyle.setBackgroundSize((String) attrs.get(MappedAttributes.BACKGROUND_SIZE.getName()));
+      }
+      if (attrs.containsKey(MappedAttributes.BACKGROUND_REPEAT.getName())) {
+        cssStyle.setBackgroundRepeat((String) attrs.get(MappedAttributes.BACKGROUND_REPEAT.getName()));
       }
       if (attrs.containsKey(MappedAttributes.PROFILES.getName())) {
         profiles = (String) attrs.get(MappedAttributes.PROFILES.getName());
@@ -609,8 +707,8 @@ public class LayoutStorage {
                              entity.getWidth(),
                              entity.getHeight(),
                              cssClass,
-                             borderColor,
                              profiles,
+                             cssStyle,
                              buildPermission(access),
                              buildPermission(moveApps),
                              buildPermission(moveConts),
@@ -638,7 +736,38 @@ public class LayoutStorage {
           JSONObject attrs = parseJsonObject(srcContainer.getProperties());
           String ctype = (String) attrs.get(MappedAttributes.TYPE.getName());
           if (BodyType.PAGE.name().equals(ctype)) {
-            BodyData body = new BodyData(String.valueOf(id), BodyType.PAGE);
+            ModelStyle cssStyle = null;
+            if (attrs != null) {
+              cssStyle = new ModelStyle();
+              if (attrs.containsKey(MappedAttributes.BORDER_COLOR.getName())) {
+                cssStyle.setBorderColor((String) attrs.get(MappedAttributes.BORDER_COLOR.getName()));
+              }
+              if (attrs.containsKey(MappedAttributes.BACKGROUND_COLOR.getName())) {
+                cssStyle.setBackgroundColor((String) attrs.get(MappedAttributes.BACKGROUND_COLOR.getName()));
+              }
+              if (attrs.containsKey(MappedAttributes.BACKGROUND_IMAGE.getName())) {
+                cssStyle.setBackgroundImage((String) attrs.get(MappedAttributes.BACKGROUND_IMAGE.getName()));
+              }
+              if (attrs.containsKey(MappedAttributes.BACKGROUND_EFFECT.getName())) {
+                cssStyle.setBackgroundEffect((String) attrs.get(MappedAttributes.BACKGROUND_EFFECT.getName()));
+              }
+              if (attrs.containsKey(MappedAttributes.BACKGROUND_POSITION.getName())) {
+                cssStyle.setBackgroundPosition((String) attrs.get(MappedAttributes.BACKGROUND_POSITION.getName()));
+              }
+              if (attrs.containsKey(MappedAttributes.BACKGROUND_SIZE.getName())) {
+                cssStyle.setBackgroundSize((String) attrs.get(MappedAttributes.BACKGROUND_SIZE.getName()));
+              }
+              if (attrs.containsKey(MappedAttributes.BACKGROUND_REPEAT.getName())) {
+                cssStyle.setBackgroundRepeat((String) attrs.get(MappedAttributes.BACKGROUND_REPEAT.getName()));
+              }
+              if (attrs.containsKey(MappedAttributes.BORDER_SIZE.getName())) {
+                cssStyle.setBorderSize((String) attrs.get(MappedAttributes.BORDER_SIZE.getName()));
+              }
+              if (attrs.containsKey(MappedAttributes.BOX_SHADOW.getName())) {
+                cssStyle.setBoxShadow((String) attrs.get(MappedAttributes.BOX_SHADOW.getName()));
+              }
+            }
+            BodyData body = new BodyData(String.valueOf(id), BodyType.PAGE, cssStyle);
             results.add(body);
           } else {
             results.add(buildContainer(containers.get(id),
@@ -783,7 +912,7 @@ public class LayoutStorage {
   }
 
   @SuppressWarnings({
-      "unchecked"
+                      "unchecked"
   })
   private void savePermissions(Long id, ComponentData srcChild) {
     if (id == null) {

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/storage/PageStorageImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/storage/PageStorageImpl.java
@@ -50,6 +50,12 @@ public class PageStorageImpl extends AbstractPageStorage {
   }
 
   @Override
+  public Page getPage(long id) {
+    PageKey key = getPageKey(id);
+    return getPage(key);
+  }
+
+  @Override
   public Page getPage(PageKey key) {
     if (key == null) {
       throw new IllegalArgumentException(NO_NULL_KEY_ACCEPTED);
@@ -222,6 +228,11 @@ public class PageStorageImpl extends AbstractPageStorage {
                                             String pageTitle) {
     List<PageContext> pages = findPages(siteType, siteName, pageTitle, from, limit);
     return new QueryResult<>(from, pages.size(), pages);
+  }
+
+  protected PageKey getPageKey(long id) {
+    PageEntity pageEntity = pageDAO.find(id);
+    return pageEntity == null ? null : new PageKey(pageEntity.getOwnerType(), pageEntity.getOwnerId(), pageEntity.getName());
   }
 
   private List<PageContext> findPages(SiteType siteType, String siteName, String pageTitle, int from, int limit) {

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestLoadedPOM.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestLoadedPOM.java
@@ -163,7 +163,6 @@ public class TestLoadedPOM extends AbstractConfigTest {
     Container column = (Container) columnsSection.getChildren().get(0);
     assertEquals(1, column.getChildren().size());
     assertEquals("CellContainer", column.getTemplate());
-    assertNull(column.getBorderColor());
     assertNotNull(column.getCssClass());
     assertTrue("'flex-cell' not found", column.getCssClass().contains("flex-cell"));
     assertTrue("'grid-cell-colspan-md-9' not found", column.getCssClass().contains("grid-cell-colspan-md-9"));
@@ -175,7 +174,6 @@ public class TestLoadedPOM extends AbstractConfigTest {
     assertTrue("'TEST-column-class' custom class not found", column.getCssClass().contains("TEST-column-class"));
 
     Application<Portlet> columnApplication = (Application<Portlet>) column.getChildren().get(0);
-    assertEquals("#CCAABB", columnApplication.getBorderColor());
     assertNotNull(columnApplication.getCssClass());
     assertTrue("'mt-n1' not found", columnApplication.getCssClass().contains("mt-n1"));
     assertTrue("'mb-n3' not found", columnApplication.getCssClass().contains("mb-n3"));
@@ -202,7 +200,6 @@ public class TestLoadedPOM extends AbstractConfigTest {
     Container cell = (Container) gridSection.getChildren().get(0);
     assertEquals(1, cell.getChildren().size());
     assertEquals("CellContainer", cell.getTemplate());
-    assertEquals("#EE3355", cell.getBorderColor());
     assertNotNull(cell.getCssClass());
     assertTrue("'grid-cell' not found", cell.getCssClass().contains("grid-cell"));
     assertTrue("'grid-cell-colspan-md-2' not found", cell.getCssClass().contains("grid-cell-colspan-md-2"));

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestSerialization.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestSerialization.java
@@ -21,6 +21,7 @@ package org.exoplatform.portal.config;
 
 import java.util.*;
 
+import org.exoplatform.portal.config.model.ModelStyle;
 import org.exoplatform.portal.mop.PageType;
 import org.gatein.common.io.IOTools;
 
@@ -33,7 +34,7 @@ import org.exoplatform.portal.pom.data.*;
  */
 public class TestSerialization extends AbstractGateInTest {
     /** . */
-    private final BodyData body = new BodyData("foo", BodyType.PAGE);
+    private final BodyData body = new BodyData("foo", BodyType.PAGE, null);
 
     /** . */
     private final ContainerData container = new ContainerData("foo01",
@@ -47,8 +48,8 @@ public class TestSerialization extends AbstractGateInTest {
                                                             "foo09",
                                                             "foo10",
                                                             "foo11",
-                                                            "foo11.1",
                                                             "foo12",
+                                                            new ModelStyle(),
                                                             Collections.singletonList("foo11"),
                                                             Collections.singletonList("foo11"),
                                                             Collections.singletonList("foo11"),
@@ -93,7 +94,6 @@ public class TestSerialization extends AbstractGateInTest {
         assertEquals(container.getWidth(), clone.getWidth());
         assertEquals(container.getHeight(), clone.getHeight());
         assertEquals(container.getAccessPermissions(), clone.getAccessPermissions());
-        assertEquals(container.getBorderColor(), clone.getBorderColor());
         List<ComponentData> clonedChildren = container.getChildren();
         assertEquals(1, clonedChildren.size());
         assertEquals("foo", clonedChildren.get(0).getStorageId());
@@ -120,6 +120,7 @@ public class TestSerialization extends AbstractGateInTest {
                                 "foo16",
                                 true,
                                 true,
+                                new ModelStyle(),
                                 Collections.singletonList("foo13"),
                                 Collections.singletonList("foo13"),
                                 PageType.LINK.name(),

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestDataStorage.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestDataStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2009 eXo Platform SAS.
+  * Copyright (C) 2009 eXo Platform SAS.
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as
@@ -266,14 +266,12 @@ public class TestDataStorage extends AbstractKernelTest {
     container.setTemplate("test");
     container.setHeight(height);
     container.setWidth(width);
-    container.setBorderColor(borderColor);
     container.setCssClass(cssClass);
     page.setChildren(new ArrayList<>(Collections.singletonList(container)));
 
     Application<Portlet> application = new Application<>(ApplicationType.PORTLET);
     application.setHeight(height);
     application.setWidth(width);
-    application.setBorderColor(borderColor);
     application.setCssClass(cssClass);
     application.setState(new TransientApplicationState<>("test/test",  null));
     container.setChildren(new ArrayList<>(Collections.singletonList(application)));
@@ -317,13 +315,11 @@ public class TestDataStorage extends AbstractKernelTest {
     assertEquals(height, childObject.getHeight());
     assertEquals(width, childObject.getWidth());
     assertEquals(cssClass, childObject.getCssClass());
-    assertEquals(borderColor, childObject.getBorderColor());
 
     childObject = ((Container) childObject).getChildren().get(0);
     assertEquals(height, childObject.getHeight());
     assertEquals(width, childObject.getWidth());
-    assertEquals(cssClass, childObject.getCssClass());
-    assertEquals(borderColor, childObject.getBorderColor());
+    assertEquals(cssClass.trim(), childObject.getCssClass().trim());
 
     pageContext = pageService.loadPage(page.getPageKey());
     assertEquals("MyTitle", pageContext.getState().getDisplayName());
@@ -903,7 +899,7 @@ public class TestDataStorage extends AbstractKernelTest {
                                                 "",
                                                 "",
                                                 "",
-                                                "",
+                                                null,
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJCBCNavigationServiceRebase.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJCBCNavigationServiceRebase.java
@@ -76,7 +76,7 @@ public class TestJCBCNavigationServiceRebase extends AbstractKernelTest {
                                                 "",
                                                 "",
                                                 "",
-                                                "",
+                                                null,
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJDBCNavigationService.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJDBCNavigationService.java
@@ -71,7 +71,7 @@ public class TestJDBCNavigationService extends AbstractKernelTest {
                                                   "",
                                                   "",
                                                   "",
-                                                  "",
+                                                  null,
                                                   Collections.emptyList(),
                                                   Collections.emptyList(),
                                                   Collections.emptyList(),

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJDBCNavigationServiceSave.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJDBCNavigationServiceSave.java
@@ -78,7 +78,7 @@ public class TestJDBCNavigationServiceSave extends AbstractKernelTest {
                                                 "",
                                                 "",
                                                 "",
-                                                "",
+                                                null,
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJDBCNavigationServiceUpdate.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJDBCNavigationServiceUpdate.java
@@ -79,7 +79,7 @@ public class TestJDBCNavigationServiceUpdate extends AbstractKernelTest {
                                                 "",
                                                 "",
                                                 "",
-                                                "",
+                                                null,
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),
                                                 Collections.emptyList(),

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJDBCNavigationServiceWrapper.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/storage/TestJDBCNavigationServiceWrapper.java
@@ -86,7 +86,7 @@ public class TestJDBCNavigationServiceWrapper extends AbstractKernelTest {
                                                   "",
                                                   "",
                                                   "",
-                                                  "",
+                                                  null,
                                                   Collections.emptyList(),
                                                   Collections.emptyList(),
                                                   Collections.emptyList(),


### PR DESCRIPTION
This change will allow to store CSS properties in Layout models, such as:
- `background-image`
- `background-repeat`
- `background-size`
- `border-size`
- `box-shadow`