### PR TITLE
fix: Remove old way of portlet height definition - MEED-7550 - Meeds-io/meeds#2428

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/application/UIPortlet.gtmpl
@@ -30,7 +30,7 @@
 		String windowHeight = uicomponent.getHeight();
 
 		String cssStyle = "";
-		if (windowHeight != null || windowWidth != null) {
+		if ((windowHeight != null || windowWidth != null) && !rcontext.isMaximizePortlet()) {
   		if (windowWidth != null) {
   			cssStyle += "width: "+ windowWidth +";";
   		}

--- a/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
@@ -276,22 +276,6 @@ public class UIPortlet<S, C extends Serializable> extends UIApplication {
     }
 
     /**
-     *  Used internally by portal to change current state
-     *  if portlet is in portal or in page
-     */
-    public void setPortletInPortal(boolean b) {
-        portletInPortal_ = b;
-    }
-
-    /**
-     * Check if portlet is in portal
-     * @return true if portlet is in portal
-     */
-    public boolean isPortletInPortal() {
-        return portletInPortal_;
-    }
-
-    /**
      * Theme is composed of map between theme name and skin name.
      * Theme format: {skinName}:{themeName}::{anotherSkin}:{anotherTheme}.
      * For example: the default them is 'Default:DefaultTheme::Vista:VistaTheme::Mac:MacTheme'.

--- a/webui/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
@@ -133,9 +133,6 @@ public class PortalDataMapper {
 
     List<UIPortlet> portlets = new ArrayList<>();
     uiPage.findComponentOfType(portlets, UIPortlet.class);
-    for (UIPortlet portlet : portlets) {
-      portlet.setPortletInPortal(false);
-    }
   }
 
   public static void toUIPortal(UIPortal uiPortal, PortalConfig model) throws Exception {

--- a/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -1186,11 +1186,11 @@ public class UIPortalApplication extends UIApplication {
   }
 
   private boolean isDraftPage() {
-    return ((PortalRequestContext) RequestContext.getCurrentInstance()).isDraftPage();
+    return PortalRequestContext.getCurrentInstance().isDraftPage();
   }
 
   public boolean isMaximizePortlet() {
-    return StringUtils.isNotBlank(PortalRequestContext.getCurrentInstance().getMaximizedPortletId());
+    return PortalRequestContext.getCurrentInstance().isMaximizePortlet();
   }
 
   public String getMaximizedPortletId() {


### PR DESCRIPTION
Prior to this change, the old height attribute defined in portlets was applied on the whole block of the portlet. This change will cancel this style application for portlets retrieved using the new layout management system so that it still be applied on old pages designed with old system but not applied on pages applied using the new layout.