### PR TITLE
fix: Fix Computing of Menu stickiness behavior switch param - MEED-7548 - Meeds-io/meeds#2430

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -108,7 +108,7 @@
   if (rcontext.getRequestParameter("sticky") == null) {
     stickyMenu = uicomponent.isMenuSticky();
   } else {
-    stickyMenu = rcontext.getRequestParameter("sticky");
+    stickyMenu = rcontext.getRequestParameter("sticky").equals("true");
   }
   if (stickyMenu) {
     bodyClasses += " HamburgerMenuSticky";


### PR DESCRIPTION
Prior to this change, the Left menu space is still displayed even when the request param 'sticky=false' is used. This change ensures to retrieve the right value for Branding Preview UI.

Resolves Meeds-io/meeds#2430