### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/component/common/src/main/resources/db/changelog/settings.db.changelog-1.0.0.xml
+++ b/component/common/src/main/resources/db/changelog/settings.db.changelog-1.0.0.xml
@@ -16,45 +16,51 @@
 
 <!-- SETTINGS -->
   <changeSet author="settings" id="1.0.0-1">
+    <validCheckSum>9:48559ec5f2406fe0a334f6345d798dd7</validCheckSum>
+    <validCheckSum>9:4c43b9b2eaf2207606959f7808075244</validCheckSum>
     <createTable tableName="STG_CONTEXTS">
       <column name="CONTEXT_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_STG_CONTEXT_ID"/>
       </column>
-      <column name="TYPE" type="NVARCHAR(200)">
+      <column name="TYPE" type="VARCHAR(200)">
         <constraints nullable="false"/>
       </column>
-      <column name="NAME" type="NVARCHAR(200)">
+      <column name="NAME" type="VARCHAR(200)">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="settings" id="1.0.0-2">
+    <validCheckSum>9:bf8625c64e2e100edadbb74dd599d22c</validCheckSum>
+    <validCheckSum>9:a5d4928c532a50653eb9aaa46dea5f9b</validCheckSum>
     <createTable tableName="STG_SCOPES">
       <column name="SCOPE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_STG_SCOPE_ID"/>
       </column>
-      <column name="TYPE" type="NVARCHAR(200)">
+      <column name="TYPE" type="VARCHAR(200)">
         <constraints nullable="false"/>
       </column>
-      <column name="NAME" type="NVARCHAR(200)">
+      <column name="NAME" type="VARCHAR(200)">
         <constraints />
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="settings" id="1.0.0-3">
+    <validCheckSum>9:50f827668e1508ed010da401be9f58e2</validCheckSum>
+    <validCheckSum>9:f6baa28d0ebe0b5d6b9567cf51c2c8b7</validCheckSum>
     <createTable tableName="STG_SETTINGS">
       <column name="SETTING_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_STG_SETTINGS_ID"/>
       </column>
-      <column name="NAME" type="NVARCHAR(200)">
+      <column name="NAME" type="VARCHAR(200)">
         <constraints nullable="false"/>
       </column>
       <column name="VALUE" type="CLOB"/>
@@ -66,7 +72,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -129,5 +135,11 @@
       ALTER TABLE STG_SETTINGS MODIFY COLUMN VALUE longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
     </sql>
   </changeSet>
-
+  <changeSet author="settings" id="1.0.0-15" >
+    <sql dbms="mysql">
+      ALTER TABLE STG_CONTEXTS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE STG_SCOPES CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE STG_SETTINGS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>

--- a/component/common/src/test/resources/db/changelog/test-rdbms.db.changelog.xml
+++ b/component/common/src/test/resources/db/changelog/test-rdbms.db.changelog.xml
@@ -10,7 +10,7 @@
       <column name="TEST_ID" type="BIGINT" autoIncrement="true" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_TEST_ID"/>
       </column>
-      <column name="TEXT" type="NVARCHAR(200)"/>
+      <column name="TEXT" type="VARCHAR(200)"/>
     </createTable>
   </changeSet>
 

--- a/component/file-storage/src/main/resources/db/changelog/file.db.changelog-1.0.0.xml
+++ b/component/file-storage/src/main/resources/db/changelog/file.db.changelog-1.0.0.xml
@@ -16,21 +16,25 @@
 
 
   <changeSet author="file" id="1.0.0-1">
+    <validCheckSum>9:be5195fa6ce6a38f3b27dcb925f4b0ed</validCheckSum>
+    <validCheckSum>9:74f9248853e225aa44e44f9bb95beb9c</validCheckSum>
     <createTable tableName="FILES_NAMESPACES">
       <column name="NAMESPACE_ID" type="INT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_FILES_NAMESPACES_ID"/>
       </column>
-      <column name="NAME" type="NVARCHAR(30)">
+      <column name="NAME" type="VARCHAR(30)">
         <constraints nullable="false"/>
       </column>
