### PR TITLE
fix: Include Body-End-Container Portlet Static Resources in Portal - Meeds-io/MIPs#175

### DIFF
--- a/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -46,13 +46,16 @@ import org.gatein.portal.controller.resource.script.Module;
 import org.gatein.portal.controller.resource.script.ScriptResource;
 import org.json.JSONObject;
 
+import org.exoplatform.commons.addons.AddOnService;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.branding.BrandingService;
 import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.portal.config.model.Application;
 import org.exoplatform.portal.config.model.Container;
 import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.config.model.TransientApplicationState;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.portal.mop.user.UserNode;
@@ -101,6 +104,8 @@ import lombok.SneakyThrows;
 public class UIPortalApplication extends UIApplication {
 
   private static final long       serialVersionUID          = 4289299002617728318L;
+
+  public static final String      PORTAL_BODY_END_CONTAINER = "body-end-container";
 
   public static final String      PORTAL_PORTLETS_SKIN_ID   = "portalPortletSkins";
 
@@ -178,19 +183,23 @@ public class UIPortalApplication extends UIApplication {
     NO_EDIT, EDIT_SITE, EDIT_PAGE
   }
 
-  private static SkinService             skinService;            // NOSONAR
+  private static SkinService             skinService;                       // NOSONAR
 
-  private static UserPortalConfigService portalConfigService;    // NOSONAR
+  private static AddOnService            addOnService;                      // NOSONAR
 
-  private static LayoutService           layoutService;          // NOSONAR
+  private static UserPortalConfigService portalConfigService;               // NOSONAR
 
-  private static SkinVisitor             skinVisitor;            // NOSONAR
+  private static LayoutService           layoutService;                     // NOSONAR
 
-  protected UIWorkingWorkspace           uiWorkingWorkspace;     // NOSONAR
+  private static SkinVisitor             skinVisitor;                       // NOSONAR
 
-  private Map<SiteKey, UIPortal>         all_UIPortals;          // NOSONAR
+  protected UIWorkingWorkspace           uiWorkingWorkspace;                // NOSONAR
 
-  private UIComponentDecorator           uiViewWorkingWorkspace; // NOSONAR
+  private Map<SiteKey, UIPortal>         all_UIPortals;                     // NOSONAR
+
+  private UIComponentDecorator           uiViewWorkingWorkspace;            // NOSONAR
+
+  private List<String>                   bodyEndContainerPortletContentIds; // NOSONAR
 
   /**
    * The constructor of this class is used to build the tree of UI components
@@ -215,6 +224,7 @@ public class UIPortalApplication extends UIApplication {
       skinVisitor = getApplicationComponent(SkinVisitor.class); // NOSONAR
       layoutService = getApplicationComponent(LayoutService.class); // NOSONAR
       portalConfigService = getApplicationComponent(UserPortalConfigService.class); // NOSONAR
+      addOnService = getApplicationComponent(AddOnService.class); // NOSONAR
     }
     context.setUIApplication(this);
 
@@ -437,18 +447,27 @@ public class UIPortalApplication extends UIApplication {
    */
   public Set<Skin> getPortletSkins() {
     String skin = getSkin();
-    List<SkinConfig> portletSkins =
-                                  getCurrentPortlets().stream().map(this::getPortletSkinConfig).filter(Objects::nonNull).toList();
-    List<SkinConfig> additionalSkins = portletSkins.stream()
-                                                   .filter(portletSkin -> portletSkin instanceof SkinConfig skinConfig
-                                                                          && CollectionUtils.isNotEmpty(skinConfig.getAdditionalModules()))
-                                                   .map(SkinConfig::getAdditionalModules)
-                                                   .flatMap(List::stream)
-                                                   .distinct()
-                                                   .map(module -> skinService.getPortalSkin(module, skin))
-                                                   .filter(Objects::nonNull)
-                                                   .toList();
-    return Stream.concat(portletSkins.stream(), additionalSkins.stream())
+    List<SkinConfig> portletSkins = getCurrentPortlets().stream()
+                                                        .map(this::getPortletSkinConfig)
+                                                        .filter(Objects::nonNull)
+                                                        .toList();
+    // Load static body-end-container applications added on UIPortalApplication
+    // Body independently from SharedLayout Display State and from displayed
+    // Page/Site
+    List<SkinConfig> bodyEndPortletSkins = getBodyEndContainerContentIds().stream()
+                                                                          .map(this::getPortletSkinConfig)
+                                                                          .filter(Objects::nonNull)
+                                                                          .toList();
+    List<SkinConfig> additionalSkins = Stream.concat(portletSkins.stream(), bodyEndPortletSkins.stream())
+                                             .filter(portletSkin -> portletSkin instanceof SkinConfig skinConfig
+                                                                    && CollectionUtils.isNotEmpty(skinConfig.getAdditionalModules()))
+                                             .map(SkinConfig::getAdditionalModules)
+                                             .flatMap(List::stream)
+                                             .distinct()
+                                             .map(module -> skinService.getPortalSkin(module, skin))
+                                             .filter(Objects::nonNull)
+                                             .toList();
+    return Stream.concat(Stream.concat(portletSkins.stream(), bodyEndPortletSkins.stream()), additionalSkins.stream())
                  .filter(Objects::nonNull)
                  .filter(c -> !(c instanceof SkinConfig skinConfig) || skinConfig.getCSSPath() != null)
                  .sorted((s1, s2) -> s1.getCSSPriority() - s2.getCSSPriority())
@@ -518,11 +537,25 @@ public class UIPortalApplication extends UIApplication {
 
   private SkinConfig getPortletSkinConfig(UIPortlet portlet) {
     String portletId = portlet.getSkinId();
-    if (portletId != null) {
-      return skinService.getSkin(portletId, getSkin());
+    return getPortletSkinConfig(portletId);
+  }
+
+  private SkinConfig getPortletSkinConfig(String contentId) {
+    if (contentId != null) {
+      return skinService.getSkin(contentId, getSkin());
     } else {
       return null;
     }
+  }
+
+  private List<String> getBodyEndContainerContentIds() {
+    if (bodyEndContainerPortletContentIds == null) {
+      List<Application> applications = addOnService.getApplications(PORTAL_BODY_END_CONTAINER);
+      bodyEndContainerPortletContentIds = applications.stream()
+                                                      .map(app -> ((TransientApplicationState) app.getState()).getContentId())
+                                                      .toList();
+    }
+    return bodyEndContainerPortletContentIds;
   }
 
   /**
@@ -827,6 +860,16 @@ public class UIPortalApplication extends UIApplication {
         }
       }
     }
+    // Load static body-end-container applications added on UIPortalApplication
+    // Body independently from SharedLayout Display State and from displayed
+    // Page/Site
+    getBodyEndContainerContentIds().forEach(contentId -> {
+      try {
+        jsMan.loadScriptResource(ResourceScope.PORTLET, contentId);
+      } catch (Exception e) {
+        LOG.warn("Can't load JS resource for portlet {}", contentId, e);
+      }
+    });
   }
 
   public UIPage getCurrentPage() {


### PR DESCRIPTION
Prior to this change, the 'body-end-container' addons container has been moved from sharedlayout and pages to be included inside the UIPortalApplication directly which leads to not include JS & CSS of referenced applications automatically. This change will statically include those resources to ensure that those resources are properly loaded in all pages.