### PR TITLE
fix Fix Retrieving Layout when Application Deleted - Meeds-io/MIPs#156

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/storage/LayoutStorage.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/storage/LayoutStorage.java
@@ -629,7 +629,11 @@ public class LayoutStorage {
         TYPE type = TYPE.valueOf(jsonComponent.get(TYPE_PROP).toString());
 
         if (type == TYPE.WINDOW) {
-          results.add(buildWindow(windows.get(id)));
+          WindowEntity windowEntity = windows.get(id);
+          if (windowEntity == null) {
+            continue;
+          }
+          results.add(buildWindow(windowEntity));
         } else if (type == TYPE.CONTAINER) {
           ContainerEntity srcContainer = containerDAO.find(id);
           if (srcContainer == null) {


### PR DESCRIPTION
Prior to this change, when an application is removed from store without having updated the Page JSON, the whole page/portal layout parsing fails. This change ensures to not making the page body parsing fail when missing an application entity which may be deleted in a different Hibernate session.