### PR TITLE
fix: Fix ACL check for Page Access in WebUI - MEED-7989 - Meeds-io/meeds#2698

### DIFF
--- a/webui/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
+++ b/webui/src/main/java/org/exoplatform/portal/application/PortalRequestContext.java
@@ -138,6 +138,10 @@ public class PortalRequestContext extends WebuiRequestContext {
   /** . */
   private final SiteKey                    siteKey;
 
+  /** . */
+  @Getter
+  private final PortalConfig               portalConfig;
+
   /** The locale from the request. */
   @Getter
   private final Locale                     requestLocale;
@@ -283,6 +287,7 @@ public class PortalRequestContext extends WebuiRequestContext {
     }
 
     this.siteKey = new SiteKey(SiteType.valueOf(requestSiteType.toUpperCase()), requestSiteName);
+    this.portalConfig = layoutService.getPortalConfig(this.siteKey);
     this.nodePath = requestPath;
     this.requestLocale = requestLocale;
 

--- a/webui/src/main/java/org/exoplatform/portal/webui/page/UIPage.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/page/UIPage.java
@@ -24,9 +24,13 @@ import java.util.List;
 
 import javax.portlet.WindowState;
 
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.webui.application.UIPortlet;
 import org.exoplatform.portal.webui.container.UIContainer;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.core.UIComponent;
 
@@ -84,6 +88,13 @@ public class UIPage extends UIContainer {
   @Deprecated
   public String getOwnerId() {
     return getSiteKey().getName();
+  }
+
+  @Override
+  public boolean hasAccessPermission() {
+    return ExoContainerContext.getService(UserACL.class)
+                              .hasAccessPermission(PortalRequestContext.getCurrentInstance().getPage(),
+                                                   ConversationState.getCurrent().getIdentity());
   }
 
   private List<UIPortlet> recursivelyFindUIPortlets(org.exoplatform.webui.core.UIContainer uiContainer) {

--- a/webui/src/main/java/org/exoplatform/portal/webui/portal/UIPortal.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/portal/UIPortal.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.ObjectUtils;
 
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.model.Page;
 import org.exoplatform.portal.config.model.Properties;
 import org.exoplatform.portal.mop.SiteKey;
@@ -42,6 +43,7 @@ import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.listener.Asynchronous;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.web.application.RequestContext;
 import org.exoplatform.web.login.LoginUtils;
 import org.exoplatform.web.login.LogoutControl;
@@ -59,13 +61,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.Setter;
 
-@ComponentConfig(
-                 lifecycle = UIPortalLifecycle.class,
-                 template = "system:/groovy/portal/webui/page/UIPortal.gtmpl",
-                 events = {
-                            @EventConfig(listeners = UIPortal.LogoutActionListener.class,
-                                         csrfCheck = false),
-                 })
+@ComponentConfig(lifecycle = UIPortalLifecycle.class, template = "system:/groovy/portal/webui/page/UIPortal.gtmpl", events = {
+  @EventConfig(listeners = UIPortal.LogoutActionListener.class, csrfCheck = false),
+})
 public class UIPortal extends UIContainer {
 
   @Getter
@@ -107,6 +105,13 @@ public class UIPortal extends UIContainer {
     // Listen to storage to update cached pages when updated
     ListenerService listenerService = ExoContainerContext.getService(ListenerService.class);
     listenerService.addListener(LayoutService.PAGE_UPDATED, new RefreshUIPageListener());
+  }
+
+  @Override
+  public boolean hasAccessPermission() {
+    return ExoContainerContext.getService(UserACL.class)
+                              .hasAccessPermission(PortalRequestContext.getCurrentInstance().getPortalConfig(),
+                                                   ConversationState.getCurrent().getIdentity());
   }
 
   public SiteType getSiteType() {


### PR DESCRIPTION
Prior to this change, the ACL check on page access was made using a permission check on page access permissions instead of using the centralized algorithm usin `UserACL.hasAccessPermission(Page, Identity)`. This change will ensure to make ACL checks using centralized methods on UserACL Service to allow override behavior using Social Module Business Logic for Spaces to include coordinators as super administrators of spaces even when not member of the space.