### PR TITLE
feat: Improve JS Preloading when using HTTP/2 protocol - MEED-8372 - Meeds-io/meeds#2924

### DIFF
--- a/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
@@ -19,25 +19,25 @@
 
 package org.exoplatform.portal.webui.application;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.portlet.MimeResponse;
 import javax.portlet.PortletMode;
 import javax.portlet.WindowState;
 import javax.xml.namespace.QName;
 
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.gatein.common.i18n.LocalizedString;
 import org.gatein.common.net.media.MediaType;
@@ -60,11 +60,11 @@ import org.gatein.pc.api.invocation.EventInvocation;
 import org.gatein.pc.api.invocation.PortletInvocation;
 import org.gatein.pc.api.invocation.RenderInvocation;
 import org.gatein.pc.api.invocation.ResourceInvocation;
+import org.gatein.pc.api.invocation.response.ContentResponse;
 import org.gatein.pc.api.invocation.response.ErrorResponse;
 import org.gatein.pc.api.invocation.response.FragmentResponse;
 import org.gatein.pc.api.invocation.response.PortletInvocationResponse;
 import org.gatein.pc.api.state.PropertyChange;
-import org.gatein.pc.portlet.impl.info.ContainerPortletInfo;
 import org.gatein.pc.portlet.impl.spi.AbstractClientContext;
 import org.gatein.pc.portlet.impl.spi.AbstractPortalContext;
 import org.gatein.pc.portlet.impl.spi.AbstractRequestContext;
@@ -135,6 +135,9 @@ import lombok.Setter;
   @EventConfig(phase = Phase.PROCESS, listeners = ServeResourceActionListener.class, csrfCheck = false),
   @EventConfig(phase = Phase.PROCESS, listeners = ProcessEventsActionListener.class, csrfCheck = false),
 })
+@SuppressWarnings("unchecked")
+@Getter
+@Setter
 public class UIPortlet extends UIApplication {
 
   protected static final Log                 LOG                   = ExoLogger.getLogger("portal:UIPortlet");
@@ -147,64 +150,46 @@ public class UIPortlet extends UIApplication {
                                                                                                                         "javax.portlet.markup.head.element.support",
                                                                                                                         "true"));
 
-  /** . */
   private String                             storageId;
 
-  /** . */
   private String                             storageName;
 
-  /** . */
   private ModelAdapter                       adapter;
 
-  /** . */
   private org.gatein.pc.api.Portlet          producedOfferedPortlet;
 
-  /** . */
   private PortletContext                     producerOfferedPortletContext;
 
-  /**
-   * A computed field that contains the runtime description of the portlet for
-   * edit mode.
-   */
   private LocalizedString                    displayName;
 
-  /** . */
   private PortletState                       state;
 
-  /** . */
   private String                             applicationId;
 
   private String                             theme;
 
   private String                             portletStyle;
 
-  private Boolean                            lazyResourcesLoading  = null;
+  private List<String>                       supportModes;
 
-  private List<String>                       supportModes_;
+  private List<QName>                        supportedProcessingEvents;
 
-  private List<QName>                        supportedProcessingEvents_;
+  private List<QName>                        supportedPublishingEvents;
 
-  private List<QName>                        supportedPublishingEvents_;
-
-  private Map<QName, String>                 supportedPublicParams_;
+  private Map<QName, String>                 supportedPublicParams;
 
   private StateString                        navigationalState;
 
   /** A field storing localized value of javax.portlet.title * */
   private String                             configuredTitle;
 
-  @Getter
-  @Setter
   private String                             cssClass;
 
-  private boolean                            showPortletMode       = true;
+  private boolean                            showPortletMode;
 
