### PR TITLE
fix: Fix Application Layout CSS Class Computing - MEED-7321 - Meeds-io/meeds#2305

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/config/model/Application.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/Application.java
@@ -230,7 +230,7 @@ public class Application<S> extends ModelObject implements Cloneable {
         return cssStyle.getCssClass();
       } else {
         StringBuilder cssClasses = new StringBuilder();
-        cssClasses.append(cssStyle.getCssClass());
+        cssClasses.append(cssStyle.getCssClass(cssClass));
         cssClasses.append(" ");
         cssClasses.append(cssClass);
         return cssClasses.toString();

--- a/component/api/src/main/java/org/exoplatform/portal/config/model/ModelStyle.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/ModelStyle.java
@@ -20,6 +20,8 @@ package org.exoplatform.portal.config.model;
 
 import java.io.Serializable;
 
+import org.apache.commons.lang3.StringUtils;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -98,40 +100,56 @@ public class ModelStyle implements Serializable {
   private String            textSubtitleFontStyle;
 
   public String getCssClass() { // NOSONAR
+    return getCssClass(null);
+  }
+
+  public String getCssClass(String existingCssClass) { // NOSONAR
     StringBuilder cssClass = new StringBuilder();
-    if (marginTop != null && marginTop >= 0) {
-      cssClass.append(" mt-n");
+    if (marginTop != null && marginTop >= 0 && !StringUtils.contains(existingCssClass, "mt-")) {
+      cssClass.append(" mt-");
+      if (marginTop < 20) {
+        cssClass.append("n");
+      }
       cssClass.append(Math.abs((marginTop - 20) / 4));
     }
-    if (marginBottom != null && marginBottom >= 0) {
-      cssClass.append(" mb-n");
+    if (marginBottom != null && marginBottom >= 0 && !StringUtils.contains(existingCssClass, "mb-")) {
+      cssClass.append(" mb-");
+      if (marginBottom < 20) {
+        cssClass.append("n");
+      }
       cssClass.append(Math.abs((marginBottom - 20) / 4));
     }
-    if (marginRight != null && marginRight >= 0) {
-      cssClass.append(" me-n");
+    if (marginRight != null && marginRight >= 0 && !StringUtils.contains(existingCssClass, "me-")) {
+      cssClass.append(" me-");
+      if (marginRight < 20) {
+        cssClass.append("n");
+      }
       cssClass.append(Math.abs((marginRight - 20) / 4));
     }
-    if (marginLeft != null && marginLeft >= 0) {
-      cssClass.append(" ms-n");
+    if (marginLeft != null && marginLeft >= 0 && !StringUtils.contains(existingCssClass, "ms-")) {
+      cssClass.append(" ms-");
+      if (marginLeft < 20) {
+        cssClass.append("n");
+      }
       cssClass.append(Math.abs((marginLeft - 20) / 4));
     }
-    if (radiusTopRight != null) {
+    if (radiusTopRight != null && !StringUtils.contains(existingCssClass, "brtr-")) {
       cssClass.append(" brtr-");
       cssClass.append(radiusTopRight / 4);
     }
-    if (radiusTopLeft != null) {
+    if (radiusTopLeft != null && !StringUtils.contains(existingCssClass, "brtl-")) {
       cssClass.append(" brtl-");
       cssClass.append(radiusTopLeft / 4);
     }
-    if (radiusBottomRight != null) {
+    if (radiusBottomRight != null && !StringUtils.contains(existingCssClass, "brbr-")) {
       cssClass.append(" brbr-");
       cssClass.append(radiusBottomRight / 4);
     }
-    if (radiusBottomLeft != null) {
+    if (radiusBottomLeft != null && !StringUtils.contains(existingCssClass, "brbl-")) {
       cssClass.append(" brbl-");
       cssClass.append(radiusBottomLeft / 4);
     }
-    if (mobileHidden != null && mobileHidden.booleanValue()) {
+    if (mobileHidden != null && mobileHidden.booleanValue() && !StringUtils.contains(existingCssClass, "hidden-sm-and-down")) {
       cssClass.append(" hidden-sm-and-down");
     }
     return cssClass.toString();

--- a/component/api/src/test/java/io/meeds/portal/mop/PageParsingTest.java
+++ b/component/api/src/test/java/io/meeds/portal/mop/PageParsingTest.java
@@ -73,7 +73,7 @@ public class PageParsingTest extends TestCase {
 
       Application<Portlet> columnApplication = (Application<Portlet>) column.getChildren().get(0);
       assertNotNull(columnApplication.getCssClass());
-      assertTrue("'mt-n1' not found in: " + columnApplication.getCssClass(), columnApplication.getCssClass().contains("mt-n1"));
+      assertTrue("'mt-0' not found in: " + columnApplication.getCssClass(), columnApplication.getCssClass().contains("mt-0"));
       assertTrue("'mb-n3' not found in: " + columnApplication.getCssClass(), columnApplication.getCssClass().contains("mb-n3"));
       assertTrue("'me-n4' not found", columnApplication.getCssClass().contains("me-n4"));
       assertTrue("'ms-n5' not found", columnApplication.getCssClass().contains("ms-n5"));

--- a/component/api/src/test/resources/page.xml
+++ b/component/api/src/test/resources/page.xml
@@ -45,7 +45,7 @@
             <portlet-ref>TestPortlet</portlet-ref>
           </portlet>
           <css-style>
-            <margin-top>16</margin-top>
+            <margin-top>20</margin-top>
             <margin-bottom>8</margin-bottom>
             <margin-right>4</margin-right>
             <margin-left>0</margin-left>


### PR DESCRIPTION
Prior to this change, the CSS Classes were duplicated in Application CSS Computed Class when there is already margin classes introduced in the custom attribute cssClass. This change ensures to not introduce twice the same class. Besides this change will apply 'mt-0' instead of 'mt-n0' class when margin is 20 to ensure to apply the right class even if not useful for now since the 'mt-0' applies a 0 margin.

Resolves Meeds-io/meeds/issues/2305