### PR TITLE
fix: Fix Retrieving current instance of PortalRequestContext - MEED-8372 - Meeds-io/meeds#2924

### DIFF
--- a/component/web/controller/src/main/java/org/exoplatform/web/application/RequestContext.java
+++ b/component/web/controller/src/main/java/org/exoplatform/web/application/RequestContext.java
@@ -169,7 +169,15 @@ public abstract class RequestContext {
 
     public abstract UserPortal getUserPortal();
 
+    /**
+     * @param <T>
+     * @return
+     * @deprecated Use PortalRequestContext#getCurrentInstance or
+     *             PortletRequestContext#getCurrentInstance for type casting
+     *             safe instead
+     */
     @SuppressWarnings("unchecked")
+    @Deprecated(forRemoval = true, since = "7.0")
     public static <T extends RequestContext> T getCurrentInstance() {
         return (T) tlocal_.get();
     }

--- a/webui/src/main/java/org/exoplatform/portal/application/PortalLogoutLifecycle.java
+++ b/webui/src/main/java/org/exoplatform/portal/application/PortalLogoutLifecycle.java
@@ -76,8 +76,7 @@ public class PortalLogoutLifecycle implements ApplicationLifecycle<WebuiRequestC
             param.put(LoginError.ERROR_PARAM, error.toString());
         }
 