-  public String getStorageId() {
-    return storageId;
-  }
-
-  public void setStorageId(String storageId) {
-    this.storageId = storageId;
+  @Override
+  public String getId() {
+    return storageId == null ? super.getId() : storageId;
   }
 
   public String getStorageName() {
@@ -212,10 +197,6 @@ public class UIPortlet extends UIApplication {
       storageName = UUID.randomUUID().toString();
     }
     return storageName;
-  }
-
-  public void setStorageName(String storageName) {
-    this.storageName = storageName;
   }
 
   public String getWindowId() {
@@ -234,43 +215,12 @@ public class UIPortlet extends UIApplication {
     return applicationId;
   }
 
-  public String getId() {
-    return storageId == null ? super.getId() : storageId;
-  }
-
-  public String getApplicationId() {
-    return applicationId;
-  }
-
-  /**
-   * portletStyle is 'Window' when it's in WebOS project - an GateIn extension,
-   * portletStyle is null if is not in WebOS
-   * 
-   * @return a string represent current portlet style
-   */
-  public String getPortletStyle() {
-    return portletStyle;
-  }
-
-  public void setPortletStyle(String s) {
-    portletStyle = s;
-  }
-
   /**
    * @return true if portlet is configured to show control icon that allow to
    *         change portlet mode
    */
   public boolean getShowPortletMode() {
     return showPortletMode;
-  }
-
-  /**
-   * Used by portal to show the icon that allow to change portlet mode
-   * 
-   * @param b if show icon
-   */
-  public void setShowPortletMode(Boolean b) {
-    showPortletMode = b;
   }
 
   /**
@@ -288,33 +238,6 @@ public class UIPortlet extends UIApplication {
       return DEFAULT_THEME;
     }
     return theme;
-  }
-
-  public void setTheme(String theme) {
-    this.theme = theme;
-  }
-
-  private String themeMapToString(Map<String, String> themeMap) {
-    StringBuffer builder = new StringBuffer();
-    Iterator<Entry<String, String>> itr = themeMap.entrySet().iterator();
-    while (itr.hasNext()) {
-      Entry<String, String> entry = itr.next();
-      builder.append(entry.getKey()).append(":").append(entry.getValue());
-      if (itr.hasNext()) {
-        builder.append("::");
-      }
-    }
-    return builder.toString();
-  }
-
-  private Map<String, String> stringToThemeMap(String themesString) {
-    Map<String, String> themeMap = new HashMap<String, String>();
-    String[] themeIds = themesString.split("::");
-    for (String ele : themeIds) {
-      String[] strs = ele.split(":");
-      themeMap.put(strs[0], strs[1]);
-    }
-    return themeMap;
   }
 
   public PortletMode getCurrentPortletMode() {
@@ -342,22 +265,6 @@ public class UIPortlet extends UIApplication {
 
   public void setCurrentWindowState(WindowState state) {
     PortletRequestContext.setCurrentWindowState(state);
-  }
-
-  public List<QName> getSupportedProcessingEvents() {
-    return supportedProcessingEvents_;
-  }
-
-  public void setSupportedProcessingEvents(List<QName> supportedProcessingEvents) {
-    supportedProcessingEvents_ = supportedProcessingEvents;
-  }
-
-  public Map<QName, String> getSupportedPublicRenderParameters() {
-    return supportedPublicParams_;
-  }
-
-  public void setSupportedPublicRenderParameters(Map<QName, String> supportedPublicRenderParameters) {
-    supportedPublicParams_ = supportedPublicRenderParameters;
   }
 
   /**
@@ -404,19 +311,13 @@ public class UIPortlet extends UIApplication {
     }
   }
 
-  public org.gatein.pc.api.Portlet getProducedOfferedPortlet() {
-    return producedOfferedPortlet;
-  }
-
   public List<String> getSupportModes() {
-    if (supportModes_ != null) {
-      return supportModes_;
+    if (supportModes != null) {
+      return supportModes;
     }
 
-    List<String> supportModes = new ArrayList<String>();
-
+    this.supportModes = new ArrayList<>();
     org.gatein.pc.api.Portlet portlet = getProducedOfferedPortlet();
-
     // if we couldn't get the portlet that just return an empty modes list
     if (portlet == null) {
       return supportModes;
@@ -426,173 +327,10 @@ public class UIPortlet extends UIApplication {
     for (ModeInfo mode : modes) {
       supportModes.add(mode.getModeName());
     }
-
-    if (supportModes.size() > 0) {
+    if (!supportModes.isEmpty()) {
       supportModes.remove("view");
     }
-    setSupportModes(supportModes);
-
     return supportModes;
-  }
-
-  public void setSupportModes(List<String> supportModes) {
-    supportModes_ = supportModes;
-  }
-
-  /**
-   * Tells, according to the info located in portlet.xml, wether this portlet
-   * can handle a portlet event with the QName given as the method argument
-   */
-  public boolean supportsProcessingEvent(QName name) {
-
-    if (supportedProcessingEvents_ == null) {
-
-      org.gatein.pc.api.Portlet portlet = getProducedOfferedPortlet();
-
-      if (portlet == null) {
-        if (producerOfferedPortletContext != null) {
-          LOG.debug("Could not find portlet with ID : " + producerOfferedPortletContext.getId());
-        } else {
-          LOG.debug("Could not find portlet. The producerOfferedPortletContext is null");
-        }
-        return false;
-      }
-
-      Map<QName, EventInfo> consumedEvents = (Map<QName, EventInfo>) portlet.getInfo().getEventing().getConsumedEvents();
-
-      if (consumedEvents == null) {
-        return false;
-      }
-
-      supportedProcessingEvents_ = new ArrayList<QName>(consumedEvents.keySet());
-    }
-
-    for (QName eventName : supportedProcessingEvents_) {
-      if (eventName.equals(name)) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("The Portlet " + producerOfferedPortletContext + " supports comsuming the event : " + name);
-        }
-        return true;
-      }
-    }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("The portlet " + producerOfferedPortletContext + " doesn't support consuming the event : " + name);
-    }
-    return false;
-  }
-
-  public boolean supportsPublishingEvent(QName name) {
-    if (supportedPublishingEvents_ == null) {
-      org.gatein.pc.api.Portlet portlet = getProducedOfferedPortlet();
-
-      if (portlet == null) {
-        LOG.info("Could not find portlet with ID : " + producerOfferedPortletContext.getId());
-        return false;
-      }
-
-      Map<QName, EventInfo> producedEvents = (Map<QName, EventInfo>) portlet.getInfo().getEventing().getProducedEvents();
-
-      if (producedEvents == null) {
-        return false;
-      }
-
-      supportedPublishingEvents_ = new ArrayList<QName>(producedEvents.keySet());
-    }
-
-    for (QName eventName : supportedPublishingEvents_) {
-      if (eventName.equals(name)) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("The Portlet " + producerOfferedPortletContext + " supports producing the event : " + name);
-        }
-        return true;
-      }
-    }
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("The portlet " + producerOfferedPortletContext + " doesn't support producing the event : " + name);
-    }
-    return false;
-  }
-
-  /**
-   * Tells, according to the info located in portlet.xml, wether this portlet
-   * supports the public render parameter qname given as method argument. If the
-   * qname is supported, the public render parameter id is returned otherwise
-   * false is returned.
-   *
-   * @param supportedPublicParam the supported public parameter qname
-   * @return the supported public parameter id
-   */
-  public String supportsPublicParam(QName supportedPublicParam) {
-    if (supportedPublicParams_ == null) {
-
-      //
-      if (producedOfferedPortlet == null) {
-        if (producerOfferedPortletContext != null) {
-          LOG.debug("Could not find portlet with ID : " + producerOfferedPortletContext.getId());
-        }
-        return null;
-      }
-
-      //
-      Collection<ParameterInfo> parameters = (Collection<ParameterInfo>) producedOfferedPortlet.getInfo()
-                                                                                               .getNavigation()
-                                                                                               .getPublicParameters();
-      supportedPublicParams_ = new HashMap<QName, String>();
-      for (ParameterInfo parameter : parameters) {
-        supportedPublicParams_.put(parameter.getName(), parameter.getId());
-      }
-    }
-
-    //
-    String id = supportedPublicParams_.get(supportedPublicParam);
-    if (id != null) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("The Portlet " + producerOfferedPortletContext.getId() + " supports the public render parameter : " +
-            supportedPublicParam);
-      }
-      return id;
-    }
-
-    //
-    return null;
-  }
-
-  /**
-   * Tells, according to the info located in portlet.xml, wether this portlet
-   * supports the public render parameter given as a method argument
-   */
-  public boolean supportsPublicParam(String supportedPublicParam) {
-    if (supportedPublicParams_ == null) {
-
-      //
-      if (producedOfferedPortlet == null) {
-        LOG.info("Could not find portlet with ID : " + producerOfferedPortletContext.getId());
-        return false;
-      }
-
-      //
-      Collection<ParameterInfo> parameters = (Collection<ParameterInfo>) producedOfferedPortlet.getInfo()
-                                                                                               .getNavigation()
-                                                                                               .getPublicParameters();
-      supportedPublicParams_ = new HashMap<QName, String>();
-      for (ParameterInfo parameter : parameters) {
-        supportedPublicParams_.put(parameter.getName(), parameter.getId());
-      }
-    }
-
-    //
-    for (String publicParam : supportedPublicParams_.values()) {
-      if (publicParam.equals(supportedPublicParam)) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("The Portlet " + producerOfferedPortletContext.getId() + " supports the public render parameter : " +
-              supportedPublicParam);
-        }
-        return true;
-      }
-    }
-
-    //
-    return false;
   }
 
   /**
@@ -646,13 +384,10 @@ public class UIPortlet extends UIApplication {
 
     // Case when portlet has not public parameters in UIPortal but there are
     // supported public parameters in URL
-    if (supportedPublicParams_ != null &&
-        portletParameters != null
-        &&
-        portletParameters.size() > 0
-        &&
-        allPublicParamsNames.size() == 0) {
-      for (QName qName : supportedPublicParams_.keySet()) {
+    if (supportedPublicParams != null
+        && MapUtils.isNotEmpty(portletParameters)
+        && allPublicParamsNames.isEmpty()) {
+      for (QName qName : supportedPublicParams.keySet()) {
         String prpId = supportsPublicParam(qName);
         if (prpId != null && portletParameters.containsKey(prpId)) {
           publicParamsMap.put(prpId, portletParameters.get(prpId));
@@ -927,7 +662,7 @@ public class UIPortlet extends UIApplication {
    * This is used by the dashboard portlet and should not be used else where. It
    * will be removed some day.
    */
