### PR TITLE
fix: Delete configuration of missing I18N files - MEED-7340 - Meeds-io/meeds#2317

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/common-configuration.xml
@@ -193,9 +193,7 @@
         <name>init.resources</name>
         <description>Initiate the following resources during the first launch</description>
         <value>locale.portal.expression</value>
-        <value>locale.portal.services</value>
         <value>locale.portal.webui</value>
-        <value>locale.portal.custom</value>
         <value>locale.portal.login</value>
         <value>locale.navigation.portal.global</value>
       </values-param>
@@ -209,9 +207,7 @@
           into one ResoruceBundle properties
         </description>
         <value>locale.portal.expression</value>
-        <value>locale.portal.services</value>
         <value>locale.portal.webui</value>
-        <value>locale.portal.custom</value>
         <value>locale.portal.login</value>
       </values-param>
       <values-param>


### PR DESCRIPTION
Prior to this change, when starting the server, some warn logs are displayed about missing I18N files. This change will delete the configuration of those deleted files.

Resolves Meeds-io/meeds/issues/2317