### PR TITLE
fix: Fix Retrieving Leaderboard App - MEED-8355 - Meeds-io/MIPs#175

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl
@@ -1,10 +1,3 @@
-<%
-  _ctx.getRequestContext().getJavascriptManager()
-    .require("SHARED/bodyScrollListener", "bodyScrollListener");
-  _ctx.getRequestContext().getJavascriptManager()
-    .require("SHARED/topbarLoading", "topbarLoading")
-    .addScripts("topbarLoading.init()");
-%>
 <div class="VuetifyApp TopbarLoading position-sticky t-0 z-index-modal" id="TopbarLoading">
   <div data-app="true" class="v-application position-absolute full-width <%= isRT ? "v-application--is-rtl" : "v-application--is-ltr" %> transparent theme--light">
     <div role="progressbar" aria-valuemin="0" aria-valuemax="100"

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIApplication.gtmpl
@@ -1,5 +1,11 @@
+<%
+uicomponent.includePortletScripts();
+%>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <body>
 <%_ctx.getRequestContext().getMaximizedUIPortlet().processRender(_ctx.getRequestContext());%>
+  <script type="text/javascript" id="jsManager">
+    <%=_ctx.getRequestContext().getJavascriptManager().getJavaScripts()%>
+  </script>
 </body>
 </html>

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -260,17 +260,4 @@
        <a onclick="javascript:ajaxAbort();" class="uiIconClose uiIconWhite pull-right"></a>
        <i class="loadingProgressBar pull-left"></i>
        <div class="loadingText"><%=_ctx.appRes("UIPortalApplication.label.Loading")%></div>
-     </div><%
-    uicomponent.renderChildren();
-    uicomponent.includePortletScripts();
-  %>
-  </div><%
-  /* Include extensible templates configured by Kernel configuration to be imported in Page Header */
-  if (!rcontext.isMaximizePortlet()) {
-    _ctx.includeTemplates("UIPortalApplication-End-Body");
-  } %>
-  <script type="text/javascript" id="jsManager">
-    <%=rcontext.getJavascriptManager().getJavaScripts()%>
-  </script>
-</body>
-</html>
+     </div>

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl
@@ -1,0 +1,20 @@
+<%
+  def rcontext = _ctx.getRequestContext();
+  def jsManager = rcontext.getJavascriptManager();
+  jsManager
+    .require("SHARED/bodyScrollListener", "bodyScrollListener");
+  jsManager
+    .require("SHARED/topbarLoading", "topbarLoading")
+    .addScripts("topbarLoading.init()");
+  uicomponent.renderChildren();
+  uicomponent.includePortletScripts();
+%></div><%
+  /* Include extensible templates configured by Kernel configuration to be imported in Page Header */
+  if (!rcontext.isMaximizePortlet()) {
+    _ctx.includeTemplates("UIPortalApplication-End-Body");
+  } %>
+  <script type="text/javascript" id="jsManager">
+    <%=jsManager.getJavaScripts()%>
+  </script>
+</body>
+</html>

--- a/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplicationLifecycle.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplicationLifecycle.java
@@ -80,8 +80,9 @@ public class UIPortalApplicationLifecycle extends Lifecycle<UIPortalApplication>
   public void processRender(UIPortalApplication uicomponent, WebuiRequestContext context) throws Exception {
     PortalRequestContext portalRequestContext = (PortalRequestContext) context;
     OutputStream responseOutputStream = portalRequestContext.getResponse().getOutputStream();
-    PortalPrinter parentWriter = new PortalPrinter(responseOutputStream, true, 25000);
-    portalRequestContext.setWriter(parentWriter);
+    PortalPrinter parentWriter = new PortalPrinter(responseOutputStream, true, 5000);
+
+    PortalPrinter childWriter = null;
     if (portalRequestContext.isFullRendering()) {
       JavascriptManager jsManager = portalRequestContext.getJavascriptManager();
       // Add JS resource of current portal
@@ -91,14 +92,31 @@ public class UIPortalApplicationLifecycle extends Lifecycle<UIPortalApplication>
       jsManager.loadScriptResource(ResourceScope.SHARED, JavascriptConfigParser.LEGACY_JAVA_SCRIPT);
       // Need to add bootstrap as immediate since it contains the loader
       jsManager.loadScriptResource(ResourceScope.SHARED, "bootstrap");
-      processRender(uicomponent, portalRequestContext, "system:/groovy/portal/webui/workspace/UIPortalApplication.gtmpl");
+
+      childWriter = new PortalPrinter(responseOutputStream, true, 25000, true);
+
+      context.setWriter(childWriter);
+      processRender(uicomponent, context, "system:/groovy/portal/webui/workspace/UIPortalApplicationChildren.gtmpl");
+
+      context.setWriter(parentWriter);
+      processRender(uicomponent, context, "system:/groovy/portal/webui/workspace/UIPortalApplication.gtmpl");
+      portalRequestContext.setWriter(parentWriter);
     } else {
+      portalRequestContext.setWriter(parentWriter);
       processRender(uicomponent, portalRequestContext, "system:/groovy/portal/webui/workspace/UIApplication.gtmpl");
     }
 
     try {
+      // flush the parent writer to the output stream so that we are really to
+      // accept the child content
       portalRequestContext.commitResponse();
       parentWriter.flushOutputStream();
+      if (childWriter != null) {
+        // now that the parent has been flushed, we can flush the contents of
+        // the
+        // child to the output
+        childWriter.flushOutputStream();
+      }
     } catch (IOException e) {
       // We want to ignore the ClientAbortException since this is caused by the
       // users browser closing the connection and is not something we should be


### PR DESCRIPTION
Prior to this change, the Portlets specific JS in HTTP Headers wasn't included since the 'jsManager' Tag is built before building the Portlets content. This change will ensure to build the Portlet Header Markup and JS dependencies before retrieving the JS Content.