### PR TITLE
feat: Allow to define Parent CSS Classes on Application Parent Container - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
@@ -39,9 +39,10 @@
   		}
   		cssStyle = " style=\"" + cssStyle + "\"";
     }
+    String cssClass = uicomponent.getCssClass() == null ? "" : " " + uicomponent.getCssClass();
  %>
   	<div id="$portletId" $hiddenClass>
-  		<div class="PORTLET-FRAGMENT" $cssStyle>
+  		<div class="PORTLET-FRAGMENT$cssClass" $cssStyle>
   			<% println portletContent; %>
   		</div>
   	</div>	

--- a/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
@@ -106,6 +106,8 @@ import org.exoplatform.webui.event.Event.Phase;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * This UI component represent a portlet window on a page. <br>
@@ -194,6 +196,10 @@ public class UIPortlet<S, C extends Serializable> extends UIApplication {
 
     /** A field storing localized value of javax.portlet.title * */
     private String configuredTitle;
+
+    @Getter
+    @Setter
+    private String cssClass;
 
     public String getStorageId() {
         return storageId;
@@ -1068,8 +1074,8 @@ public class UIPortlet<S, C extends Serializable> extends UIApplication {
         if (pir instanceof FragmentResponse) {
             if (lazyResourcesLoading == null) {
               PortletInfo portletInfo = producedOfferedPortlet.getInfo();
-              if (portletInfo instanceof ContainerPortletInfo) {
-                String prefetchResources = ((ContainerPortletInfo) portletInfo).getInitParameter("prefetch.resources");
+              if (portletInfo instanceof ContainerPortletInfo containerPortletInfo) {
+                String prefetchResources = containerPortletInfo.getInitParameter("prefetch.resources");
                 lazyResourcesLoading = StringUtils.equals(prefetchResources, "true");
               } else {
                 lazyResourcesLoading = false;

--- a/webui/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
@@ -24,10 +24,12 @@ import java.util.List;
 import java.util.Set;
 
 import org.exoplatform.portal.mop.service.LayoutService;
+
 import org.gatein.common.net.media.MediaType;
 import org.gatein.pc.api.Portlet;
 import org.gatein.pc.api.info.ModeInfo;
 import org.gatein.pc.api.info.PortletInfo;
+import org.gatein.pc.portlet.impl.info.ContainerPortletInfo;
 
 import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.portal.config.model.Application;
@@ -249,7 +251,10 @@ public class PortalDataMapper {
         if (supportModes.size() > 1)
             supportModes.remove("view");
         uiPortlet.setSupportModes(supportModes);
-    }
+        if (portletInfo instanceof ContainerPortletInfo containerPortletInfo) {
+          uiPortlet.setCssClass(containerPortletInfo.getInitParameter("layout-css-class"));
+        }
+      }
 
     public static void toUIContainer(UIContainer uiContainer, Container model) throws Exception {
         uiContainer.setStorageId(model.getStorageId());


### PR DESCRIPTION
This change will allow to define a custom CSS class to a portlet using a portlet.xml definition inside an init param with key 'layout-css-class'. This CSS is part of portlet definition and not attached to a particular of Portlet instance only.