### PR TITLE
feat: Allow to retrieve I18N from global Site files for Spaces Navs - Meeds-io/MIPs#150

### DIFF
--- a/component/resources/src/main/java/org/exoplatform/services/resources/impl/LocaleConfigImpl.java
+++ b/component/resources/src/main/java/org/exoplatform/services/resources/impl/LocaleConfigImpl.java
@@ -29,6 +29,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import org.exoplatform.commons.utils.I18N;
 import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.services.resources.LocaleConfig;
 import org.exoplatform.services.resources.Orientation;
 import org.exoplatform.services.resources.ResourceBundleService;
@@ -137,14 +138,17 @@ public class LocaleConfigImpl implements LocaleConfig {
     }
 
     public ResourceBundle getMergeResourceBundle(String[] names) {
-        ResourceBundleService service = (ResourceBundleService) ExoContainerContext.getCurrentContainer()
+        ResourceBundleService service = ExoContainerContext.getCurrentContainer()
                 .getComponentInstanceOfType(ResourceBundleService.class);
-        ResourceBundle res = service.getResourceBundle(names, locale_);
-        return res;
+        return service.getResourceBundle(names, locale_);
     }
 
     public ResourceBundle getNavigationResourceBundle(String ownerType, String ownerId) {
-        return getResourceBundle("locale.navigation." + ownerType + "." + ownerId.replaceAll("/", "."));
+        ResourceBundle resourceBundle = getResourceBundle("locale.navigation." + ownerType + "." + ownerId.replaceAll("/", "."));
+        if (resourceBundle == null) {
+          return getResourceBundle("locale.navigation.portal.global");
+        }
+        return resourceBundle;
     }
 
     public void setInput(HttpServletRequest req) throws java.io.UnsupportedEncodingException {


### PR DESCRIPTION
Prior to this change, when creating a space navigation, the I18N expressions couldn't be used since there is no specific definition of resource bundle for newly created site. This change ensures to inherit from Global Site I18N, any site not having its own I18N file.