### PR TITLE
fix: Delete configuration of missing I18N files - MEED-7340 - Meeds-io/meeds#2317

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/webui-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/webui-configuration.xml
@@ -24,7 +24,7 @@
     <init-params>
       <param>
         <name>application.resource.bundle</name>
-        <value>locale.portal.expression, locale.portal.services, locale.portal.webui</value>
+        <value>locale.portal.expression, locale.portal.webui</value>
       </param>
     </init-params>
 


### PR DESCRIPTION
Prior to this change, when starting the server and display the home page after login, some missing I18N files warn logs are displayed. This change will delete the configuration of those deleted I18N file.

Resolves https://github.com/Meeds-io/meeds/issues/2317