-      <column name="DESCRIPTION" type="NVARCHAR(100)"/>
+      <column name="DESCRIPTION" type="VARCHAR(100)"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="file" id="1.0.0-2">
+    <validCheckSum>9:a092999e7d167e9b9bb761cb89fcd8ad</validCheckSum>
+    <validCheckSum>9:1166e5b1dd1d0161dc080749b292c003</validCheckSum>
     <createTable tableName="FILES_FILES">
       <column name="FILE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_FILES_FILES_ID"/>
@@ -38,24 +42,26 @@
       <column name="NAMESPACE_ID" type="INT">
         <constraints nullable="false" foreignKeyName="FK_FILES_FILES_NAMESPACE_ID" references="FILES_NAMESPACES(NAMESPACE_ID)"/>
       </column>
-      <column name="NAME" type="NVARCHAR(550)">
+      <column name="NAME" type="VARCHAR(550)">
         <constraints nullable="false"/>
       </column>
-      <column name="MIMETYPE" type="NVARCHAR(100)"/>
+      <column name="MIMETYPE" type="VARCHAR(100)"/>
       <column name="FILE_SIZE" type="BIGINT"/>
       <column name="UPDATED_DATE" type="TIMESTAMP" defaultValueComputed="${now}">
         <constraints nullable="false"/>
       </column>
-      <column name="UPDATER" type="NVARCHAR(100)"/>
-      <column name="CHECKSUM" type="NVARCHAR(100)"/>
+      <column name="UPDATER" type="VARCHAR(100)"/>
+      <column name="CHECKSUM" type="VARCHAR(100)"/>
       <column name="DELETED" type="BOOLEAN" defaultValueBoolean="false"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="file" id="1.0.0-3">
+    <validCheckSum>9:f8b2b501b543dd5bfc14f5efabbd4a8d</validCheckSum>
+    <validCheckSum>9:bfadbe7f211d58f5c8b30fa2d226302f</validCheckSum>
     <createTable tableName="FILES_ORPHAN_FILES">
       <column name="ID" type="INT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_FILES_ORPHAN_ID"/>
@@ -66,10 +72,10 @@
       <column name="DELETED_DATE" type="TIMESTAMP" defaultValueComputed="${now}">
         <constraints nullable="false"/>
       </column>
-      <column name="CHECKSUM" type="NVARCHAR(100)"/>
+      <column name="CHECKSUM" type="VARCHAR(100)"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -86,18 +92,20 @@
   </changeSet>
 
   <changeSet author="file" id="1.0.0-7">
+    <validCheckSum>9:23baec6f374d5ca8976caec7d755b30e</validCheckSum>
+    <validCheckSum>9:64ead1b3dd8dd0680e38b1b4ccfae087</validCheckSum>
     <createTable tableName="FILES_BINARY">
       <column name="BLOB_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_FILES_BLOB_ID"/>
       </column>
-      <column name="NAME" type="NVARCHAR(100)">
+      <column name="NAME" type="VARCHAR(100)">
         <constraints nullable="false"  unique="true"/>
       </column>
       <column name="DATA" type="LONGBLOB"/>
       <column name="UPDATED_DATE" type="TIMESTAMP" defaultValueComputed="${now}"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -133,8 +141,9 @@
   </changeSet>
 
   <changeSet author="file" id="1.0.0-13">
+    <validCheckSum>9:f84b9d63cb36a643ab71f5f0de6c86fc</validCheckSum>
     <modifyDataType columnName="UPDATER"
-                    newDataType="NVARCHAR(200)"
+                    newDataType="VARCHAR(200)"
                     tableName="FILES_FILES"/>
   </changeSet>
 
@@ -144,5 +153,12 @@
     <createSequence sequenceName="SEQ_FILES_ORPHAN_FILES_ID" startValue="1" />
     <createSequence sequenceName="SEQ_FILES_BINARY_BLOB_ID" startValue="1" />
   </changeSet>