-  private static final ThreadLocal<UIPortlet> currentPortlet = new ThreadLocal<UIPortlet>();
+  private static final ThreadLocal<UIPortlet> currentPortlet = new ThreadLocal<>();
 
   public static UIPortlet getCurrentUIPortlet() {
     return currentPortlet.get();
@@ -951,52 +686,6 @@ public class UIPortlet extends UIApplication {
   }
 
   /**
-   * navigationalState - internal portlet container parameter (go with portlet
-   * url). called when navigation state updated
-   * 
-   * @param navigationalState
-   */
-  void setNavigationalState(StateString navigationalState) {
-    this.navigationalState = navigationalState;
-  }
-
-  /**
-   * configuredTitle - the localized title configured in portlet.xml. This value
-   * returned ans set after portlet container invocation.
-   * 
-   * @param _configuredTitle - portlet title responsed from portlet container
-   */
-  protected void setConfiguredTitle(String _configuredTitle) {
-    this.configuredTitle = _configuredTitle;
-  }
-
-  /**
-   * Returns the title showed on the InfoBar. The title is computed in following
-   * manner. <br>
-   * 1. First, the method getTitle(), inherited from UIPortalComponent is
-   * called. The getTitle() returns what users set in the PortletSetting tab,
-   * the current method returns call result if it is not null. <br>
-   * 2. configuredTitle, which is the localized value of javax.portlet.title is
-   * returned if it is not null. <br>
-   * 3. If the method does not terminate at neither (1) nor (2), the configured
-   * display name is returned.
-   *
-   * @return
-   */
-  public String getDisplayTitle() {
-    String displayedTitle = getTitle();
-    if (displayedTitle != null && displayedTitle.trim().length() > 0) {
-      return displayedTitle;
-    }
-
-    if (configuredTitle != null) {
-      return configuredTitle;
-    }
-
-    return getDisplayName();
-  }
-
-  /**
    * Parsing response from portlet container. The response contains:<br>
    * html markup, portlet title, response properties:<br>
    * - JS resource dependency (defined in gatein-resources.xml)<br>
@@ -1016,26 +705,15 @@ public class UIPortlet extends UIApplication {
     PortalRequestContext prcontext = (PortalRequestContext) context;
 
     Text markup = null;
-    if (pir instanceof FragmentResponse) {
-      if (lazyResourcesLoading == null) {
-        PortletInfo portletInfo = producedOfferedPortlet.getInfo();
-        if (portletInfo instanceof ContainerPortletInfo containerPortletInfo) {
-          String prefetchResources = containerPortletInfo.getInitParameter("prefetch.resources");
-          lazyResourcesLoading = StringUtils.equals(prefetchResources, "true");
-        } else {
-          lazyResourcesLoading = false;
-        }
-      }
-
-      FragmentResponse fragmentResponse = (FragmentResponse) pir;
+    if (pir instanceof FragmentResponse fragmentResponse) {
       switch (fragmentResponse.getType()) {
-      case FragmentResponse.TYPE_CHARS:
+      case ContentResponse.TYPE_CHARS:
         markup = Text.create(fragmentResponse.getContent());
         break;
-      case FragmentResponse.TYPE_BYTES:
-        markup = Text.create(fragmentResponse.getBytes(), Charset.forName("UTF-8"));
+      case ContentResponse.TYPE_BYTES:
+        markup = Text.create(fragmentResponse.getBytes(), StandardCharsets.UTF_8);
         break;
-      case FragmentResponse.TYPE_EMPTY:
+      default:
         markup = Text.create("");
         break;
       }
@@ -1075,7 +753,7 @@ public class UIPortlet extends UIApplication {
           List<Element> markupElements = markupHeaders.getValues(MimeResponse.MARKUP_HEAD_ELEMENT);
           if (markupElements != null) {
             for (Element element : markupElements) {
-              if (!context.useAjax() && "title".equals(element.getNodeName().toLowerCase())
+              if (!context.useAjax() && "title".equalsIgnoreCase(element.getNodeName())
                   && element.getFirstChild() != null) {
                 String title = element.getFirstChild().getNodeValue();
                 prcontext.getRequest().setAttribute(PortalRequestContext.REQUEST_TITLE, title);
@@ -1086,36 +764,128 @@ public class UIPortlet extends UIApplication {
           }
         }
       }
-
     } else {
-
       PortletContainerException pcException;
-
-      if (pir instanceof ErrorResponse) {
-        ErrorResponse errorResponse = (ErrorResponse) pir;
+      if (pir instanceof ErrorResponse errorResponse) {
         pcException = new PortletContainerException(errorResponse.getMessage(), errorResponse.getCause());
       } else {
         pcException = new PortletContainerException("Unknown invocation response type [" + pir.getClass() +
             "]. Expected a FragmentResponse or an ErrorResponse");
       }
-
-      //
       PortletExceptionHandleService portletExceptionService = getApplicationComponent(PortletExceptionHandleService.class);
       if (portletExceptionService != null) {
         portletExceptionService.handle(pcException);
       }
-
       // Log the error
       LOG.error("Portlet render threw an exception in page {}", prcontext.getRequest().getRequestURI(), pcException);
-
       markup = Text.create(context.getApplicationResourceBundle().getString("UIPortlet.message.RuntimeError"));
     }
-
     return markup;
   }
 
-  public boolean isLazyResourcesLoading() {
-    return lazyResourcesLoading != null && lazyResourcesLoading.booleanValue();
+  /**
+   * Tells, according to the info located in portlet.xml, wether this portlet
+   * supports the public render parameter qname given as method argument. If the
+   * qname is supported, the public render parameter id is returned otherwise
+   * false is returned.
+   *
+   * @param supportedPublicParam the supported public parameter qname
+   * @return the supported public parameter id
+   */
+  public String supportsPublicParam(QName supportedPublicParam) {
+    return getSupportedPublicParams().get(supportedPublicParam);
+  }
+
+  /**
+   * Tells, according to the info located in portlet.xml, wether this portlet
+   * supports the public render parameter given as a method argument
+   */
+  public boolean supportsPublicParam(String supportedPublicParam) {
+    return getSupportedPublicParams().values().contains(supportedPublicParam);
+  }
+
+  /**
+   * Tells, according to the info located in portlet.xml, wether this portlet
+   * can handle a portlet event with the QName given as the method argument
+   */
+  public boolean supportsProcessingEvent(QName name) {
+    return getSupportedProcessingEvents().contains(name);
+  }
+
+  public boolean supportsPublishingEvent(QName name) {
+    return getSupportedPublishingEvents().contains(name);
+  }
+
+  public Map<QName, String> getSupportedPublicParams() {
+    if (supportedPublicParams == null) {
+      if (producedOfferedPortlet == null) {
+        supportedPublicParams = Collections.emptyMap();
+      } else {
+        Collection<ParameterInfo> parameters = (Collection<ParameterInfo>) producedOfferedPortlet.getInfo()
+                                                                                                 .getNavigation()
+                                                                                                 .getPublicParameters();
+        supportedPublicParams = parameters.stream().collect(Collectors.toMap(ParameterInfo::getName, ParameterInfo::getId));
+      }
+    }
+    return supportedPublicParams;
+  }
+
+  public List<QName> getSupportedProcessingEvents() {
+    if (supportedProcessingEvents == null) {
+      org.gatein.pc.api.Portlet portlet = getProducedOfferedPortlet();
+      if (portlet == null) {
+        supportedProcessingEvents = Collections.emptyList();
+      } else {
+        Map<QName, EventInfo> consumedEvents = (Map<QName, EventInfo>) portlet.getInfo().getEventing().getConsumedEvents();
+        if (MapUtils.isEmpty(consumedEvents)) {
+          supportedProcessingEvents = Collections.emptyList();
+        } else {
+          supportedProcessingEvents = new ArrayList<>(consumedEvents.keySet());
+        }
+      }
+    }
+    return supportedProcessingEvents;
+  }
+
+  public List<QName> getSupportedPublishingEvents() {
+    if (supportedPublishingEvents == null) {
+      org.gatein.pc.api.Portlet portlet = getProducedOfferedPortlet();
+      if (portlet == null) {
+        supportedPublishingEvents = Collections.emptyList();
+      } else {
+        Map<QName, EventInfo> producedEvents = (Map<QName, EventInfo>) portlet.getInfo().getEventing().getProducedEvents();
+        if (MapUtils.isEmpty(producedEvents)) {
+          supportedPublishingEvents = Collections.emptyList();
+        } else {
+          supportedPublishingEvents = new ArrayList<>(producedEvents.keySet());
+        }
+      }
+    }
+    return supportedPublishingEvents;
+  }
+
+  /**
+   * Returns the title showed on the InfoBar. The title is computed in following
+   * manner. <br>
+   * 1. First, the method getTitle(), inherited from UIPortalComponent is
+   * called. The getTitle() returns what users set in the PortletSetting tab,
+   * the current method returns call result if it is not null. <br>
+   * 2. configuredTitle, which is the localized value of javax.portlet.title is
+   * returned if it is not null. <br>
+   * 3. If the method does not terminate at neither (1) nor (2), the configured
+   * display name is returned.
+   *
+   * @return
+   */
+  public String getDisplayTitle() {
+    String displayedTitle = getTitle();
+    if (displayedTitle != null && displayedTitle.trim().length() > 0) {
+      return displayedTitle;
+    }
+    if (configuredTitle != null) {
+      return configuredTitle;
+    }
+    return getDisplayName();
   }
 
   private String getMaximizedPortletMode() {

--- a/webui/src/main/java/org/exoplatform/portal/webui/page/UIPageBody.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/page/UIPageBody.java
@@ -24,24 +24,11 @@ import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.core.UIComponentDecorator;
 
-/**
- * May 19, 2006
- */
 @ComponentConfig(template = "system:/groovy/portal/webui/page/UIPageBody.gtmpl")
 public class UIPageBody extends UIComponentDecorator {
 
-  private String storageId;
-
   public UIPageBody() {
     setId("UIPageBody");
-  }
-
-  public String getStorageId() {
-    return storageId;
-  }
-
-  public void setStorageId(String storageId) {
-    this.storageId = storageId;
   }
 
   public String getPageName() {

--- a/webui/src/main/java/org/exoplatform/portal/webui/page/UISiteBody.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/page/UISiteBody.java
@@ -19,84 +19,59 @@
 
 package org.exoplatform.portal.webui.page;
 
-import javax.portlet.WindowState;
-
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.portal.application.PortalRequestContext;
-import org.exoplatform.portal.webui.application.UIPortlet;
 import org.exoplatform.web.application.RequestContext;
-import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.core.UIComponentDecorator;
 
-/**
- * May 19, 2006
- */
 @ComponentConfig(template = "system:/groovy/portal/webui/page/UISiteBody.gtmpl")
 public class UISiteBody extends UIComponentDecorator {
 
-    /** The storage id. */
-    private String storageId;
-
-    public String getStorageId() {
-        return storageId;
-    }
-
-    public void setStorageId(String storageId) {
-        this.storageId = storageId;
-    }
-
-    @Override
-    public void processRender(WebuiRequestContext context) throws Exception {
-      PortalRequestContext portalRequestContext = PortalRequestContext.getCurrentInstance();
-      portalRequestContext.startServerTime("UISiteBody");
-      try {
-        if (isShowSiteBody()) {
-          processContainerRender(context);
-        } else {
-          processPageBodyRender(context);
-        }
-      } finally {
-        portalRequestContext.endServerTime("UISiteBody");
-      }
-    }
-
-    public String getSiteClass() {
-      String portalOwner = ((PortalRequestContext) RequestContext.getCurrentInstance()).getPortalOwner();
-      if (StringUtils.isBlank(portalOwner)) {
-        return "";
+  @Override
+  public UIComponent getUIComponent() {
+    if (isShowSiteBody()) {
+      return getSiteComponent();
+    } else {
+      if (PortalRequestContext.getCurrentInstance().isMaximizePortlet()) {
+        return getMaximizedPortlet();
       } else {
-        return portalOwner.toUpperCase() + "Site";
+        return getPageComponent();
       }
     }
+  }
 
-    @Override
-    public UIComponent getUIComponent() {
-      return PortalRequestContext.getCurrentInstance().getUiPortal();
+  /**
+   * @return Site CSS class. Used in gtmpl in order to allow specifying a
+   *         specific CSS selector for current Site
+   */
+  public String getSiteClass() {
+    String portalOwner = PortalRequestContext.getCurrentInstance().getPortalOwner();
+    if (StringUtils.isBlank(portalOwner)) {
+      return "";
+    } else {
+      return portalOwner.toUpperCase() + "Site";
     }
+  }
 
-    protected boolean isShowSiteBody() {
-      PortalRequestContext requestContext = RequestContext.getCurrentInstance();
-      return !requestContext.isShowMaxWindow() && (requestContext.getUiPage() == null || !requestContext.getUiPage().isShowMaxWindow());
-    }
+  protected UIComponent getSiteComponent() {
+    return PortalRequestContext.getCurrentInstance().getUiPortal();
+  }
 
-    protected void processPageBodyRender(WebuiRequestContext context) throws Exception {
-      UIPortlet maximizedUIPortlet = PortalRequestContext.getCurrentInstance().getMaximizedUIPortlet();
-      if (maximizedUIPortlet != null) {
-        maximizedUIPortlet.setCurrentWindowState(WindowState.MAXIMIZED);
-        maximizedUIPortlet.processRender(context);
-      } else {
-        UIPageBody uiPageBody = findFirstComponentOfType(UIPageBody.class);
-        if (uiPageBody != null) {
-          uiPageBody.processRender(context);
-        }
-      }
-    }
+  protected UIComponent getPageComponent() {
+    return getSiteComponent().findFirstComponentOfType(UIPageBody.class);
+  }
 
-    protected void processContainerRender(WebuiRequestContext context) throws Exception {
-      super.processRender(context);
-    }
+  protected UIComponent getMaximizedPortlet() {
+    return PortalRequestContext.getCurrentInstance().getMaximizedUIPortlet();
+  }
+
+  protected boolean isShowSiteBody() {
+    PortalRequestContext requestContext = RequestContext.getCurrentInstance();
+    return !requestContext.isShowMaxWindow()
+           && (requestContext.getUiPage() == null || !requestContext.getUiPage().isShowMaxWindow());
+  }
 
 }

--- a/webui/src/main/java/org/exoplatform/portal/webui/portal/UISharedLayout.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/portal/UISharedLayout.java
@@ -19,6 +19,9 @@
 
 package org.exoplatform.portal.webui.portal;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.portal.application.PortalRequestContext;
@@ -28,28 +31,21 @@ import org.exoplatform.portal.mop.SiteType;
 import org.exoplatform.portal.webui.container.UIContainer;
 import org.exoplatform.portal.webui.page.UIPage;
 import org.exoplatform.portal.webui.page.UISiteBody;
-import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
+import org.exoplatform.webui.core.UIComponent;
 
-@ComponentConfig(
-
-)
+@ComponentConfig
 public class UISharedLayout extends UIContainer {
 
   private String metaPortal;
 
   @Override
-  public void processRender(WebuiRequestContext context) throws Exception {
+  public List<UIComponent> getChildren() {
     PortalRequestContext portalRequestContext = PortalRequestContext.getCurrentInstance();
-    portalRequestContext.startServerTime("UISharedLayout");
-    try {
-      if (isShowSharedLayout(portalRequestContext)) {
-        processContainerRender(context);
-      } else {
-        processSiteBodyRender(context);
-      }
-    } finally {
-      portalRequestContext.endServerTime("UISharedLayout");
+    if (isShowSharedLayout(portalRequestContext)) {
+      return getSharedLayoutChildren();
+    } else {
+      return getSiteLayoutChildren();
     }
   }
 
@@ -69,13 +65,13 @@ public class UISharedLayout extends UIContainer {
     return showSharedLayout;
   }
 
-  protected void processSiteBodyRender(WebuiRequestContext context) throws Exception {
-    UISiteBody uiSiteBody = findFirstComponentOfType(UISiteBody.class);
-    uiSiteBody.processRender(context);
+  protected List<UIComponent> getSiteLayoutChildren() {
+    UISiteBody uiSiteBody = findFirstComponentOfType(UISiteBody.class, getSharedLayoutChildren());
+    return Collections.singletonList(uiSiteBody);
   }
 
-  protected void processContainerRender(WebuiRequestContext context) throws Exception {
-    super.processRender(context);
+  protected List<UIComponent> getSharedLayoutChildren() {
+    return super.getChildren();
   }
 
   private boolean showSiteSharedLayout(PortalConfig site) {

--- a/webui/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/util/PortalDataMapper.java
@@ -140,15 +140,15 @@ public class PortalDataMapper {
     uiPage.findComponentOfType(portlets, UIPortlet.class);
   }
 
-  public static void toUIPortal(UIPortal uiPortal, PortalConfig model) throws Exception {
+  public static void toUIPortal(UIPortal uiPortal, PortalConfig model) {
     buildUIPortal(uiPortal, model, false);
   }
 
-  public static void toUIPortalWithMetaLayout(UIPortal uiPortal, PortalConfig model) throws Exception {
+  public static void toUIPortalWithMetaLayout(UIPortal uiPortal, PortalConfig model) {
     buildUIPortal(uiPortal, model, true);
   }
 
-  private static void buildUIPortal(UIPortal uiPortal, PortalConfig model, boolean metaLayout) throws Exception {
+  private static void buildUIPortal(UIPortal uiPortal, PortalConfig model, boolean metaLayout) {
     uiPortal.setSiteKey(new SiteKey(model.getType(), model.getName()));
     uiPortal.setStorageId(model.getStorageId());
     uiPortal.setName(model.getName());
@@ -183,14 +183,10 @@ public class PortalDataMapper {
     UIComponent uiComponent = null;
     WebuiRequestContext context = Util.getPortalRequestContext();
 
-    if (model instanceof SiteBody siteBody) {
-      UISiteBody uiSiteBody = uiContainer.createUIComponent(context, UISiteBody.class, null, null);
-      uiSiteBody.setStorageId(siteBody.getStorageId());
-      uiComponent = uiSiteBody;
-    } else if (model instanceof PageBody pageBody) {
-      UIPageBody uiPageBody = uiContainer.createUIComponent(context, UIPageBody.class, null, null);
-      uiPageBody.setStorageId(pageBody.getStorageId());
-      uiComponent = uiPageBody;
+    if (model instanceof SiteBody) {
+      uiComponent = uiContainer.createUIComponent(context, UISiteBody.class, null, null);
+    } else if (model instanceof PageBody) {
+      uiComponent = uiContainer.createUIComponent(context, UIPageBody.class, null, null);
     } else if (model instanceof Application application) {
       UIPortlet uiPortlet = uiContainer.createUIComponent(context, UIPortlet.class, null, null);
       uiPortlet.setStorageId(application.getStorageId());

--- a/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -852,12 +852,10 @@ public class UIPortalApplication extends UIApplication {
     List<UIPortlet> portlets = new ArrayList<>();
     uiViewWorkingWorkspace.findComponentOfType(portlets, UIPortlet.class);
     for (UIPortlet uiPortlet : portlets) {
-      if (!uiPortlet.isLazyResourcesLoading()) {
-        try {
-          jsMan.loadScriptResource(ResourceScope.PORTLET, uiPortlet.getApplicationId());
-        } catch (Exception e) {
-          LOG.warn("Can't load JS resource for portlet {}", uiPortlet.getName(), e);
-        }
+      try {
+        jsMan.loadScriptResource(ResourceScope.PORTLET, uiPortlet.getApplicationId());
+      } catch (Exception e) {
+        LOG.warn("Can't load JS resource for portlet {}", uiPortlet.getName(), e);
       }
     }
     // Load static body-end-container applications added on UIPortalApplication

--- a/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIWorkingWorkspace.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIWorkingWorkspace.java
@@ -19,8 +19,6 @@
 
 package org.exoplatform.portal.webui.workspace;
 
-import org.exoplatform.portal.webui.page.UISiteBody;
-import org.exoplatform.portal.webui.portal.UIPortal;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.core.UIContainer;
 
@@ -30,25 +28,4 @@ import org.exoplatform.webui.core.UIContainer;
 
 @ComponentConfig(id = "UIWorkingWorkspace", template = "system:/groovy/portal/webui/workspace/UIWorkingWorkspace.gtmpl")
 public class UIWorkingWorkspace extends UIContainer {
-
-    private UIPortal backupUIPortal = null;
-
-    public UIPortal getBackupUIPortal() {
-        return backupUIPortal;
-    }
-
-    public void setBackupUIPortal(UIPortal uiPortal) {
-        backupUIPortal = uiPortal;
-    }
-
-    public UIPortal restoreUIPortal() {
-        UIPortal result = backupUIPortal;
-        if (result == null) {
-            throw new IllegalStateException("backupUIPortal not available");
-        } else {
-            UISiteBody siteBody = findFirstComponentOfType(UISiteBody.class);
-            siteBody.setUIComponent(result);
-            return result;
-        }
-    }
 }

--- a/webui/src/main/java/org/exoplatform/webui/core/UIContainer.java
+++ b/webui/src/main/java/org/exoplatform/webui/core/UIContainer.java
@@ -187,19 +187,23 @@ public class UIContainer extends UIComponent {
   @Override
   public <T extends UIComponent> T findFirstComponentOfType(Class<T> type) {
     List<UIComponent> subComponents = getChildren();
-    if (type.isInstance(this)) {
+    return findFirstComponentOfType(type, subComponents);
+  }
+
+  public <T extends UIComponent> T findFirstComponentOfType(Class<T> type, List<UIComponent> components) {
+    if (components == null) {
+      return null;
+    } else if (type.isInstance(this)) {
       return type.cast(this);
-    }
-    if (children == null) {
+    } else {
+      for (UIComponent uichild : components) {
+        T found = uichild.findFirstComponentOfType(type);
+        if (found != null) {
+          return found;
+        }
+      }
       return null;
     }
-    for (UIComponent uichild : subComponents) {
-      T found = uichild.findFirstComponentOfType(type);
-      if (found != null) {
-        return found;
-      }
-    }
-    return null;
   }
 
   @Override

--- a/webui/src/main/java/org/exoplatform/webui/ext/UIExtension.java
+++ b/webui/src/main/java/org/exoplatform/webui/ext/UIExtension.java
@@ -238,7 +238,7 @@ public class UIExtension implements Comparable<UIExtension> {
         }
       }
     }
-    throw new UnsupportedDataTypeException("The expected type is a list of objects of type UIExtensionFilter");
+    throw new UnsupportedDataTypeException(String.format("The expected type is a list of objects of type UIExtensionFilter. found: %s", returnType));
   }
   
   /**

--- a/webui/src/test/java/org/exoplatform/portal/webui/workspace/UISharedLayoutTest.java
+++ b/webui/src/test/java/org/exoplatform/portal/webui/workspace/UISharedLayoutTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.AfterClass;
@@ -33,8 +35,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.webui.portal.UISharedLayout;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.web.application.RequestContext;
 import org.exoplatform.webui.application.WebuiRequestContext;
+import org.exoplatform.webui.core.UIComponent;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UISharedLayoutTest {
@@ -51,7 +55,7 @@ public class UISharedLayoutTest {
 
   @Before
   public void setUp() {
-    PORTAL_REQUEST_CONTEXT.when(() -> RequestContext.getCurrentInstance()).thenReturn(pcontext);
+    PORTAL_REQUEST_CONTEXT.when(RequestContext::getCurrentInstance).thenReturn(pcontext);
   }
 
   @Test
@@ -59,32 +63,47 @@ public class UISharedLayoutTest {
     AtomicInteger siteBodyRenderCount = new AtomicInteger(0);
     AtomicInteger overallRenderCount = new AtomicInteger(0);
 
-    UISharedLayout sharedLayout = new UISharedLayout() {
-      @Override
-      protected void processSiteBodyRender(WebuiRequestContext context) throws Exception {
-        siteBodyRenderCount.incrementAndGet();
-      }
+    ConversationState.setCurrent(new ConversationState(null));
+    try {
 
-      @Override
-      protected void processContainerRender(WebuiRequestContext context) throws Exception {
-        overallRenderCount.incrementAndGet();
-      }
+      UISharedLayout sharedLayout = new UISharedLayout() {
 
-      @Override
-      public boolean isShowSharedLayout(PortalRequestContext requestContext) {
-        return !pcontext.isHideSharedLayout();
-      }
-    };
-    sharedLayout.processRender(pcontext);
+        @Override
+        public void processRender(WebuiRequestContext context) throws Exception {
+          renderChildren();
+        }
 
-    assertEquals(1, overallRenderCount.get());
-    assertEquals(0, siteBodyRenderCount.get());
+        @Override
+        public boolean isShowSharedLayout(PortalRequestContext requestContext) {
+          return !pcontext.isHideSharedLayout();
+        }
 
-    when(pcontext.isHideSharedLayout()).thenReturn(true);
-    sharedLayout.processRender(pcontext);
+        @Override
+        protected List<UIComponent> getSiteLayoutChildren() {
+          siteBodyRenderCount.incrementAndGet();
+          return Collections.emptyList();
+        }
 
-    assertEquals(1, overallRenderCount.get());
-    assertEquals(1, siteBodyRenderCount.get());
+        @Override
+        protected List<UIComponent> getSharedLayoutChildren() {
+          overallRenderCount.incrementAndGet();
+          return Collections.emptyList();
+        }
+
+      };
+      sharedLayout.processRender(pcontext);
+
+      assertEquals(1, overallRenderCount.get());
+      assertEquals(0, siteBodyRenderCount.get());
+
+      when(pcontext.isHideSharedLayout()).thenReturn(true);
+      sharedLayout.processRender(pcontext);
+
+      assertEquals(1, overallRenderCount.get());
+      assertEquals(1, siteBodyRenderCount.get());
+    } finally {
+      ConversationState.setCurrent(null);
+    }
   }
 
 }

--- a/webui/src/test/java/org/exoplatform/portal/webui/workspace/UISiteBodyTest.java
+++ b/webui/src/test/java/org/exoplatform/portal/webui/workspace/UISiteBodyTest.java
@@ -35,6 +35,7 @@ import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.webui.page.UISiteBody;
 import org.exoplatform.web.application.RequestContext;
 import org.exoplatform.webui.application.WebuiRequestContext;
+import org.exoplatform.webui.core.UIComponent;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UISiteBodyTest {
@@ -61,14 +62,22 @@ public class UISiteBodyTest {
 
     UISiteBody uiSiteBody = new UISiteBody() {
       @Override
-      protected void processPageBodyRender(WebuiRequestContext context) throws Exception {
-        pageBodyRenderCount.incrementAndGet();
+      public void processRender(WebuiRequestContext context) throws Exception {
+        getUIComponent();
       }
 
       @Override
-      protected void processContainerRender(WebuiRequestContext context) throws Exception {
+      protected UIComponent getSiteComponent() {
         overallRenderCount.incrementAndGet();
+        return null;
       }
+
+      @Override
+      protected UIComponent getPageComponent() {
+        pageBodyRenderCount.incrementAndGet();
+        return null;
+      }
+
     };
     uiSiteBody.processRender(pcontext);
 

--- a/webui/src/test/java/org/exoplatform/webui/ext/UIExtensionTest.java
+++ b/webui/src/test/java/org/exoplatform/webui/ext/UIExtensionTest.java
@@ -176,7 +176,7 @@ public class UIExtensionTest extends TestCase {
   public static class MyTestUIExtensionComponent3 extends UIComponent {
     @UIExtensionFilters
     public List<UIExtensionFilter> getFilters() {
-      return Arrays.asList(new UIExtensionFilter[]{new MyTestUIExtensionFilter1(), new MyTestUIExtensionFilter1()});
+      return Arrays.asList(new MyTestUIExtensionFilter1(), new MyTestUIExtensionFilter1());
     }    
   }
   
@@ -184,15 +184,14 @@ public class UIExtensionTest extends TestCase {
     private MyTestUIExtensionComponent4(){}    
     @UIExtensionFilters
     public List<UIExtensionFilter> getFilters() {
-      return Arrays.asList(new UIExtensionFilter[]{new MyTestUIExtensionFilter1()});
+      return Arrays.asList(new MyTestUIExtensionFilter1());
     }    
   }
   
   public static class MyTestUIExtensionComponent5 extends UIComponent {
-    @SuppressWarnings("unused")
     @UIExtensionFilters
     private List<UIExtensionFilter> getFilters() {
-      return Arrays.asList(new UIExtensionFilter[]{new MyTestUIExtensionFilter1()});
+      return Arrays.asList(new MyTestUIExtensionFilter1());
     }    
   }
   


### PR DESCRIPTION
Prior to this change, some Portlets were loaded later in Page Rendering phase while it should be included in JS files to preload in page retrieving phase. This change will disable the lazy loading of JS of portlets to rely all time on preloading mechanism.

Resolves Meeds-io/meeds#2924