### PR TITLE
fix: Exclude Draft Pages from Default Site Pages - MEED-8044 - Meeds-io/meeds#2721

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -370,60 +370,62 @@ public class UserPortalConfigService implements Startable {
                                           String portalName,
                                           String nodePath,
                                           String username) {
-    UserNode rootUserNode = getSiteRootNode(portalType,
-                                            portalName,
-                                            username,
-                                            false);
-    if (rootUserNode == null) {
-      return null;
-    } else if (StringUtils.isBlank(nodePath)) {
-      return getNodeOrFirstChildWithPage(rootUserNode, username);
+    if (StringUtils.isBlank(nodePath)) {
+      return getDefaultSiteNode(portalType, portalName, username);
     } else {
-      UserNode globalRootUserNode = getSiteRootNode(PortalConfig.PORTAL_TYPE,
-                                                    globalPortal,
-                                                    username,
-                                                    false);
-      UserNode siteUserNode = rootUserNode;
-      UserNode globalUserNode = globalRootUserNode;
-      int validGlobalDepth = 0;
-      int validSiteDepth = 0;
-      int currentDepth = 0;
-
-      String[] nodeNames = Utils.parsePath(nodePath);
-      Iterator<String> iterator = Arrays.stream(nodeNames).iterator();
-      while (iterator.hasNext()
-             && (validSiteDepth == currentDepth
-                 || validGlobalDepth == currentDepth)) {
-        String path = iterator.next();
-        if (validSiteDepth == currentDepth) {
-          UserNode childUserNode = siteUserNode.getChild(path);
-          if (childUserNode != null) {
-            siteUserNode = childUserNode;
-            validSiteDepth++;
-          }
-        }
-        if (globalUserNode != null && validGlobalDepth == currentDepth) {
-          UserNode childGlobalUserNode = globalUserNode.getChild(path);
-          if (childGlobalUserNode != null) {
-            globalUserNode = childGlobalUserNode;
-            validGlobalDepth++;
-          }
-        }
-        currentDepth++;
-      }
-      if (globalUserNode != null) {
-        if (validSiteDepth >= validGlobalDepth) {
-          return getNodeOrFirstChildWithPage(siteUserNode, username);
-        } else {
-          if (globalUserNode.getPageRef() == null
-              || getPage(globalUserNode.getPageRef(), username) == null) {
-            return null;
-          } else {
-            return globalUserNode;
-          }
-        }
+      UserNode rootUserNode = getSiteRootNode(portalType,
+                                              portalName,
+                                              username,
+                                              false);
+      if (rootUserNode == null) {
+        return null;
       } else {
-        return getNodeOrFirstChildWithPage(siteUserNode, username);
+        UserNode globalRootUserNode = getSiteRootNode(PortalConfig.PORTAL_TYPE,
+                                                      globalPortal,
+                                                      username,
+                                                      false);
+        UserNode siteUserNode = rootUserNode;
+        UserNode globalUserNode = globalRootUserNode;
+        int validGlobalDepth = 0;
+        int validSiteDepth = 0;
+        int currentDepth = 0;
+
+        String[] nodeNames = Utils.parsePath(nodePath);
+        Iterator<String> iterator = Arrays.stream(nodeNames).iterator();
+        while (iterator.hasNext()
+               && (validSiteDepth == currentDepth
+                   || validGlobalDepth == currentDepth)) {
+          String path = iterator.next();
+          if (validSiteDepth == currentDepth) {
+            UserNode childUserNode = siteUserNode.getChild(path);
+            if (childUserNode != null) {
+              siteUserNode = childUserNode;
+              validSiteDepth++;
+            }
+          }
+          if (globalUserNode != null && validGlobalDepth == currentDepth) {
+            UserNode childGlobalUserNode = globalUserNode.getChild(path);
+            if (childGlobalUserNode != null) {
+              globalUserNode = childGlobalUserNode;
+              validGlobalDepth++;
+            }
+          }
+          currentDepth++;
+        }
+        if (globalUserNode != null) {
+          if (validSiteDepth >= validGlobalDepth) {
+            return getNodeOrFirstChildWithPage(siteUserNode, username);
+          } else {
+            if (globalUserNode.getPageRef() == null
+                || getPage(globalUserNode.getPageRef(), username) == null) {
+              return null;
+            } else {
+              return globalUserNode;
+            }
+          }
+        } else {
+          return getNodeOrFirstChildWithPage(siteUserNode, username);
+        }
       }
     }
   }


### PR DESCRIPTION
Prior to this change, the draft nodes were included when getting the default site page. This change will ensure to reuse the same algorithm of default site path computing when the url doesn't specify the full navigation node to display.

Resolves Meeds-io/meeds#2721