### PR TITLE
feat: Move System Addon Containers as UIPortalApplication extensions - MEED-8281 - Meeds-io/MIPs#175

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UIBottomAllContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UIBottomAllContainer.gtmpl
@@ -1,0 +1,35 @@
+<%
+  import java.util.ArrayList;
+
+  import org.apache.commons.collections4.CollectionUtils;
+
+  import org.exoplatform.container.ExoContainerContext;
+  import org.exoplatform.commons.addons.AddOnService;
+  import org.exoplatform.portal.config.model.Application;
+  import org.exoplatform.portal.webui.util.PortalDataMapper;
+  import org.exoplatform.portal.webui.application.UIPortlet;
+
+  def rcontext = _ctx.getRequestContext();
+  AddOnService addOnService = ExoContainerContext.getService(AddOnService.class);
+  List<Application> applications = addOnService.getApplications("body-end-container");
+  if (CollectionUtils.isEmpty(applications)) {
+    return;
+  }
+%>
+<div id="body-end-container">
+<%
+  for (application in applications) {
+    def child = rcontext.getUiPortal().getChildById(application.getId());
+    if (child != null) {
+      child.processRender(rcontext);
+    } else {
+      UIPortlet uiPortlet = rcontext.getUiPortal().createUIComponent(rcontext, UIPortlet.class, null, null);
+      uiPortlet.setStorageId(application.getStorageId());
+      uiPortlet.setStorageName(application.getStorageId());
+      PortalDataMapper.toUIPortlet(uiPortlet, application);
+      uiPortlet.setParent(rcontext.getUiPortal());
+      uiPortlet.processRender(rcontext);
+    }
+  }
+%>
+</div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl
@@ -1,8 +1,9 @@
 <%
   _ctx.getRequestContext().getJavascriptManager()
-    .require("SHARED/topbarLoading", "topbarLoading").addScripts("topbarLoading.init()");
+    .require("SHARED/topbarLoading", "topbarLoading")
+    .addScripts("topbarLoading.init()");
 %>
-<div class="VuetifyApp TopbarLoadingContainer" id="$uicomponent.id">
+<div class="VuetifyApp TopbarLoadingContainer" id="TopbarLoadingContainer">
   <div data-app="true"
     class="v-application <%= isRT ? "v-application--is-rtl" : "v-application--is-ltr" %> transparent theme--light">
     <div role="progressbar" aria-valuemin="0" aria-valuemax="100"

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -123,7 +123,9 @@
     %><meta name="<%=metaName%>" content="<%=metaContent%>" /><% 
          }
       }
-      _ctx.includeTemplates("UIPortalApplication-Start-head"); %>
+      if (!rcontext.isMaximizePortlet()) {
+        _ctx.includeTemplates("UIPortalApplication-Start-head");
+      }%>
     <link rel="shortcut icon" href="<%= org.exoplatform.portal.branding.Utils.getFaviconPath() %>" />
     <%/* Styles */%>
     <link id="brandingSkin" rel="stylesheet" type="text/css" href="<%=uicomponent.getBrandingUrl()%>">
@@ -236,20 +238,23 @@
        }
      }
    </script>
-   <%/* 508 Compliancy */%>
-
-   <%/* Include extensible templates configured by Kernel configuration to be imported in Page Header */%>
-   <% _ctx.includeTemplates("UIPortalApplication-head") %>
+   <%/* 508 Compliancy */
+   /* Include extensible templates configured by Kernel configuration to be imported in Page Header */
+   if (!rcontext.isMaximizePortlet()) {
+       _ctx.includeTemplates("UIPortalApplication-head");
+   }%>
  </head>
-
- <body style="height: 100%;$bodyStyle" class="$bodyClasses" onload="eXo.env.portal.onLoad()">
-   <%/* Include extensible templates configured by Kernel configuration to be imported in the beginning of the body section of the Page */%>
-   <% _ctx.includeTemplates("UIPortalApplication-Start-body") %>
+ <body style="height: 100%;$bodyStyle" class="$bodyClasses" onload="eXo.env.portal.onLoad()"><%
+   /* Include extensible templates configured by Kernel configuration to be imported in the beginning of the body section of the Page */
+   if (!rcontext.isMaximizePortlet()) {
+     _ctx.includeTemplates("UIPortalApplication-Start-body");
+   }%>
    <div class="visible-tablet"></div>
    <div class="visible-tabletL"></div>
    <div class="visible-phone"></div>
    <div class="visible-phone-small"></div>
    <div class="VuetifyApp"><div data-app="true" class="v-application v-application--is-<%= orientation == Orientation.RT ? "rtl" : "ltr"  %> transparent theme--light" id="vuetify-apps"></div></div>
+   <div class="VuetifyApp"><div data-app="true" class="v-application v-application--is-<%= orientation == Orientation.RT ? "rtl" : "ltr"  %> transparent theme--light" id="drawers-overlay"></div></div>
    <div class="$uicomponent.skin" id="UIPortalApplication" style="!height: 100%;">
      <div class="ajaxLoadingMask clearfix" id="AjaxLoadingMask" style="display: none; margin: auto;">
        <a onclick="javascript:ajaxAbort();" class="uiIconClose uiIconWhite pull-right"></a>

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
@@ -5,10 +5,11 @@
   uicomponent.renderChildren();
   uicomponent.includePortletScripts();
 %>
-</div>
-   <% /* Include extensible templates configured by Kernel configuration to be imported in Page Header */ %>
-   <% _ctx.includeTemplates("UIPortalApplication-End-Body") %>
-
+</div><%
+   /* Include extensible templates configured by Kernel configuration to be imported in Page Header */
+   if (!rcontext.isMaximizePortlet()) {
+     _ctx.includeTemplates("UIPortalApplication-End-Body");
+   } %>
   <script type="text/javascript" id="jsManager">
     <%=jsManager.getJavaScripts()%>
   </script>

--- a/webui/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.gatein.common.net.media.MediaType;
 import org.gatein.pc.api.Portlet;
 import org.gatein.pc.api.info.ModeInfo;
@@ -55,9 +56,10 @@ import lombok.SneakyThrows;
 
 public class PortalDataMapper {
 
+  private static final String SITE_LAYOUT_TEMPLATE = "system:/groovy/portal/webui/container/UISiteLayout.gtmpl";
   protected static final Log log = ExoLogger.getLogger("portal:PortalDataMapper");
 
-  private static void toUIPortlet(UIPortlet uiPortlet, Application model) {
+  public static void toUIPortlet(UIPortlet uiPortlet, Application model) {
     PortletState portletState = new PortletState(model.getState());
     uiPortlet.setWidth(model.getWidth());
     uiPortlet.setHeight(model.getHeight());
@@ -165,8 +167,12 @@ public class PortalDataMapper {
     Container layout = metaLayout && model.isDisplayed() ? metaSite.getPortalLayout() : model.getPortalLayout();
     List<ModelObject> children = layout.getChildren();
     if (children != null) {
-      for (Object child : children) {
-        buildUIContainer(uiPortal, child);
+      if (StringUtils.equals(layout.getTemplate(), SITE_LAYOUT_TEMPLATE)) {
+        buildUIContainer(uiPortal, layout);
+      } else {
+        for (ModelObject child : children) {
+          buildUIContainer(uiPortal, child);
+        }
       }
     }
   }


### PR DESCRIPTION
This change will allow to centralize the system apps and divs to be served by `UIPortalApplication` rather than Addon Containers added inside the `sharedlayout.xml` and `portal.xml` of standalone sites.