### PR TITLE
feat: Allow to Configure Spring Caches through properties - MEED-7059- Meeds-io/meeds#2145

### DIFF
--- a/component/common/src/main/java/io/meeds/spring/kernel/KernelCacheConfiguration.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/KernelCacheConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 import org.exoplatform.services.cache.CacheService;
 
@@ -34,8 +35,8 @@ import org.exoplatform.services.cache.CacheService;
 public class KernelCacheConfiguration {
 
   @Bean
-  public CacheManager cacheManager(CacheService cacheService) {
-    return new CacheManagerImpl(cacheService);
+  public CacheManager cacheManager(CacheService cacheService, Environment environment) {
+    return new CacheManagerImpl(cacheService, environment);
   }
 
 }


### PR DESCRIPTION
This change will allow to define properties of caches instatiated through Spring Cache management. The cache properties are of tyme:
- meeds.cache.<<`CACHE_NAME`>>.ttl : TTL in seconds
- meeds.cache.<<`CACHE_NAME`>>.max : Cache MAX entries.

(Resolves Meeds-io/meeds#2145)