### PR TITLE
fix: Fix Missing Quote in Deprecated gtmpl files - EXO-76079

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveColumnGroupContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveColumnGroupContainer.gtmpl
@@ -15,7 +15,7 @@
 		uicomponent.setId(componentId.substring("UIContainer-".length()));
 	}
 %>
-<div class="UIContainer UIResponsiveColumnGroupContainer <%=uiComponentClass%> id="${uicomponent.id}" ${cssStyle}>
+<div class="UIContainer UIResponsiveColumnGroupContainer <%=uiComponentClass%>" id="${uicomponent.id}" ${cssStyle}>
 	<div class="NormalContainerBlock UIComponentBlock">
 		<div class="VIEW-CONTAINER VIEW-BLOCK">
       <div class="UIIntermediateContainer">

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableBigSmallColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableBigSmallColumnContainer.gtmpl
@@ -13,7 +13,7 @@
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
 <div
-  class="UIContainer UITableColumnContainer UIResponsiveTable66ColumnContainer <%=uiComponentClass%>  id="${uicomponent.id}">
+  class="UIContainer UITableColumnContainer UIResponsiveTable66ColumnContainer <%=uiComponentClass%>"  id="${uicomponent.id}">
   <div class="NormalContainerBlock UIComponentBlock">
     <div class="VIEW-CONTAINER VIEW-BLOCK">
       <div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableColumnContainer.gtmpl
@@ -13,7 +13,7 @@
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
 <div
-  class="UIContainer UITableColumnContainer UIResponsiveTableColumnContainer <%=uiComponentClass%>  id="${uicomponent.id}">
+  class="UIContainer UITableColumnContainer UIResponsiveTableColumnContainer <%=uiComponentClass%>"  id="${uicomponent.id}">
   <div class="NormalContainerBlock UIComponentBlock">
     <div class="VIEW-CONTAINER VIEW-BLOCK">
       <div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableSmallBigColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableSmallBigColumnContainer.gtmpl
@@ -13,7 +13,7 @@
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
 <div
-  class="UIContainer UITableColumnContainer UIResponsiveTable33ColumnContainer <%=uiComponentClass%>  id="${uicomponent.id}">
+  class="UIContainer UITableColumnContainer UIResponsiveTable33ColumnContainer <%=uiComponentClass%>"  id="${uicomponent.id}">
   <div class="NormalContainerBlock UIComponentBlock">
     <div class="VIEW-CONTAINER VIEW-BLOCK">
       <div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableThreeColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableThreeColumnContainer.gtmpl
@@ -13,7 +13,7 @@
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
 <div
-  class="UIContainer UITableColumnContainer UIResponsiveTableThreeColumnContainer <%=uiComponentClass%>  id="${uicomponent.id}">
+  class="UIContainer UITableColumnContainer UIResponsiveTableThreeColumnContainer <%=uiComponentClass%>"  id="${uicomponent.id}">
   <div class="NormalContainerBlock UIComponentBlock">
     <div class="VIEW-CONTAINER VIEW-BLOCK">
       <div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableTwoColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIResponsiveTableTwoColumnContainer.gtmpl
@@ -13,7 +13,7 @@
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
 <div
-  class="UIContainer UITableColumnContainer UIResponsiveTableTwoColumnContainer <%=uiComponentClass%>  id="${uicomponent.id}">
+  class="UIContainer UITableColumnContainer UIResponsiveTableTwoColumnContainer <%=uiComponentClass%>"  id="${uicomponent.id}">
   <div class="NormalContainerBlock UIComponentBlock">
     <div class="VIEW-CONTAINER VIEW-BLOCK">
       <div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UISwitchingContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UISwitchingContainer.gtmpl
@@ -15,7 +15,7 @@
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
 <div
-  class="UIContainer UITableColumnContainer UISwitchingContainer <%=uiComponentClass%>  id="${uicomponent.id}">
+  class="UIContainer UITableColumnContainer UISwitchingContainer <%=uiComponentClass%>"  id="${uicomponent.id}">
   <div class="NormalContainerBlock UIComponentBlock">
     <div class="VIEW-CONTAINER VIEW-BLOCK">
       <div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITableAutofitColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITableAutofitColumnContainer.gtmpl
@@ -13,7 +13,7 @@
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
 <div
-  class="UIContainer UITableColumnContainer <%=uiComponentClass%>  id="${uicomponent.id}">
+  class="UIContainer UITableColumnContainer <%=uiComponentClass%>"  id="${uicomponent.id}">
   <div class="NormalContainerBlock UIComponentBlock">
     <div class="VIEW-CONTAINER VIEW-BLOCK">
       <div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITableColumnContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITableColumnContainer.gtmpl
@@ -13,7 +13,7 @@
   String uiComponentClass = uicomponent.getCssClass() == null ? "" : uicomponent.getCssClass();
 %>
 <div
-  class="UIContainer UITableColumnContainer <%=uiComponentClass%>  id="${uicomponent.id}">
+  class="UIContainer UITableColumnContainer <%=uiComponentClass%>"  id="${uicomponent.id}">
   <div class="NormalContainerBlock UIComponentBlock">
     <div class="VIEW-CONTAINER VIEW-BLOCK">
       <div>


### PR DESCRIPTION
Prior to this change, the retrieved DOM from legacy gtmpl files is missing a double quote at the end of HTML class attribute definition. This change will fix it by introducing the missing double quote.

Resolves Meeds-io/meeds#2690

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
