### PR TITLE
fix: Avoid NPE when page not accessible - MEED-7500 - Meeds-io/meeds#2390

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -643,6 +643,9 @@ public class UserPortalConfigService implements Startable {
       }
       UserPortal userPortal = userPortalConfig.getUserPortal();
       UserNavigation navigation = userPortal.getNavigation(new SiteKey(SiteType.valueOf(siteType.toUpperCase()), siteName));
+      if (navigation == null) {
+        return null;
+      }
       UserNodeFilterConfig builder = UserNodeFilterConfig.builder()
                                                          .withReadWriteCheck()
                                                          .withVisibility(Visibility.DISPLAYED, Visibility.TEMPORAL)

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
@@ -193,6 +193,9 @@ public class UserPortalImpl implements UserPortal {
                           NodeChangeListener<UserNode> listener) throws NullPointerException,
                                                                  UserPortalException,
                                                                  NavigationServiceException {
+    if (userNavigation == null || userNavigation.navigation == null) {
+      return null;
+    }
     UserNodeContext userNodeContext = new UserNodeContext(userNavigation, filterConfig);
     NodeContext<UserNode> nodeContext = service.getNavigationService()
                                                .loadNode(userNodeContext,


### PR DESCRIPTION
Prior to this change when accessing anonymously to a non accessible page, an NPE is thrown and a blank page is displayed. This change will avoid NPE to let the login page displayed instead.