### PR TITLE
fix: Update IdentityRegistry identities when memberships changes - MEED-7488 - Meeds-io/MIPs#147

### DIFF
--- a/component/identity/src/main/java/io/meeds/services/organization/listener/IdentityRegistryMembershipListener.java
+++ b/component/identity/src/main/java/io/meeds/services/organization/listener/IdentityRegistryMembershipListener.java
@@ -1,0 +1,62 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.services.organization.listener;
+
+import java.util.Objects;
+
+import org.exoplatform.services.organization.Membership;
+import org.exoplatform.services.organization.MembershipEventListener;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.IdentityRegistry;
+import org.exoplatform.services.security.MembershipEntry;
+
+public class IdentityRegistryMembershipListener extends MembershipEventListener {
+
+  private IdentityRegistry identityRegistry;
+
+  public IdentityRegistryMembershipListener(IdentityRegistry identityRegistry) {
+    this.identityRegistry = identityRegistry;
+  }
+
+  @Override
+  public void postDelete(Membership membership) throws Exception {
+    Identity identity = identityRegistry.getIdentity(membership.getUserName());
+    if (identity != null) {
+      MembershipEntry membershipEntry = toMembershipEntry(membership);
+      identity.getMemberships()
+              .removeIf(m -> Objects.equals(m, membershipEntry));
+    }
+  }
+
+  @Override
+  public void postSave(Membership membership, boolean isNew) throws Exception {
+    Identity identity = identityRegistry.getIdentity(membership.getUserName());
+    if (identity != null) {
+      MembershipEntry membershipEntry = toMembershipEntry(membership);
+      if (identity.getMemberships().stream().noneMatch(m -> m.equals(membershipEntry))) {
+        identity.getMemberships().add(membershipEntry);
+      }
+    }
+  }
+
+  private MembershipEntry toMembershipEntry(Membership membership) {
+    return new MembershipEntry(membership.getGroupId(), membership.getMembershipType());
+  }
+
+}

--- a/component/identity/src/test/java/org/exoplatform/services/organization/mock/InMemoryMembershipHandler.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/mock/InMemoryMembershipHandler.java
@@ -16,7 +16,6 @@
 package org.exoplatform.services.organization.mock;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +89,7 @@ public class InMemoryMembershipHandler implements MembershipHandler {
   public List<Membership> removeMembershipByUser(String userName, boolean broadcast) {
     List<Membership> memberships = userMemberships.compute(userName,
                                                            (key,
-                                                            existingMemberships) -> existingMemberships == null ? Collections.emptyList()
+                                                            existingMemberships) -> existingMemberships == null ? new ArrayList<>()
                                                                                                                 : new ArrayList<>(existingMemberships));
     removeMemberships(memberships, broadcast);
     return memberships;
@@ -99,7 +98,7 @@ public class InMemoryMembershipHandler implements MembershipHandler {
   public List<Membership> removeMembershipByGroup(String groupId, boolean broadcast) {
     List<Membership> memberships = groupMemberships.compute(groupId,
                                                             (key,
-                                                             existingMemberships) -> existingMemberships == null ? Collections.emptyList()
+                                                             existingMemberships) -> existingMemberships == null ? new ArrayList<>()
                                                                                                                  : new ArrayList<>(existingMemberships));
     removeMemberships(memberships, broadcast);
     return memberships;
@@ -108,7 +107,7 @@ public class InMemoryMembershipHandler implements MembershipHandler {
   public List<Membership> removeMembershipByMembershipType(String membershipType, boolean broadcast) {
     List<Membership> memberships = membershipTypeMemberships.compute(membershipType,
                                                                      (key,
-                                                                      existingMemberships) -> existingMemberships == null ? Collections.emptyList()
+                                                                      existingMemberships) -> existingMemberships == null ? new ArrayList<>()
                                                                                                                           : new ArrayList<>(existingMemberships));
     removeMemberships(memberships, broadcast);
     return memberships;
@@ -142,7 +141,7 @@ public class InMemoryMembershipHandler implements MembershipHandler {
 
   @Override
   public List<Membership> findMembershipsByUser(String userName) {
-    return userMemberships.computeIfAbsent(userName, key -> Collections.emptyList());
+    return userMemberships.computeIfAbsent(userName, key -> new ArrayList<>());
   }
 
   @Override
@@ -152,11 +151,11 @@ public class InMemoryMembershipHandler implements MembershipHandler {
 
   @Override
   public List<Membership> findMembershipsByGroup(Group group) {
-    return groupMemberships.computeIfAbsent(group.getId(), key -> Collections.emptyList());
+    return groupMemberships.computeIfAbsent(group.getId(), key -> new ArrayList<>());
   }
 
   public List<Membership> findMembershipsByGroupId(String groupId) {
-    return groupMemberships.computeIfAbsent(groupId, key -> Collections.emptyList());
+    return groupMemberships.computeIfAbsent(groupId, key -> new ArrayList<>());
   }
 
   @Override

--- a/component/identity/src/test/resources/conf/exo.portal.component.identity-configuration.xml
+++ b/component/identity/src/test/resources/conf/exo.portal.component.identity-configuration.xml
@@ -303,6 +303,16 @@
           </object-param>
         </init-params>
       </component-plugin>
+      <component-plugin>
+        <name>MembershipUpdateListener</name>
+        <set-method>addListenerPlugin</set-method>
+        <type>org.exoplatform.services.organization.impl.MembershipUpdateListener</type>
+      </component-plugin>
+      <component-plugin>
+        <name>MembershipUpdateListener</name>
+        <set-method>addListenerPlugin</set-method>
+        <type>io.meeds.services.organization.listener.IdentityRegistryMembershipListener</type>
+      </component-plugin>
     </component-plugins>
   </component>
 

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/organization-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/organization-configuration.xml
@@ -331,5 +331,11 @@
       <set-method>addListenerPlugin</set-method>
       <type>org.exoplatform.services.organization.impl.MembershipUpdateListener</type>
     </component-plugin>
+
+    <component-plugin>
+      <name>MembershipUpdateListener</name>
+      <set-method>addListenerPlugin</set-method>
+      <type>io.meeds.services.organization.listener.IdentityRegistryMembershipListener</type>
+    </component-plugin>
   </external-component-plugins>
 </configuration>


### PR DESCRIPTION
Prior to this change, when the user memberships are updated, the list of memberships stored in Identity Registry isn't updated. This change adds a new Listener to update authenticated and registered user identities right after updating their roles.