-
+  <changeSet author="file" id="1.0.0-15" >
+    <sql dbms="mysql">
+      ALTER TABLE FILES_NAMESPACES CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE FILES_FILES CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE FILES_ORPHAN_FILES CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE FILES_BINARY CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>

--- a/component/identity/src/main/resources/db/changelog/idm.queue.db.changelog-1.0.0.xml
+++ b/component/identity/src/main/resources/db/changelog/idm.queue.db.changelog-1.0.0.xml
@@ -10,11 +10,13 @@
   <property name="autoIncrement" value="false" dbms="oracle,postgresql"/>
 
   <changeSet author="idmQueue" id="1.0.0-1">
+    <validCheckSum>9:c2a458a9756c2e843d0eec147955d740</validCheckSum>
+    <validCheckSum>9:9a368cbaa9d8b54a9ea08d00cfa54fba</validCheckSum>
     <createTable tableName="IDM_QUEUE">
       <column name="IDM_QUEUE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_IDM_QUEUE_ID"/>
       </column>
-      <column name="ENTITY_ID" type="NVARCHAR(200)">
+      <column name="ENTITY_ID" type="VARCHAR(200)">
         <constraints nullable="false"/>
       </column>
       <column name="ENTITY_TYPE" type="INT">
@@ -34,7 +36,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -55,4 +57,9 @@
     <createSequence sequenceName="SEQ_IDM_QUEUE_ID" startValue="1"/>
   </changeSet>
 
+  <changeSet author="idmQueue" id="1.0.0-5" >
+    <sql dbms="mysql">
+      ALTER TABLE IDM_QUEUE CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>

--- a/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
+++ b/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
@@ -10,21 +10,23 @@
 
   <!-- Site -->
   <changeSet author="portal" id="1.0.0-6">
+    <validCheckSum>9:0fd6de2c90ea745a8d75f49d98a1ef4d</validCheckSum>
+    <validCheckSum>9:ca5439fc665d690f25b24fa0979a696d</validCheckSum>
     <createTable tableName="PORTAL_SITES">
       <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_SITE"/>
       </column>
       <column name="TYPE" type="INT"/>
-      <column name="NAME" type="NVARCHAR(200)"/>
+      <column name="NAME" type="VARCHAR(200)"/>
       <column name="LOCALE" type="VARCHAR(20)" />
-      <column name="SKIN" type="NVARCHAR(200)"/>
-      <column name="LABEL" type="NVARCHAR(200)"/>
+      <column name="SKIN" type="VARCHAR(200)"/>
+      <column name="LABEL" type="VARCHAR(200)"/>
       <column name="DESCRIPTION" type="LONGTEXT" />
       <column name="PROPERTIES" type="LONGTEXT"/>
       <column name="SITE_BODY" type="LONGTEXT" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   <changeSet author="portal" id="1.0.0-7" dbms="oracle,postgresql">
@@ -46,14 +48,14 @@
         <constraints nullable="false"/>
       </column>
       <column name="SHOW_MAX_WINDOW" type="BOOLEAN" defaultValueBoolean="false" />
-      <column name="DISPLAY_NAME" type="NVARCHAR(200)"/>
-      <column name="NAME" type="NVARCHAR(200)"/>
+      <column name="DISPLAY_NAME" type="VARCHAR(200)"/>
+      <column name="NAME" type="VARCHAR(200)"/>
       <column name="DESCRIPTION" type="LONGTEXT" />
-      <column name="FACTORY_ID" type="NVARCHAR(200)"/>
+      <column name="FACTORY_ID" type="VARCHAR(200)"/>
       <column name="PAGE_BODY" type="LONGTEXT" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   <changeSet author="portal" id="1.0.0-10" dbms="oracle,postgresql">
@@ -70,13 +72,15 @@
 
   <!-- Navigation -->
   <changeSet author="portal" id="1.0.0-12">
+    <validCheckSum>9:8aeda2e99a606a9a6060ec9de9379008</validCheckSum>
+    <validCheckSum>9:0e6d5d9ed955f12f95a691aca1039022</validCheckSum>
     <createTable tableName="PORTAL_NAVIGATION_NODES">
       <column name="NODE_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_NAVIGATION_NODE"/>
       </column>
