### PR TITLE
fix: Fix Loading shared layout and site portlets - Meeds-io/meeds#2274

### DIFF
--- a/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -649,7 +649,13 @@ public class UIPortalApplication extends UIApplication {
     public Set<Skin> getPortletSkins() {
         // Determine portlets visible on the page
         List<UIPortlet> uiportlets = new ArrayList<>();
-        uiWorkingWorkspace.findComponentOfType(uiportlets, UIPortlet.class);
+        getCurrentPage().findComponentOfType(uiportlets, UIPortlet.class);
+        if (!PortalRequestContext.getCurrentInstance().isMaximizePortlet()) {
+          getCurrentSite().findComponentOfType(uiportlets, UIPortlet.class);
+        }
+        if (!PortalRequestContext.getCurrentInstance().isHideSharedLayout()) {
+          uiWorkingWorkspace.findComponentOfType(uiportlets, UIPortlet.class);
+        }
         List<Skin> portletSkins = new ArrayList<>();
         Set<SkinConfig> portalPortletSkins = getPortalPortletSkins();
         // don't merge portlet if portlet not available


### PR DESCRIPTION
Prior to this change, when the loaded page is using hideSharedLayout flag, the shared layout CSS resources are loaded. This change makes sure to avoid loading CSS Resources of portlets only when needed and displayed.

Resolves Meeds-io/meeds/issues/2274