### PR TITLE
fix: Fix NPE when requesting WebUI the first time - MEED-7941 - Meeds-io/meeds#2673

### DIFF
--- a/webui/src/main/java/org/exoplatform/portal/application/PortalRequestHandler.java
+++ b/webui/src/main/java/org/exoplatform/portal/application/PortalRequestHandler.java
@@ -168,6 +168,7 @@ public class PortalRequestHandler extends WebRequestHandler {
                                                             requestSiteName,
                                                             requestPath,
                                                             requestLocale);
+    RequestContext.setCurrentInstance(context);
     try {
       PortalConfig persistentPortalConfig = context.getDynamicPortalConfig();
       if (context.getUserPortalConfig() == null) {
@@ -196,7 +197,13 @@ public class PortalRequestHandler extends WebRequestHandler {
         return true;
       }
     } finally {
-      context.onRequestEnd();
+      try {
+        context.onRequestEnd();
+      } finally {
+        // To avoid memory leak, the ThreadLocal instances have to be purged all
+        // time, even if an error occurs
+        RequestContext.setCurrentInstance(null);
+      }
     }
   }
 
@@ -226,9 +233,8 @@ public class PortalRequestHandler extends WebRequestHandler {
    */
   @SuppressWarnings("unchecked")
   protected void processRequest(PortalRequestContext context, PortalApplication app) throws Exception {
-    RequestContext.setCurrentInstance(context);
-    createPortalRequestInstance(context);
     List<ApplicationLifecycle> lifecycles = app.getApplicationLifecycle();
+    createPortalRequestInstance(context);
     try {
       if (context.getResponse() instanceof PortalHttpServletResponseWrapper responseWrapper) {
         responseWrapper.setWrapMethods(true);
@@ -286,7 +292,6 @@ public class PortalRequestHandler extends WebRequestHandler {
       } finally {
         // To avoid memory leak, the ThreadLocal instances have to be purged all
         // time, even if an error occurs
-        RequestContext.setCurrentInstance(null);
         PortalRequestImpl.clearInstance();
       }
     }

--- a/webui/src/main/java/org/exoplatform/webui/application/portlet/PortletApplication.java
+++ b/webui/src/main/java/org/exoplatform/webui/application/portlet/PortletApplication.java
@@ -38,6 +38,7 @@ import javax.portlet.ResourceResponse;
 
 import org.exoplatform.commons.utils.PortalPrinter;
 import org.exoplatform.commons.utils.Safe;
+import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.resolver.ApplicationResourceResolver;
 import org.exoplatform.resolver.PortletResourceResolver;
 import org.exoplatform.services.log.ExoLogger;
@@ -204,33 +205,33 @@ public class PortletApplication extends WebuiApplication {
      * serveResource of UIPortletApplication is called 7) Finally, the method onEndRequest() is called on every
      * ApplicationLifecycle referenced in the portlet configuration XML file and the parent WebuiRequestContext is restored
      */
+    @SuppressWarnings("unchecked")
     public void serveResource(ResourceRequest req, ResourceResponse res) throws Exception {
-        WebuiRequestContext parentAppRequestContext = WebuiRequestContext.getCurrentInstance();
-        PortletRequestContext context = createRequestContext(req, res, parentAppRequestContext);
-        WebuiRequestContext.setCurrentInstance(context);
-        try {
-            for (ApplicationLifecycle<RequestContext> lifecycle : getApplicationLifecycle()) {
-                lifecycle.onStartRequest(this, context);
-            }
-            StateManager sm = getStateManager();
-            UIApplication uiApp = sm.restoreUIRootComponent(context);
-            context.setUIApplication(uiApp);
-            if (uiApp instanceof UIPortletApplication) {
-                ((UIPortletApplication) uiApp).serveResource(context);
-            }
-
-            // Store ui root
-            sm.storeUIRootComponent(context);
-        } finally {
-            try {
-                for (ApplicationLifecycle<RequestContext> lifecycle : getApplicationLifecycle()) {
-                    lifecycle.onEndRequest(this, context);
-                }
-            } catch (Exception exception) {
-                log.error("Error while trying to call onEndRequest of the portlet ApplicationLifecycle", exception);
-            }
-            WebuiRequestContext.setCurrentInstance(parentAppRequestContext);
+      PortalRequestContext parentAppRequestContext = PortalRequestContext.getCurrentInstance();
+      PortletRequestContext context = createRequestContext(req, res, parentAppRequestContext);
+      RequestContext.setCurrentInstance(context);
+      try {
+        for (ApplicationLifecycle<RequestContext> lifecycle : getApplicationLifecycle()) {
+          lifecycle.onStartRequest(this, context);
         }
+        StateManager sm = getStateManager();
+        UIApplication uiApp = sm.restoreUIRootComponent(context);
+        context.setUIApplication(uiApp);
+        if (uiApp instanceof UIPortletApplication uiPortlet) {
+          uiPortlet.serveResource(context);
+        }
+        // Store ui root
+        sm.storeUIRootComponent(context);
+      } finally {
+        try {
+          for (ApplicationLifecycle<RequestContext> lifecycle : getApplicationLifecycle()) {
+            lifecycle.onEndRequest(this, context);
+          }
+        } catch (Exception exception) {
+          log.error("Error while trying to call onEndRequest of the portlet ApplicationLifecycle", exception);
+        }
+        RequestContext.setCurrentInstance(parentAppRequestContext);
+      }
     }
 
     /**


### PR DESCRIPTION
Prior to this change, when requesting WebUI for the first time, an NPE is raised. This is due to the fact that the PortalRequestContext isn't set in its ThreadLocal right away after its instanciation. This change ensures to set it and clear it in the right `try/finally` block.

Resolves Meeds-io/meeds#2673