### PR TITLE
fix: Fix computing url redirection for global site navigation nodes - EXO-75516 - Meeds-io/MIPs#161

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserPortalImpl.java
@@ -411,7 +411,7 @@ public class UserPortalImpl implements UserPortal {
         ret.owner.filterConfig.path = null;
         if (!segments[segments.length - 1].equals(ret.getName())) {
           globalUserNode = getGlobalUserNode(filterConfig, navigation.getKey(), segments);
-          if (globalUserNode != null && segments[segments.length - 1].equals(globalUserNode.getName())) {
+          if (globalUserNode != null) {
             ret = globalUserNode;
           }
         }


### PR DESCRIPTION
Prior to this change, when fetching a site navigation node from the global site navigation, if the current navigation URI node name doesn't match the fetched global site navigation node, the site navigation home is returned. After this change, whenever a global site navigation node is fetched, we should return it regardless the current navigation URI node name.