-        PortalRequestContext prContext = (PortalRequestContext)context;
-        prContext.requestAuthenticationLogin(param);
+        PortalRequestContext.getCurrentInstance().requestAuthenticationLogin(param);
     }
 
     public void onFailRequest(Application app, WebuiRequestContext context, RequestFailure failureType) {

--- a/webui/src/main/java/org/exoplatform/portal/application/PortalStateManager.java
+++ b/webui/src/main/java/org/exoplatform/portal/application/PortalStateManager.java
@@ -52,7 +52,7 @@ public class PortalStateManager extends StateManager {
 
     //
     ApplicationState appState = null;
-    HttpSession session = getSession(context);
+    HttpSession session = getSession();
     String key = getKey(context);
     if (session != null) {
       appState = (ApplicationState) session.getAttribute(APPLICATION_ATTRIBUTE_PREFIX + key);
@@ -90,7 +90,7 @@ public class PortalStateManager extends StateManager {
 
     //
     if (uiapp != null) {
-      HttpSession session = getSession(context);
+      HttpSession session = getSession();
 
       // At this point if it returns null it means that it was not possible to
       // create a session
@@ -106,23 +106,16 @@ public class PortalStateManager extends StateManager {
   }
 
   private String getKey(WebuiRequestContext webuiRC) {
-    if (webuiRC instanceof PortletRequestContext) {
-      PortletRequestContext portletRC = (PortletRequestContext) webuiRC;
+    if (webuiRC instanceof PortletRequestContext portletRC) {
       return portletRC.getApplication().getApplicationId() + "/" + portletRC.getWindowId();
     } else {
       return PortalApplication.PORTAL_APPLICATION_ID;
     }
   }
 
-  private HttpSession getSession(WebuiRequestContext webuiRC) {
-    PortalRequestContext portalRC;
-    if (webuiRC instanceof PortletRequestContext) {
-      PortletRequestContext portletRC = (PortletRequestContext) webuiRC;
-      portalRC = (PortalRequestContext) portletRC.getParentAppRequestContext();
-    } else {
-      portalRC = (PortalRequestContext) webuiRC;
-    }
-    HttpServletRequest req = portalRC.getRequest();
+  private HttpSession getSession() {
+    HttpServletRequest req = PortalRequestContext.getCurrentInstance().getRequest();
     return req.getSession(false);
   }
+
 }

--- a/webui/src/main/java/org/exoplatform/portal/application/localization/LocalizationLifecycle.java
+++ b/webui/src/main/java/org/exoplatform/portal/application/localization/LocalizationLifecycle.java
@@ -132,7 +132,7 @@ public class LocalizationLifecycle extends BaseComponentPlugin implements Applic
   public void onEndRequest(Application app, WebuiRequestContext context) throws Exception {
     // if onStartRequest survived the cast, this one should as well - no check
     // necessary
-    PortalRequestContext reqCtx = (PortalRequestContext) context;
+    PortalRequestContext reqCtx = PortalRequestContext.getCurrentInstance();
     Locale loc = reqCtx.getLocale();
 
     // if locale changed since previous request

--- a/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortlet.java
@@ -702,7 +702,7 @@ public class UIPortlet extends UIApplication {
    * @see PortletExceptionHandleService
    */
   public Text generateRenderMarkup(PortletInvocationResponse pir, WebuiRequestContext context) {
-    PortalRequestContext prcontext = (PortalRequestContext) context;
+    PortalRequestContext prcontext = PortalRequestContext.getCurrentInstance();
 
     Text markup = null;
     if (pir instanceof FragmentResponse fragmentResponse) {

--- a/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortletActionListener.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortletActionListener.java
@@ -98,7 +98,7 @@ public class UIPortletActionListener {
   public static class ProcessActionActionListener<S, C extends Serializable, I> extends EventListener<UIPortlet> {
     public void execute(Event<UIPortlet> event) throws Exception {
       UIPortlet uiPortlet = event.getSource();
-      PortalRequestContext prcontext = (PortalRequestContext) event.getRequestContext();
+      PortalRequestContext prcontext = PortalRequestContext.getCurrentInstance();
 
       // set the public render parameters from the request before creating the
       // invocation
@@ -326,7 +326,7 @@ public class UIPortletActionListener {
       String resourceId = null;
 
       //
-      PortalRequestContext context = (PortalRequestContext) event.getRequestContext();
+      PortalRequestContext context = PortalRequestContext.getCurrentInstance();
       HttpServletResponse response = context.getResponse();
 
       //
@@ -482,7 +482,7 @@ public class UIPortletActionListener {
   public static class ProcessEventsActionListener extends EventListener<UIPortlet> {
     public void execute(Event<UIPortlet> event) throws Exception {
       UIPortlet uiPortlet = event.getSource();
-      PortalRequestContext context = (PortalRequestContext) event.getRequestContext();
+      PortalRequestContext context = PortalRequestContext.getCurrentInstance();
       List<UIPortlet> portletInstancesInPage = new ArrayList<UIPortlet>();
       // UIPortalApplication uiPortal =
       // uiPortlet.getAncestorOfType(UIPortalApplication.class);

--- a/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortletLifecycle.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/application/UIPortletLifecycle.java
@@ -182,7 +182,7 @@ public class UIPortletLifecycle extends Lifecycle<UIPortlet> {
     PortalRequestContext portalRequestContext = PortalRequestContext.getCurrentInstance();
     String key = "UIPortlet_" + uicomponent.getApplicationId().split("/")[1] + "_" + uicomponent.getStorageId();
     boolean started = portalRequestContext.startServerTime(key);
-    PortalRequestContext prcontext = (PortalRequestContext) context;
+    PortalRequestContext prcontext = PortalRequestContext.getCurrentInstance();
     Text markup = null;
     try {
       Map<String, String[]> paramMap = prcontext.getRequest().getParameterMap();

--- a/webui/src/main/java/org/exoplatform/portal/webui/page/UISiteBody.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/page/UISiteBody.java
@@ -22,7 +22,6 @@ package org.exoplatform.portal.webui.page;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.portal.application.PortalRequestContext;
-import org.exoplatform.web.application.RequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.core.UIComponentDecorator;
@@ -69,7 +68,7 @@ public class UISiteBody extends UIComponentDecorator {
   }
 
   protected boolean isShowSiteBody() {
-    PortalRequestContext requestContext = RequestContext.getCurrentInstance();
+    PortalRequestContext requestContext = PortalRequestContext.getCurrentInstance();
     return !requestContext.isShowMaxWindow()
            && (requestContext.getUiPage() == null || !requestContext.getUiPage().isShowMaxWindow());
   }

--- a/webui/src/main/java/org/exoplatform/portal/webui/portal/UIPortal.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/portal/UIPortal.java
@@ -150,11 +150,11 @@ public class UIPortal extends UIContainer {
   }
 
   public boolean isDraftPage() {
-    return ((PortalRequestContext) RequestContext.getCurrentInstance()).isDraftPage();
+    return PortalRequestContext.getCurrentInstance().isDraftPage();
   }
 
   public boolean isNoCache() {
-    return ((PortalRequestContext) RequestContext.getCurrentInstance()).isNoCache();
+    return PortalRequestContext.getCurrentInstance().isNoCache();
   }
 
   public void clearUIPage(String pageReference) {

--- a/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplication.java
@@ -604,7 +604,7 @@ public class UIPortalApplication extends UIApplication {
    */
   @Override
   public void processAction(WebuiRequestContext context) throws Exception {
-    PortalRequestContext pcontext = (PortalRequestContext) context;
+    PortalRequestContext pcontext = PortalRequestContext.getCurrentInstance();
     UserNode targetNode = pcontext.getNavigationNode();
     if (targetNode == null) {
       // If unauthenticated users have no permission on PORTAL node and

--- a/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplicationLifecycle.java
+++ b/webui/src/main/java/org/exoplatform/portal/webui/workspace/UIPortalApplicationLifecycle.java
@@ -45,7 +45,7 @@ public class UIPortalApplicationLifecycle extends Lifecycle<UIPortalApplication>
     if (uiTarget == null) {
       context.addUIComponentToUpdateByAjax(uicomponent.<UIComponent> getChildById(UIPortalApplication.UI_WORKING_WS_ID));
       context.addUIComponentToUpdateByAjax(uicomponent.getChild(UIMaskWorkspace.class));
-      ((PortalRequestContext) context).ignoreAJAXUpdateOnPortlets(true);
+      PortalRequestContext.getCurrentInstance().ignoreAJAXUpdateOnPortlets(true);
       return;
     }
     if (uiTarget == uicomponent) {
@@ -78,7 +78,7 @@ public class UIPortalApplicationLifecycle extends Lifecycle<UIPortalApplication>
 
   @Override
   public void processRender(UIPortalApplication uicomponent, WebuiRequestContext context) throws Exception {
-    PortalRequestContext portalRequestContext = (PortalRequestContext) context;
+    PortalRequestContext portalRequestContext = PortalRequestContext.getCurrentInstance();
     OutputStream responseOutputStream = portalRequestContext.getResponse().getOutputStream();
     PortalPrinter parentWriter = new PortalPrinter(responseOutputStream, true, 5000);
 


### PR DESCRIPTION
Prior to this change, when requesting `UISiteBody` from a WebUI portlet (**eXo ecms**), the returned Request Context is of type PortletRequestCotnext. This change ensures to not cast the returned value of '`RequestContext.getCurrentInstance`' but to rely on newly added method '`PortalRequestContext.getCurrentInstance`' which will retrieve the **parent context** if called from a portlet.

Resolves Meeds-io/meeds#2924