### PR TITLE
fix: Fix Translation of Navigation Nodes when not I18N - MEED-7092 - Meeds-io/meeds#2198

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNode.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNode.java
@@ -33,6 +33,7 @@ import org.exoplatform.portal.mop.navigation.NodeState;
 import org.exoplatform.portal.mop.page.PageKey;
 import org.exoplatform.portal.mop.storage.DescriptionStorage;
 import org.exoplatform.services.resources.ResourceBundleService;
+
 import org.gatein.common.util.EmptyResourceBundle;
 
 /**
@@ -172,14 +173,15 @@ public class UserNode {
       return cachedResolvedLabel;
     }
 
-    String resolvedLabel = null;
+    String resolvedLabel = context.getState().getLabel();
 
     //
     String id = context.getId();
 
     //
     Locale userLocale = owner.navigation.portal.context.getUserLocale();
-    if (context.getState().getLabel() != null) {
+    if (context.getState().getLabel() != null
+        && ExpressionUtil.isResourceBindingExpression(context.getState().getLabel())) {
       ResourceBundle bundle = owner.navigation.getBundle();
       if (bundle == EmptyResourceBundle.INSTANCE) {
         ResourceBundleService resourceBundleService = ExoContainerContext.getService(ResourceBundleService.class);


### PR DESCRIPTION
Prior to this change, the node label is all time translated using I18N Resource Bundle service. This change allows to use Description Service Translation mechanism when the label isn't an I18N expression.

( Resolves Meeds-io/meeds#2198 )