### PR TITLE
fix: Avoid flushing IDM Hibernate session on read operations - MEED-8013 - Meeds-io/meeds#2662

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
@@ -125,9 +125,10 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         if(g != null) {
              throw new Exception("Group " + child.getGroupName() + " is already exist");
         }
-        org.picketlink.idm.api.Group childGroup = persistGroup(child);
 
+        org.picketlink.idm.api.Group childGroup = null;
         try {
+            childGroup = persistGroup(child);
             if (parentGroup != null) {
                 getIdentitySession().getRelationshipManager().associateGroups(parentGroup, childGroup);
 
@@ -151,6 +152,8 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
                 handleException("Cannot deassociate groups: ", e1);
         	}
           throw e;
+        } finally {
+          orgService.flush();
         }
 
         if (broadcast) {
@@ -221,6 +224,8 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
                                                  .disassociateGroups(jbidParentOriginGroup, List.of(jbidGroupToMove));
         } catch (Exception e) {
             handleException("Cannot dissociate: " + plGroupToMoveName + " to "+plParentOriginGroupName+"; ", e);
+        } finally {
+          orgService.flush();
         }
         //use RelationshiManager.associate
         try {
@@ -228,6 +233,8 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
                                 .associateGroups(jbidParentTargetGroup,jbidGroupToMove);
         } catch (Exception e) {
             handleException("Cannot associate: " + plGroupToMoveName + " to "+plParentTargetGroupName+"; ", e);
+        } finally {
+          orgService.flush();
         }
 
     }
