### PR TITLE
fix: Avoid NPE when page not accessible - MEED-7500 - Meeds-io/meeds#2390

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -643,6 +643,9 @@ public class UserPortalConfigService implements Startable {
       }
       UserPortal userPortal = userPortalConfig.getUserPortal();
       UserNavigation navigation = userPortal.getNavigation(new SiteKey(SiteType.valueOf(siteType.toUpperCase()), siteName));
+      if (navigation == null) {
+        return null;
+      }
       UserNodeFilterConfig builder = UserNodeFilterConfig.builder()
                                                          .withReadWriteCheck()
                                                          .withVisibility(Visibility.DISPLAYED, Visibility.TEMPORAL)

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
@@ -193,6 +193,9 @@ public class UserPortalImpl implements UserPortal {
                           NodeChangeListener<UserNode> listener) throws NullPointerException,
                                                                  UserPortalException,
                                                                  NavigationServiceException {
+    if (userNavigation == null || userNavigation.navigation == null) {
+      return null;
+    }
     UserNodeContext userNodeContext = new UserNodeContext(userNavigation, filterConfig);
     NodeContext<UserNode> nodeContext = service.getNavigationService()
                                                .loadNode(userNodeContext,

--- a/webui/src/main/java/org/exoplatform/portal/application/PortalRequestHandler.java
+++ b/webui/src/main/java/org/exoplatform/portal/application/PortalRequestHandler.java
@@ -76,6 +76,8 @@ public class PortalRequestHandler extends WebRequestHandler {
                                                                                  .findFirst()
                                                                                  .orElse(null);
 
+  private static final String                   PORTAL_PUBLIC_PAGE_NOT_FOUND = "/portal/public/page-not-found";
+
   public String getHandlerName() {
     return "portal";
   }
@@ -153,7 +155,23 @@ public class PortalRequestHandler extends WebRequestHandler {
         } else if (req.getRemoteUser() == null) {
           context.requestAuthenticationLogin();
         } else {
-          context.sendRedirect("/portal/" + portalConfigService.getMetaPortal() + "/page-not-found");
+          String metaPageNotFound = "/portal/" + portalConfigService.getMetaPortal() + "/page-not-found";
+          if (!StringUtils.equals(req.getRequestURI(), metaPageNotFound)) {
+            if (StringUtils.equals(req.getRequestURI(), PORTAL_PUBLIC_PAGE_NOT_FOUND)) {
+              // In case page-not-found can't be displayed in 'public' or 'meta' sites
+              // If logged in => redirect to /
+              // If Anonymous => redirect to Login page
+              if (StringUtils.isNotBlank(req.getRemoteUser())) {
+                context.sendRedirect("/");
+              } else {
+                context.requestAuthenticationLogin();
+              }
+            } else {
+              context.sendRedirect(metaPageNotFound);
+            }
+          } else {
+            context.sendRedirect(PORTAL_PUBLIC_PAGE_NOT_FOUND);
+          }
         }
       } else if (persistentPortalConfig != null
                  && StringUtils.equals(persistentPortalConfig.getName(), portalConfigService.getGlobalPortal())) {


### PR DESCRIPTION
Prior to this change when accessing anonymously to a non accessible page, an NPE is thrown and a blank page is displayed. This change will avoid NPE to let the login page displayed instead. Besides, this will avoid cyclic redirection when not permitted to access public site nor meta site for a user.