-      <column name="NAME" type="NVARCHAR(200)"/>
-      <column name="LABEL" type="NVARCHAR(200)"/>
-      <column name="ICON" type="NVARCHAR(200)"/>
+      <column name="NAME" type="VARCHAR(200)"/>
+      <column name="LABEL" type="VARCHAR(200)"/>
+      <column name="ICON" type="VARCHAR(200)"/>
       <column name="START_TIME" type="BIGINT"/>
       <column name="END_TIME" type="BIGINT"/>
       <column name="VISIBILITY" type="INT"/>
@@ -89,7 +93,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   <changeSet author="portal" id="1.0.0-13" dbms="oracle,postgresql">
@@ -106,6 +110,7 @@
                              onDelete="CASCADE" onUpdate="NO ACTION" />
   </changeSet>
   <changeSet author="portal" id="1.0.0-15">
+    <validCheckSum>9:e6f3aabe1e7a0c508b7ebf5d9f164c55</validCheckSum>
     <createTable tableName="PORTAL_NAVIGATIONS">
       <column name="NAVIGATION_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_NAVIGATION"/>
@@ -119,7 +124,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   <changeSet author="portal" id="1.0.0-16" dbms="oracle,postgresql">
@@ -139,16 +144,18 @@
 
 
   <changeSet author="portal" id="1.0.0-18">
+    <validCheckSum>9:b16621d25e0354200ab842a7da7c7b99</validCheckSum>
+    <validCheckSum>9:3d1f47a8d10ef6d656ca5d77b4dfdbd2</validCheckSum>
     <createTable tableName="PORTAL_DESCRIPTIONS">
       <column name="DESCRIPTION_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_DESCRIPTIONS"/>
       </column>
       <column name="REF_ID" type="VARCHAR(200)"/>
-      <column name="NAME" type="NVARCHAR(200)"/>
-      <column name="DESCRIPTION" type="NVARCHAR(200)"/>
+      <column name="NAME" type="VARCHAR(200)"/>
+      <column name="DESCRIPTION" type="VARCHAR(200)"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   <changeSet author="portal" id="1.0.0-19" dbms="oracle,postgresql">
@@ -156,14 +163,16 @@
   </changeSet>
 
   <changeSet author="portal" id="1.0.0-20">
+    <validCheckSum>9:13cbfb463ac0a5011b516dcb47d77abf</validCheckSum>
+    <validCheckSum>9:87c54ae055461a765c99abcfb400cd1d</validCheckSum>
     <createTable tableName="PORTAL_DESCRIPTION_LOCALIZED">
       <column name="DESCRIPTION_ID" type="BIGINT"/>
       <column name="LOCALE" type="VARCHAR(20)"/>
-      <column name="NAME" type="NVARCHAR(200)"/>
-      <column name="DESCRIPTION" type="NVARCHAR(200)"/>
+      <column name="NAME" type="VARCHAR(200)"/>
+      <column name="DESCRIPTION" type="VARCHAR(200)"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   <changeSet author="portal" id="1.0.0-21">
@@ -179,16 +188,18 @@
 
   <!-- Portal/Page Layout -->
   <changeSet author="portal" id="1.0.0-22">
+    <validCheckSum>9:87976b2625260b3a49eee9f49751f974</validCheckSum>
+    <validCheckSum>9:498e2093e53a289fa221429bad89fd44</validCheckSum>
     <createTable tableName="PORTAL_CONTAINERS">
       <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_CONTAINER"/>
       </column>
       <column name="WEBUI_ID" type="VARCHAR(200)"/>