@@ -256,9 +263,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         String plGroupName = getPLIDMGroupName(group.getGroupName());
 
         try {
-
-            orgService.flush();
-
             jbidGroup = getIdentitySession().getPersistenceManager().findGroup(plGroupName,
                     orgService.getConfiguration().getGroupType(group.getParentId()));
         } catch (Exception e) {
@@ -275,13 +279,13 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
 
         //Check: Has this group got any child?
         Collection<org.picketlink.idm.api.Group> oneLevelChilds = null;
-        orgService.flush();
         try {
             oneLevelChilds = getIdentitySession().getRelationshipManager()
                     .findAssociatedGroups(jbidGroup, null, true, false);
         } catch (Exception e) {
             handleException("Cannot clear group relationships: " + plGroupName + "; ", e);
         } finally {
+            orgService.flush();
             if(oneLevelChilds != null && oneLevelChilds.size() > 0) {
                 throw new IllegalStateException("Group " + group.getGroupName() + " has at least one child group");
             }
@@ -293,23 +297,7 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         }
 
         try {
-            /*orgService.flush();
-
-            Collection<org.picketlink.idm.api.Group> oneLevelChilds = getIdentitySession().getRelationshipManager()
-                    .findAssociatedGroups(jbidGroup, null, true, false);
-
-            Collection<org.picketlink.idm.api.Group> allChilds = getIdentitySession().getRelationshipManager()
-                    .findAssociatedGroups(jbidGroup, null, true, true);
-
-            getIdentitySession().getRelationshipManager().disassociateGroups(jbidGroup, oneLevelChilds);
-
-            for (org.picketlink.idm.api.Group child : allChilds) {
-                // TODO: impl force in IDM
-                getIdentitySession().getPersistenceManager().removeGroup(child, true);
-            }*/
-
             // Obtain parents
-
             Collection<org.picketlink.idm.api.Group> parents = getIdentitySession().getRelationshipManager()
                     .findAssociatedGroups(jbidGroup, null, false, false);
 
@@ -323,6 +311,8 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
 
         } catch (Exception e) {
             handleException("Cannot clear group relationships: " + plGroupName + "; ", e);
+        } finally {
+          orgService.flush();
         }
 
         try {
@@ -330,6 +320,8 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
 
         } catch (Exception e) {
             handleException("Cannot remove group: " + plGroupName + "; ", e);
+        } finally {
+          orgService.flush();
         }
 
         if (broadcast) {
@@ -346,8 +338,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         Collection<Role> allRoles = new HashSet<Role>();
 
         try {
-            orgService.flush();
-
             allRoles = getIdentitySession().getRoleManager().findRoles(userName, membershipType);
         } catch (Exception e) {
             handleException("Identity operation error: ", e);
@@ -368,8 +358,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
             Collection<org.picketlink.idm.api.Group> groups = new HashSet<org.picketlink.idm.api.Group>();
 
             try {
-                orgService.flush();
-
                 groups = getIdentitySession().getRelationshipManager().findAssociatedGroups(userName, null);
             } catch (Exception e) {
                 handleException("Identity operation error: ", e);
@@ -401,8 +389,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         Collection<Role> roles = new HashSet<Role>();
 
         try {
-            orgService.flush();
-
             roles.addAll(getIdentitySession().getRoleManager().findRoles(userName, membershipType));
 
             roles.addAll(getIdentitySession().getRoleManager().findRoles(userName, MembershipTypeHandler.ANY_MEMBERSHIP_TYPE));
@@ -425,8 +411,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
             Collection<org.picketlink.idm.api.Group> groups = new HashSet<org.picketlink.idm.api.Group>();
 
             try {
-                orgService.flush();
-
                 groups = getIdentitySession().getRelationshipManager().findAssociatedGroups(userName, null);
             } catch (Exception e) {
                 handleException("Identity operation error: ", e);
@@ -523,8 +507,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         Collection<org.picketlink.idm.api.Group> allGroups = new HashSet<org.picketlink.idm.api.Group>();
 
         try {
-            orgService.flush();
-
             allGroups = getIdentitySession().getRelationshipManager().findRelatedGroups(user, null, null);
         } catch (Exception e) {
             // TODO:
@@ -567,7 +549,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
       }
       Collection<org.picketlink.idm.api.Group> allGroups = new HashSet<>();
       try {
-        orgService.flush();
         allGroups = getIdentitySession().getRelationshipManager().findRelatedGroups(user, groupType, identitySearchCriteria);
       } catch (Exception e) {
         // TODO:
@@ -598,9 +579,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         Set<org.picketlink.idm.api.Group> plGroups = new HashSet<>();
 
         try {
-
-            orgService.flush();
-
             plGroups.addAll(getIdentitySession().getRelationshipManager()
                     .findAssociatedGroups(getRootGroup(), null, true, true));
         } catch (Exception e) {
@@ -690,7 +668,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         return Collections.emptyList();
       }
       Collection<org.picketlink.idm.api.Group> allGroups = new HashSet<>();
-      orgService.flush();
       List<String> excludedGroupsTypes = excludedGroupsParent.stream()
                                                              .map(parent -> orgService.getConfiguration().getGroupType(parent))
                                                              .collect(Collectors.toList());
@@ -739,7 +716,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
 
       Set<org.picketlink.idm.api.Group> plGroups = new HashSet<org.picketlink.idm.api.Group>();
       try {
-          orgService.flush();
           plGroups.addAll(getIdentitySession().getRelationshipManager().findAssociatedGroups(jbidGroup, null, true, false, identitySearchCriteria));
       } catch (Exception e) {
           handleException("Identity operation error: ", e);
@@ -819,8 +795,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         Map<String, Attribute> attrs = new HashMap<String, Attribute>();
 
         try {
-            orgService.flush();
-
             attrs = getIdentitySession().getAttributesManager().getAttributes(jbidGroup);
         } catch (Exception e) {
             // TODO:
@@ -897,8 +871,6 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
         String gtnGroupName = getGtnGroupName(jbidGroup.getName());
 
         try {
-            orgService.flush();
-
             parents = getIdentitySession().getRelationshipManager().findAssociatedGroups(jbidGroup, null, false, false);
         } catch (Exception e) {
             // TODO:
@@ -1028,6 +1000,8 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
             } catch (Exception e) {
                 // TODO:
                 handleException("Identity operation error: ", e);
+            } finally {
+              orgService.flush();
             }
 
         }

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipDAOImpl.java
@@ -27,6 +27,7 @@ import org.exoplatform.services.organization.*;
 import org.exoplatform.services.organization.impl.MembershipTypeImpl;
 import org.picketlink.idm.api.Role;
 import org.picketlink.idm.api.RoleType;
+import org.picketlink.idm.common.exception.FeatureNotSupportedException;
 import org.picketlink.idm.common.exception.IdentityException;
 
 import javax.naming.InvalidNameException;
@@ -87,8 +88,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
                     mt, "broadcast", broadcast });
         }
 
-        orgService.flush();
-
         if (user == null) {
             throw new InvalidNameException("Can not create membership record because user is null");
         }
@@ -124,7 +123,11 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
 
         if (isCreateMembership(mt.getName(), g.getId())) {
             if (getIdentitySession().getRoleManager().getRoleType(mt.getName()) == null) {
+              try {
                 getIdentitySession().getRoleManager().createRoleType(mt.getName());
+              } finally {
+                orgService.flush();
+              }
             }
 
             if (getIdentitySession().getRoleManager().hasRole(user.getUserName(), groupId, mt.getName())) {
@@ -137,26 +140,26 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
         membership.setUserName(user.getUserName());
         membership.setGroupId(g.getId());
 
+        if (broadcast) {
+          preSave(membership, true);
+        }
+        
         try {
-          if (broadcast) {
-            preSave(membership, true);
-          }
-          
           if (isAssociationMapped() && getAssociationMapping().equals(mt.getName())) {
             if(!getIdentitySession().getRelationshipManager().isAssociatedByKeys(groupId, user.getUserName())) {
               getIdentitySession().getRelationshipManager().associateUserByKeys(groupId, user.getUserName());
             }
           }
-          
+
           if (isCreateMembership(mt.getName(), g.getId())) {
             getIdentitySession().getRoleManager().createRole(mt.getName(), user.getUserName(), groupId);
           }
-          
-          if (broadcast) {
-            postSave(membership, true);
-          }
         } finally {
           orgService.flush();
+        }
+
+        if (broadcast) {
+          postSave(membership, true);
         }
     }
 
@@ -164,8 +167,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
         if (log.isTraceEnabled()) {
             Tools.logMethodIn(log, LogLevel.TRACE, "saveMembership", new Object[] { "membership", m, "broadcast", broadcast });
         }
-
-        orgService.flush();
 
         String plGroupName = getPLIDMGroupName(getGroupNameFromId(m.getGroupId()));
 
@@ -189,35 +190,39 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
             preSave(m, false);
         }
 
-        if (isCreateMembership(m.getMembershipType(), m.getGroupId())) {
+        try {
+          if (isCreateMembership(m.getMembershipType(), m.getGroupId())) {
 
-            try {
-                getIdentitySession().getRoleManager().createRole(m.getMembershipType(), m.getUserName(), groupId);
-            } catch (Exception e) {
-                try {
-                    if (getIdentitySession().getRoleManager().getRole(m.getMembershipType(), m.getUserName(), groupId) != null) {
-                        getIdentitySession().getRoleManager().removeRole(m.getMembershipType(), m.getUserName(), groupId);
-                    }
-                } catch (IdentityException e1) {
-                    handleException("Cannot remove role: ", e1);
-                }
-                throw e;
+              try {
+                  getIdentitySession().getRoleManager().createRole(m.getMembershipType(), m.getUserName(), groupId);
+              } catch (Exception e) {
+                  try {
+                      if (getIdentitySession().getRoleManager().getRole(m.getMembershipType(), m.getUserName(), groupId) != null) {
+                          getIdentitySession().getRoleManager().removeRole(m.getMembershipType(), m.getUserName(), groupId);
+                      }
+                  } catch (IdentityException e1) {
+                      handleException("Cannot remove role: ", e1);
+                  }
+                  throw e;
 
-            }
-        }
-        if (isAssociationMapped() && getAssociationMapping().equals(m.getMembershipType())) {
-            try {
-                getIdentitySession().getRelationshipManager().associateUserByKeys(groupId, m.getUserName());
-            } catch (Exception e) {
-                try {
-                    if (getIdentitySession().getRelationshipManager().isAssociatedByKeys(groupId, m.getUserName())) {
-                        getIdentitySession().getRelationshipManager().disassociateUsersByKeys(groupId, new ArrayList<String>(Arrays.asList(m.getUserName())));
-                    }
-                } catch (IdentityException e1) {
-                    handleException("Cannot disassociate", e1);
-                }
-                throw e;
-            }
+              }
+          }
+          if (isAssociationMapped() && getAssociationMapping().equals(m.getMembershipType())) {
+              try {
+                  getIdentitySession().getRelationshipManager().associateUserByKeys(groupId, m.getUserName());
+              } catch (Exception e) {
+                  try {
+                      if (getIdentitySession().getRelationshipManager().isAssociatedByKeys(groupId, m.getUserName())) {
+                          getIdentitySession().getRelationshipManager().disassociateUsersByKeys(groupId, new ArrayList<String>(Arrays.asList(m.getUserName())));
+                      }
+                  } catch (IdentityException e1) {
+                      handleException("Cannot disassociate", e1);
+                  }
+                  throw e;
+              }
+          }
+        } finally {
+          orgService.flush();
         }
 
         if (broadcast) {
@@ -229,8 +234,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
         if (log.isTraceEnabled()) {
             Tools.logMethodIn(log, LogLevel.TRACE, "removeMembership", new Object[] { "id", id, "broadcast", broadcast });
         }
-
-        orgService.flush();
 
         Membership m = null;
         try {
@@ -275,25 +278,29 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
             preDelete(m);
         }
 
-        if (isCreateMembership(m.getMembershipType(), m.getGroupId())) {
+        try {
+          if (isCreateMembership(m.getMembershipType(), m.getGroupId())) {
 
-            try {
-                getIdentitySession().getRoleManager().removeRole(m.getMembershipType(), m.getUserName(), groupId);
-            } catch (Exception e) {
-                // TODO:
-                handleException("Identity operation error: ", e);
-            }
-        }
+              try {
+                  getIdentitySession().getRoleManager().removeRole(m.getMembershipType(), m.getUserName(), groupId);
+              } catch (Exception e) {
+                  // TODO:
+                  handleException("Identity operation error: ", e);
+              }
+          }
 
-        if (isAssociationMapped() && getAssociationMapping().equals(m.getMembershipType()) && associated) {
-            Set<String> keys = new HashSet<String>();
-            keys.add(m.getUserName());
-            try {
-                getIdentitySession().getRelationshipManager().disassociateUsersByKeys(groupId, keys);
-            } catch (Exception e) {
-                // TODO:
-                handleException("Identity operation error: ", e);
-            }
+          if (isAssociationMapped() && getAssociationMapping().equals(m.getMembershipType()) && associated) {
+              Set<String> keys = new HashSet<String>();
+              keys.add(m.getUserName());
+              try {
+                  getIdentitySession().getRelationshipManager().disassociateUsersByKeys(groupId, keys);
+              } catch (Exception e) {
+                  // TODO:
+                  handleException("Identity operation error: ", e);
+              }
+          }
+        } finally {
+          orgService.flush();
         }
 
         if (broadcast) {
@@ -308,8 +315,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
             Tools.logMethodIn(log, LogLevel.TRACE, "removeMembershipByUser", new Object[] { "userName", userName, "broadcast",
                     broadcast });
         }
-
-        orgService.flush();
 
         Collection<Role> roles = new HashSet();
 
@@ -334,7 +339,11 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
                 preDelete(m);
             }
 
-            getIdentitySession().getRoleManager().removeRole(role);
+            try {
+              getIdentitySession().getRoleManager().removeRole(role);
+            } finally {
+              orgService.flush();
+            }
 
             if (broadcast) {
                 postDelete(m);
@@ -378,8 +387,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
             Tools.logMethodIn(log, LogLevel.TRACE, "findMembershipByUserAndType", new Object[] { "userName", userName,
                     "groupId", groupId, "type", type, });
         }
-
-        orgService.flush();
 
         String plGroupName = getPLIDMGroupName(getGroupNameFromId(groupId));
 
@@ -438,8 +445,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
             Tools.logMethodIn(log, LogLevel.TRACE, "findMembershipByUserAndGroup", new Object[] { "userName", userName,
                     "groupId", groupId, });
         }
-
-        orgService.flush();
 
         if (userName == null) {
             // julien fix : if user name is null, need to check if we do need to return a special group
@@ -507,8 +512,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
         if (log.isTraceEnabled()) {
             Tools.logMethodIn(log, LogLevel.TRACE, "findMembershipsByUser", new Object[] { "userName", userName });
         }
-
-        orgService.flush();
 
         Collection<Role> roles = new HashSet();
 
@@ -606,8 +609,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
             Tools.logMethodIn(log, LogLevel.TRACE, "findMembershipsByGroup", new Object[] { "groupId", groupId });
         }
 
-        orgService.flush();
-
         String plGroupName = getPLIDMGroupName(getGroupNameFromId(groupId));
 
         String gid = getIdentitySession().getPersistenceManager().createGroupKey(plGroupName, getGroupTypeFromId(groupId));
@@ -675,8 +676,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
             Tools.logMethodIn(log, LogLevel.TRACE, "findMembership", new Object[] { "id", id });
         }
 
-        orgService.flush();
-
         Membership m = new MembershipImpl(id);
 
         String plGroupName = getPLIDMGroupName(getGroupNameFromId(m.getGroupId()));
@@ -734,8 +733,6 @@ public class MembershipDAOImpl extends AbstractDAOImpl implements MembershipHand
           log.error("Internal ERROR. Cannot obtain group: " + groupId);
             return new ArrayList<>();
         }
-
-        orgService.flush();
 
         Collection<RoleType> roleTypes = new HashSet();
 

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -133,11 +133,11 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
 
     org.picketlink.idm.api.User plIDMUser = null;
     try {
-      orgService.flush();
-
       plIDMUser = session.getPersistenceManager().createUser(user.getUserName());
     } catch (Exception e) {
       handleException("Identity operation error: ", e);
+    } finally {
+      orgService.flush();
     }
 
     try {
@@ -153,6 +153,8 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
       } catch (Exception e2) {
         handleException("Can't remove user", e);
       }
+    } finally {
+      orgService.flush();
     }
 
     if (broadcast) {
@@ -192,7 +194,6 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
                         new Object[] { "userName", userName, "enabled", enabled, "broadcast", broadcast });
     }
 
-    orgService.flush();
     IdentitySession session = service_.getIdentitySession();
     User foundUser = getPopulatedUser(userName, session, UserStatus.ANY);
 
@@ -215,6 +216,8 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
         am.removeAttributes(userName, new String[] { USER_ENABLED });
       } catch (Exception e) {
         handleException("Cannot update enabled status for user: " + userName + "; ", e);
+      } finally {
+        orgService.flush();
       }
     } else {
       Attribute[] attrs = new Attribute[] { new SimpleAttribute(USER_ENABLED, String.valueOf(enabled)) };
@@ -222,6 +225,8 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
         am.updateAttributes(userName, attrs);
       } catch (Exception e) {
         handleException("Cannot update enabled status for user: " + userName + "; ", e);
+      } finally {
+        orgService.flush();
       }
     }
 
