### PR TITLE
fix: Restore branding name in email header and remove it from thankyou line

### DIFF
--- a/component/web/security/src/main/resources/conf/external_confirmation_account_email_template.html
+++ b/component/web/security/src/main/resources/conf/external_confirmation_account_email_template.html
@@ -5,7 +5,7 @@
                 <!-- begin top-->
                 <tr bgcolor="#f5f5f5" >
                     <td height="44" valign="middle" align="center" bgcolor="#d6d6d6" style="color: #476a98; border-bottom: 1px solid #ccc;">
-                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;">&{external.confirmation.account.email.header} ! </h2>
+                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;">&{external.confirmation.account.email.header} ${DISPLAY_NAME}! </h2>
                     </td>
                 </tr>
                 <!--end top-->
@@ -19,7 +19,7 @@
                                     <p style="margin: 0 0 10px 0;line-height: 40px;font-size: 17px;text-transform: capitalize">&{external.confirmation.account.email.hi} ${DISPLAY_NAME},</p>
 
 
-                                    <p style="margin: 0 0 5px 0;line-height:22px">&{external.confirmation.account.email.thanks} ${COMPANY_NAME}.</p>
+                                    <p style="margin: 0 0 5px 0;line-height:22px">&{external.confirmation.account.email.thanks}.</p>
                                     <p style="margin: 0 0 15px 0;line-height:22px"> &{external.confirmation.account.email.reminder} <span style="font-weight: bold;"> ${USERNAME}</span></p>
                                     <table width="100%" cellpadding="0" cellspacing="0" style="font-size: inherit;color: #333333;">
                                         <tr>

--- a/component/web/security/src/main/resources/conf/external_verification_account_email_template.html
+++ b/component/web/security/src/main/resources/conf/external_verification_account_email_template.html
@@ -5,7 +5,7 @@
                 <!-- begin top-->
                 <tr bgcolor="#f5f5f5" >
                     <td height="44" valign="middle" align="center" bgcolor="#d6d6d6" style="color: #476a98; border-bottom: 1px solid #ccc;">
-                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;">&{external.verification.account.email.header} ! </h2>
+                        <h2 style="margin: 0;padding: 0; font-size: 16px;font-family: 'Helvetica', 'Arial', sans-serif;">&{external.verification.account.email.header} ${DISPLAY_NAME}! </h2>
                     </td>
                 </tr>
                 <!--end top-->
@@ -19,7 +19,7 @@
                                     <p style="margin: 0 0 10px 0;line-height: 40px;font-size: 17px;text-transform: capitalize">&{external.verification.account.email.hi} ${DISPLAY_NAME},</p>
 
 
-                                    <p style="margin: 0 0 5px 0;line-height:22px">&{external.verification.account.email.thanks} ${COMPANY_NAME}.</p>
+                                    <p style="margin: 0 0 5px 0;line-height:22px">&{external.verification.account.email.thanks}.</p>
                                     <p style="margin: 0 0 15px 0;line-height:22px"> &{external.verification.account.email.reminder} <span style="font-weight: bold;"> ${USERNAME}</span></p>
                                     <table width="100%" cellpadding="0" cellspacing="0" style="font-size: inherit;color: #333333;">
                                         <tr>


### PR DESCRIPTION
I have made a mistake on [PR](https://github.com/Meeds-io/gatein-portal/pull/960) removing the branding name from email header while it should have been removed from tha thankyou line
this change restores the branding name to email header and removes it from thankyou line as intended