-      <column name="NAME" type="NVARCHAR(200)"/>
-      <column name="ICON" type="NVARCHAR(200)"/>
-      <column name="TEMPLATE" type="NVARCHAR(500)"/>
-      <column name="FACTORY_ID" type="NVARCHAR(200)"/>
-      <column name="TITLE" type="NVARCHAR(200)"/>
+      <column name="NAME" type="VARCHAR(200)"/>
+      <column name="ICON" type="VARCHAR(200)"/>
+      <column name="TEMPLATE" type="VARCHAR(500)"/>
+      <column name="FACTORY_ID" type="VARCHAR(200)"/>
+      <column name="TITLE" type="VARCHAR(200)"/>
       <column name="DESCRIPTION" type="LONGTEXT" />
       <column name="WIDTH" type="VARCHAR(20)"/>
       <column name="HEIGHT" type="VARCHAR(20)"/>
@@ -196,7 +207,7 @@
       <column name="CONTAINER_BODY" type="LONGTEXT" />
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
 
@@ -206,22 +217,22 @@
       <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_WINDOW"/>
       </column>
-      <column name="TITLE" type="NVARCHAR(200)"/>
-      <column name="ICON" type="NVARCHAR(200)"/>
+      <column name="TITLE" type="VARCHAR(200)"/>
+      <column name="ICON" type="VARCHAR(200)"/>
       <column name="DESCRIPTION" type="LONGTEXT" />
       <column name="SHOW_INFO_BAR" type="BOOLEAN" defaultValueBoolean="false" />
       <column name="SHOW_APP_STATE" type="BOOLEAN" defaultValueBoolean="false" />
       <column name="SHOW_APP_MODE" type="BOOLEAN" defaultValueBoolean="false" />
-      <column name="THEME" type="NVARCHAR(200)"/>
+      <column name="THEME" type="VARCHAR(200)"/>
       <column name="WIDTH" type="VARCHAR(20)"/>
       <column name="HEIGHT" type="VARCHAR(20)"/>
       <column name="PROPERTIES" type="LONGTEXT" />
       <column name="APP_TYPE" type="INT"/>
-      <column name="CONTENT_ID" type="NVARCHAR(200)"/>
+      <column name="CONTENT_ID" type="VARCHAR(200)"/>
       <column name="CUSTOMIZATION" type="BLOB"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   <changeSet author="portal" id="1.0.0-24" dbms="oracle,postgresql">
@@ -231,6 +242,8 @@
 
   <!-- Permission -->
   <changeSet author="portal" id="1.0.0-25">
+    <validCheckSum>9:de8d0b2342bb3677a596c41c009e2dd8</validCheckSum>
+    <validCheckSum>9:59c295f4ff08bdafa6a0b8130c0a2922</validCheckSum>
     <createTable tableName="PORTAL_PERMISSIONS">
       <column name="PERMISSION_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_PERMISSIONS"/>
@@ -241,11 +254,11 @@
       <column name="REF_ID" type="BIGINT">
         <constraints nullable="false"/>
       </column>
-      <column name="PERMISSION" type="NVARCHAR(200)"/>
+      <column name="PERMISSION" type="VARCHAR(200)"/>
       <column name="TYPE" type="INT"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   <changeSet author="portal" id="1.0.0-26" dbms="oracle,postgresql">
@@ -344,19 +357,19 @@
     </createIndex>
     <createIndex indexName="IDX_PORTAL_SITES_NAME_01"
                  tableName="PORTAL_SITES">
-      <column name="NAME" type="NVARCHAR(200)"/>
+      <column name="NAME" type="VARCHAR(200)"/>
     </createIndex>
     <createIndex indexName="IDX_PORTAL_LOCALE_01"
                  tableName="PORTAL_SITES">
-      <column name="LOCALE" type="NVARCHAR(200)"/>
+      <column name="LOCALE" type="VARCHAR(200)"/>
     </createIndex>
     <createIndex indexName="IDX_PORTAL_SKIN_01"
                  tableName="PORTAL_SITES">
-      <column name="SKIN" type="NVARCHAR(200)"/>
+      <column name="SKIN" type="VARCHAR(200)"/>
     </createIndex>
     <createIndex indexName="IDX_PORTAL_LABEL_01"
                  tableName="PORTAL_SITES">
-      <column name="LABEL" type="NVARCHAR(200)"/>
+      <column name="LABEL" type="VARCHAR(200)"/>
     </createIndex>
   </changeSet>
 