@@ -241,7 +246,6 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
     org.picketlink.idm.api.User foundUser = null;
 
     try {
-      orgService.flush();
       foundUser = session.getPersistenceManager().findUser(userName);
     } catch (IllegalArgumentException e) {
       // Don't rethrow the exception to be compatible with other Org Service
@@ -268,14 +272,14 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
       orgService.getUserProfileHandler().removeUserProfile(userName, false);
     } catch (Exception e) {
       handleException("Cannot cleanup user relationships: " + userName + "; ", e);
-
     }
 
     try {
       session.getPersistenceManager().removeUser(foundUser, true);
     } catch (Exception e) {
       handleException("Cannot remove user: " + userName + "; ", e);
-
+    } finally {
+      orgService.flush();
     }
 
     if (broadcast) {
@@ -402,8 +406,6 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
       authenticated = user.getPassword().equals(password);
     } else {
       try {
-        orgService.flush();
-
         IdentitySession session = service_.getIdentitySession();
         org.picketlink.idm.api.User idmUser = session.getPersistenceManager().findUser(user.getUserName());
 
@@ -549,8 +551,6 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
     org.picketlink.idm.api.User plUser = null;
 
     try {
-      orgService.flush();
-
       plUser = session.getAttributesManager().findUserByUniqueAttribute(attributeName, attributeValue);
     } catch (Exception e) {
       handleException("Cannot find user by unique attribute: attrName=" + attributeName + ", attrValue=" + attributeValue + "; ",
@@ -741,8 +741,6 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
                               org.picketlink.idm.api.User plIDMUser,
                               IdentitySession session,
                               boolean isNew) throws Exception {
-    orgService.flush();
-
     AttributesManager am = session.getAttributesManager();
 
     ArrayList attributes = new ArrayList();
@@ -799,6 +797,8 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
           am.updatePassword(plIDMUser, user.getPassword());
         } catch (Exception e) {
           handleException("Cannot update password: " + user.getUserName() + "; ", e);
+        } finally {
+          orgService.flush();
         }
       }
     }
@@ -810,14 +810,14 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
       am.updateAttributes(user.getUserName(), attrs);
     } catch (Exception e) {
       handleException("Cannot update attributes for user: " + user.getUserName() + "; ", e);
+    } finally {
+      orgService.flush();
     }
 
   }
 
   public User getPopulatedUser(String userName, IdentitySession session, UserStatus userStatus) throws Exception {
     org.picketlink.idm.api.User u = null;
-
-    orgService.flush();
 
     try {
       u = session.getPersistenceManager().findUser(userName);
@@ -895,6 +895,8 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
       }
     } catch (Exception e) {
       handleException("Cannot remove displayName attribute of user: " + user.getUserName() + "; ", e);
+    } finally {
+      orgService.flush();
     }
   }
   private UserQueryBuilder addEnabledUserFilter(UserQueryBuilder qb) throws Exception {

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserProfileDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserProfileDAOImpl.java
@@ -39,7 +39,6 @@ import org.exoplatform.services.organization.UserProfileHandler;
 import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.services.organization.impl.UserProfileImpl;
 import org.picketlink.idm.api.Attribute;
-import org.picketlink.idm.api.IdentitySession;
 import org.picketlink.idm.impl.api.SimpleAttribute;
 
 /**
@@ -47,27 +46,27 @@ import org.picketlink.idm.impl.api.SimpleAttribute;
  */
 public class UserProfileDAOImpl extends AbstractDAOImpl implements UserProfileHandler {
 
-    private static UserProfile NOT_FOUND = new UserProfileImpl();
+    private static final UserProfile       NOT_FOUND = new UserProfileImpl();
 
-    private List<UserProfileEventListener> listeners_;
+    private List<UserProfileEventListener> listeners;
 
     public UserProfileDAOImpl(PicketLinkIDMOrganizationServiceImpl orgService, PicketLinkIDMService service) {
         super(orgService, service);
-        listeners_ = new ArrayList<UserProfileEventListener>(3);
+        listeners = new ArrayList<>();
     }
 
     public void addUserProfileEventListener(UserProfileEventListener listener) {
         if (listener == null) {
             throw new IllegalArgumentException("Listener cannot be null");
         }
-        listeners_.add(listener);
+        listeners.add(listener);
     }
 
     public void removeUserProfileEventListener(UserProfileEventListener listener) {
         if (listener == null) {
             throw new IllegalArgumentException("Listener cannot be null");
         }
-        listeners_.remove(listener);
+        listeners.remove(listener);
     }
 
     public final UserProfile createUserProfileInstance() {
@@ -77,15 +76,6 @@ public class UserProfileDAOImpl extends AbstractDAOImpl implements UserProfileHa
     public UserProfile createUserProfileInstance(String userName) {
         return new UserProfileImpl(userName);
     }
-
-    // void createUserProfileEntry(UserProfile up, IdentitySession session) throws Exception
-    // {
-    // UserProfileData upd = new UserProfileData();
-    // upd.setUserProfile(up);
-    // session.save(upd);
-    // session.flush();
-    // cache_.remove(up.getUserName());
-    // }
 
     public void saveUserProfile(UserProfile profile, boolean broadcast) throws Exception {
         // We need to check if userProfile exists, because organization API is limited and it doesn't have separate methods for
@@ -191,25 +181,25 @@ public class UserProfileDAOImpl extends AbstractDAOImpl implements UserProfileHa
     }
 
     private void preSave(UserProfile profile, boolean isNew) throws Exception {
-        for (UserProfileEventListener listener : listeners_) {
+        for (UserProfileEventListener listener : listeners) {
             listener.preSave(profile, isNew);
         }
     }
 
     private void postSave(UserProfile profile, boolean isNew) throws Exception {
-        for (UserProfileEventListener listener : listeners_) {
+        for (UserProfileEventListener listener : listeners) {
             listener.postSave(profile, isNew);
         }
     }
 
     private void preDelete(UserProfile profile) throws Exception {
-        for (UserProfileEventListener listener : listeners_) {
+        for (UserProfileEventListener listener : listeners) {
             listener.preDelete(profile);
         }
     }
 
     private void postDelete(UserProfile profile) throws Exception {
-        for (UserProfileEventListener listener : listeners_) {
+        for (UserProfileEventListener listener : listeners) {
             listener.postDelete(profile);
         }
     }
@@ -294,6 +284,8 @@ public class UserProfileDAOImpl extends AbstractDAOImpl implements UserProfileHa
         } catch (Exception e) {
             // TODO:
             handleException("Identity operation error: ", e);
+        } finally {
+          orgService.flush();
         }
 
     }
@@ -310,6 +302,8 @@ public class UserProfileDAOImpl extends AbstractDAOImpl implements UserProfileHa
         } catch (Exception e) {
             // TODO:
             handleException("Identity operation error: ", e);
+        } finally {
+          orgService.flush();
         }
     }
 }


### PR DESCRIPTION
Prior to this change, the Hibernate IDM Session is flushed each read operation which may lead to a performance issue. This change ensures to not flush session and commit transaction on read but only on write operations.

Resolves Meeds-io/meeds#2662