### PR TITLE
feat: Replace Jcabi Plugin by AspectJ Maven Plugin - Meeds-io/meeds#2417

### DIFF
--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -196,10 +196,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.aspectj</groupId>
-      <artifactId>aspectjrt</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <exclusions>

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -47,6 +47,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-jakarta</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>io.meeds.kernel</groupId>
@@ -68,10 +73,6 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <executions>

--- a/component/file-storage/pom.xml
+++ b/component/file-storage/pom.xml
@@ -43,6 +43,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
@@ -51,10 +63,6 @@
             <exo.data.dir>target/exo-files</exo.data.dir>
           </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/component/file-storage/src/test/java/org/exoplatform/commons/file/services/FileServiceImplTest.java
+++ b/component/file-storage/src/test/java/org/exoplatform/commons/file/services/FileServiceImplTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityTransaction;
@@ -34,10 +34,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
-/**
- *
- */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class FileServiceImplTest {
 
   @Rule

--- a/component/identity/pom.xml
+++ b/component/identity/pom.xml
@@ -82,11 +82,37 @@
        <version>${berkeleydb.version}</version>
        <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>aspectj-maven-plugin</artifactId>
+          <configuration>
+            <aspectLibraries>
+              <aspectLibrary>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>portal.component.common</artifactId>
+              </aspectLibrary>
+            </aspectLibraries>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/component/management/pom.xml
+++ b/component/management/pom.xml
@@ -78,4 +78,20 @@
       <type>test-jar</type>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/component/pc/pom.xml
+++ b/component/pc/pom.xml
@@ -46,4 +46,20 @@
       <type>test-jar</type>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/component/portal/pom.xml
+++ b/component/portal/pom.xml
@@ -100,6 +100,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/component/resources/pom.xml
+++ b/component/resources/pom.xml
@@ -43,4 +43,20 @@
       <type>test-jar</type>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/component/scripting/pom.xml
+++ b/component/scripting/pom.xml
@@ -44,4 +44,20 @@
       <artifactId>groovy-all</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/component/web/api/pom.xml
+++ b/component/web/api/pom.xml
@@ -39,4 +39,20 @@
       <artifactId>portal.component.web.controller</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/component/web/controller/pom.xml
+++ b/component/web/controller/pom.xml
@@ -76,4 +76,20 @@
       </exclusions>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/component/web/resources/pom.xml
+++ b/component/web/resources/pom.xml
@@ -105,6 +105,18 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>

--- a/component/web/security/pom.xml
+++ b/component/web/security/pom.xml
@@ -59,13 +59,21 @@
       <artifactId>sso-agent</artifactId>
     </dependency>
   </dependencies>
-
   <build>
     <plugins>
       <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -345,18 +345,6 @@
             <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>test-jar</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -69,6 +69,18 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <configuration>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>portal.component.common</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
Prior to this change, the jcabi maven plugin was used to weave classes for annotation processing, especially  and  annotations. This plugin isn't maintained and should be replace by the default AspectJ libraries for Annotation Processing. In addition, the Jcabi plugin makes the build longer and takes a lot of time in addition to heigh I/O operations on disk. This change applies the required configuration (In addition to https://github.com/Meeds-io/maven-parent-pom/commit/bea09a8fcbc02b87ee8748cd9bbf9a524e4d74cd) in order to replace usage of Jcabi plugin.