### PR TITLE
feat: Improve Spring To Spring Beans definition compatibility - MEED-7576 - Meeds-io/meeds#2469

### DIFF
--- a/component/common/src/main/java/io/meeds/spring/kernel/PortalApplicationContextInitializer.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/PortalApplicationContextInitializer.java
@@ -26,6 +26,10 @@ import org.exoplatform.container.ExoContainer;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 
+/**
+ * A super class used to define {@link PortalApplicationContext} as the Spring
+ * Application Builder to use
+ */
 public abstract class PortalApplicationContextInitializer extends SpringBootServletInitializer {
 
   private DefaultListableBeanFactory beanFactory;

--- a/component/common/src/test/java/io/meeds/spring/kernel/test/SpringBeanFactoryInterceptor.java
+++ b/component/common/src/test/java/io/meeds/spring/kernel/test/SpringBeanFactoryInterceptor.java
@@ -49,7 +49,7 @@ public class SpringBeanFactoryInterceptor implements BeanFactoryPostProcessor, A
     LOG.info("Integrating Spring Context with Container. Application name = '{}' using Kernel configuration class '{}'",
              applicationContext.getApplicationName(),
              getTestClass());
-    addSpringContext("test", applicationContext, (BeanDefinitionRegistry) beanFactory);
+    addSpringContext("test", applicationContext, (BeanDefinitionRegistry) beanFactory, null);
     bootContainer(getTestClass());
   }
 

--- a/component/common/src/test/java/io/meeds/spring/module/service/TestServiceImpl.java
+++ b/component/common/src/test/java/io/meeds/spring/module/service/TestServiceImpl.java
@@ -18,10 +18,34 @@
  */
 package io.meeds.spring.module.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.commons.api.settings.SettingService;
+
 import io.meeds.spring.module.model.TestModel;
+import io.meeds.spring.module.storage.TestStorage;
 
-public interface TestService {
+@Service
+public class TestServiceImpl implements TestService {
 
-  TestModel save(TestModel testModel);
+  // Fake injection from Kernel for Testing Purpose
+  @Autowired
+  private SettingService settingService;
+
+  @Autowired
+  private TestStorage    storage;
+
+  @Override
+  public TestModel save(TestModel model) {
+    if (model == null) {
+      throw new IllegalArgumentException("TestModel is mandatory");
+    }
+    if (settingService == null) {
+      // Fake exception
+      throw new IllegalStateException("SettingService is null");
+    }
+    return storage.save(model);
+  }
 
 }


### PR DESCRIPTION
This change will enhance Spring contexts Beans sharing by allowing to reference Bean Interface rather than implementation between Spring contexts and without having to define the Interface As Service with Primary annotation in Implementation.

(Resolves https://github.com/Meeds-io/meeds/issues/2469)