### PR TITLE
fix: Fix Setting Permanent Link Id when set twice in two different threads - Meeds-io/MIPs#134

### DIFF
--- a/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -1204,7 +1204,7 @@ public class UIPortalApplication extends UIApplication {
       // Determine portlets visible on the page
       uiPortlets = new ArrayList<>();
       UISharedLayout sharedLayout = uiWorkingWorkspace.findFirstComponentOfType(UISharedLayout.class);
-      if (sharedLayout.isShowSharedLayout(requestContext)) {
+      if (sharedLayout == null || sharedLayout.isShowSharedLayout(requestContext)) {
         uiWorkingWorkspace.findComponentOfType(uiPortlets, UIPortlet.class);
       } else {
         UIPage currentPage = getCurrentPage();


### PR DESCRIPTION
Prior to this change, when setting twice the same value for a permanent link id in two different threads, then one of them will through an exception. This change ensures to not throw exception when the permanent link is already set.