@@ -392,8 +405,9 @@
   </changeSet>
 
   <changeSet author="portal" id="1.0.0-40">
+    <validCheckSum>9:105d4c3e63f2d4389d80ee60b93250ee</validCheckSum>
     <addColumn tableName="PORTAL_PAGES">
-      <column name="PROFILES" type="NVARCHAR(2000)" />
+      <column name="PROFILES" type="VARCHAR(2000)" />
     </addColumn>
   </changeSet>
 
@@ -408,7 +422,8 @@
   </changeSet>
 
   <changeSet author="portal" id="1.0.0-43">
-    <modifyDataType tableName="PORTAL_CONTAINERS" columnName="WIDTH" newDataType="NVARCHAR(200)" />
+    <validCheckSum>9:065c37bd73ac0a726bdd12c833b4784e</validCheckSum>
+    <modifyDataType tableName="PORTAL_CONTAINERS" columnName="WIDTH" newDataType="VARCHAR(200)" />
   </changeSet>
 
   <changeSet author="portal" id="1.0.0-44" dbms="mysql">
@@ -464,5 +479,17 @@
       ALTER TABLE PORTAL_WINDOWS MODIFY COLUMN PROPERTIES longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
     </sql>
   </changeSet>
-
+  <changeSet author="portal" id="1.0.0-53">
+    <sql dbms="mysql">
+      ALTER TABLE PORTAL_SITES CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE PORTAL_PAGES CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE PORTAL_NAVIGATION_NODES CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE PORTAL_NAVIGATIONS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE PORTAL_DESCRIPTIONS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE PORTAL_DESCRIPTION_LOCALIZED CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE PORTAL_CONTAINERS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE PORTAL_WINDOWS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE PORTAL_PERMISSIONS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>

--- a/component/web/security/src/main/resources/db/changelog/gatein-token.db.changelog-1.0.0.xml
+++ b/component/web/security/src/main/resources/db/changelog/gatein-token.db.changelog-1.0.0.xml
@@ -10,20 +10,22 @@
 
   <!-- Application Registry -->
   <changeSet author="gatein-token" id="1.0.0-1">
+    <validCheckSum>9:e84ad7ae185276a1cb8def7985a4e026</validCheckSum>
+    <validCheckSum>9:e91e82566aefa2b220f5ad3a825ba71f</validCheckSum>
     <createTable tableName="PORTAL_TOKENS">
       <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_PORTAL_TOKENS"/>
       </column>
-      <column name="TOKEN_ID" type="NVARCHAR(200)">
+      <column name="TOKEN_ID" type="VARCHAR(200)">
         <constraints nullable="false" unique="true" uniqueConstraintName="UK_GATEIN_TOKEN_ID"/>
       </column>
-      <column name="TOKEN_HASH" type="NVARCHAR(200)"/>
-      <column name="USERNAME" type="NVARCHAR(200)" />
-      <column name="PASSWORD" type="NVARCHAR(200)"/>
+      <column name="TOKEN_HASH" type="VARCHAR(200)"/>
+      <column name="USERNAME" type="VARCHAR(200)" />
+      <column name="PASSWORD" type="VARCHAR(200)"/>
       <column name="EXPIRATION_TIME" type="BIGINT"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci" />
     </modifySql>
   </changeSet>
   <changeSet author="gatein-token" id="1.0.0-2" dbms="oracle,postgresql">
@@ -38,8 +40,14 @@
     </addColumn>
   </changeSet>
   <changeSet author="gatein-token" id="1.0.0-5">
+    <validCheckSum>9:d076170f60a6b5465b1b33dde1c98ecf</validCheckSum>
     <modifyDataType tableName="PORTAL_TOKENS"
                     columnName="PASSWORD"
-                    newDataType="NVARCHAR(500)"/>
+                    newDataType="VARCHAR(500)"/>
+  </changeSet>
+  <changeSet author="gatein-token" id="1.0.0-6">
+    <sql dbms="mysql">
+      ALTER TABLE PORTAL_TOKENS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
   </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR. This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
