### PR TITLE
fix: Remove branding name from external users verification/confirmation emails - EXO-74008

### DIFF
--- a/component/web/security/src/main/resources/conf/external_confirmation_account_email_template.html
+++ b/component/web/security/src/main/resources/conf/external_confirmation_account_email_template.html
@@ -5,7 +5,7 @@
                 <!-- begin top-->
                 <tr bgcolor="#f5f5f5" >
                     <td height="44" valign="middle" align="center" bgcolor="#d6d6d6" style="color: #476a98; border-bottom: 1px solid #ccc;">
-                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;">&{external.confirmation.account.email.header} ${COMPANY_NAME}! </h2>
+                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;">&{external.confirmation.account.email.header} ! </h2>
                     </td>
                 </tr>
                 <!--end top-->

--- a/component/web/security/src/main/resources/conf/external_verification_account_email_template.html
+++ b/component/web/security/src/main/resources/conf/external_verification_account_email_template.html
@@ -5,7 +5,7 @@
                 <!-- begin top-->
                 <tr bgcolor="#f5f5f5" >
                     <td height="44" valign="middle" align="center" bgcolor="#d6d6d6" style="color: #476a98; border-bottom: 1px solid #ccc;">
-                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;">&{external.verification.account.email.header} ${COMPANY_NAME}! </h2>
+                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;">&{external.verification.account.email.header} ! </h2>
                     </td>
                 </tr>
                 <!--end top-->


### PR DESCRIPTION
Prior to this change, external users' account verification/confirmation emails include the branding name in the thank you section, which doesn't work well in the case of other languages such as fr. 
![image](https://github.com/user-attachments/assets/4ea63174-7790-4783-8818-fd59ca2596e8)

This change removes the branding name from the Thank You section since the branding name is already displayed in the header and footer.