### PR TITLE
fix: Missing double quote around component class - EXO-76079

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITableColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITableColumnContainer.gtmpl
@@ -13,7 +13,7 @@
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
 <div
-  class="UIContainer UITableColumnContainer <%=uiComponentClass%>  id="${uicomponent.id}">
+  class="UIContainer UITableColumnContainer <%=uiComponentClass%>" id="${uicomponent.id}">
   <div class="NormalContainerBlock UIComponentBlock">
     <div class="VIEW-CONTAINER VIEW-BLOCK">
       <div>


### PR DESCRIPTION
This commit add a missing double quote in the template which generate DOM error on page display

Resolves https://github.com/Meeds-io/meeds/issues/2690