### PR TITLE
fix : Default language has become ar instead of en - MEED-8471

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/common/locales-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/common/locales-config.xml
@@ -26,8 +26,17 @@
     The encoding parameter will be used for the request  response stream.
     The input-encoding parameter will be used for request setCharacterEncoding(..) 
 
-    encoding: ISO-8859-1 
+    encoding: ISO-8859-1
+
+    The first defined locale is used as default locale in the platform => keep en as first
   -->
+  <locale-config>
+    <locale>en</locale>
+    <output-encoding>UTF-8</output-encoding>
+    <input-encoding>UTF-8</input-encoding>
+    <description>Default configuration for english locale</description>
+  </locale-config>
+
   <locale-config>
     <locale>ar</locale>
     <output-encoding>UTF-8</output-encoding>
@@ -91,13 +100,6 @@
     <output-encoding>UTF-8</output-encoding>
     <input-encoding>UTF-8</input-encoding>
     <description>Default configuration for the Dutch locale</description>
-  </locale-config>
-
-  <locale-config>
-    <locale>en</locale>
-    <output-encoding>UTF-8</output-encoding>
-    <input-encoding>UTF-8</input-encoding>
-    <description>Default configuration for english locale</description>
   </locale-config>
 
   <locale-config>


### PR DESCRIPTION
Before this fix, default language of the platform is ar This problem comes from the fact that the first language in locales-config file is ar This commit moves en as first language to keep en as default.

Resolves meeds-io/meeds#2997

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
