### PR TITLE
fix: Register new account : username need to be cleaned up to remove grave accent - EXO-72767 - meeds-io/meeds#2251 (#930)

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/register/ExternalRegisterHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/register/ExternalRegisterHandler.java
@@ -561,7 +561,7 @@ public class ExternalRegisterHandler extends JspBasedWebHandler {
   }
 
   private String unAccent(String src) {
-    return Normalizer.normalize(src, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "").replace("'", "");
+    return Normalizer.normalize(src, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "").replace("'", "").replace("`", "");
   }
 
   private void wrapForAutomaticLogin(HttpServletRequest request,


### PR DESCRIPTION
Prior to this change, if an external user tries to create a new account by adding a first name or a last name containing a grave accent, the user is created with userNamecontaining the accant that can cause lot of problems.
This change removes the grave accent from the generated userName.