### PR TITLE
fix: Display problems with languages with a dialect like PT-BR - MEED-8467

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -37,7 +37,7 @@
   String language = rcontext.getLocale().getLanguage();
   String country = rcontext.getLocale().getCountry();
   if (country != null && country.length() > 0) {
-    language += "-" + country;
+    language += "_" + country;
   }
   String docBase =  rcontext.getRequestContextPath() ;
   String skin = uicomponent.getSkin();


### PR DESCRIPTION
Before this fix, the language code used for languages with dialects is pt-br, but the value returned by LocaleContextInfoUtils is pt_br It leads to some display problems explained in the attached issue.

This commit replace the - by a _

Resolves meeds-io/meeds#2990

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
