### PR TITLE
fix: Allow direct access to allowed sub-pages - MEED-8472 - Meeds-io/meeds#2999

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/mop/navigation/NodeContext.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/navigation/NodeContext.java
@@ -254,7 +254,7 @@ public final class NodeContext<N> extends ListTree<NodeContext<N>> {
                     throw new IllegalArgumentException("the node " + name + " already exist");
                 }
             } else {
-                tree.addChange(new NodeChange.Renamed<NodeContext<N>>(getParent(), this, name));
+                tree.addChange(new NodeChange.Renamed<>(getParent(), this, name));
             }
         }
     }
@@ -265,12 +265,24 @@ public final class NodeContext<N> extends ListTree<NodeContext<N>> {
      * @param filter the filter to apply
      */
     public void filter(NodeFilter filter) {
-
-        setHidden(!accept(filter));
         if (expanded) {
             for (NodeContext<N> node = getFirst(); node != null; node = node.getNext()) {
                 node.filter(filter);
             }
+        }
+        if (accept(filter)) {
+          setHidden(false);
+        } else if (filter.isHideOnlyPage() && getNodeSize() > 0) {
+          if (state != null) {
+            state = state.builder().pageRef(null).build();
+          }
+          if (data != null && data.getState() != null) {
+            data = new NodeData(this);
+            data.state = data.state.builder().pageRef(null).build();
+          }
+          setHidden(false);
+        } else {
+          setHidden(true);
         }
     }
 

--- a/component/api/src/main/java/org/exoplatform/portal/mop/navigation/NodeFilter.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/navigation/NodeFilter.java
@@ -38,4 +38,10 @@ public interface NodeFilter {
      */
     boolean accept(int depth, String id, String name, NodeState state);
 
+    /**
+     * @return true if the node should be hidden only when not having access to
+     *         page and not having children, else false
+     */
+    boolean isHideOnlyPage();
+
 }

--- a/component/management/src/main/java/org/gatein/api/PortalImpl.java
+++ b/component/management/src/main/java/org/gatein/api/PortalImpl.java
@@ -39,7 +39,6 @@ import org.exoplatform.services.log.Log;
 
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.portal.config.*;
-import org.exoplatform.portal.config.model.Container;
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.portal.mop.QueryResult;
 import org.exoplatform.portal.mop.SiteKey;

--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -53,12 +53,15 @@ import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.SiteType;
 import org.exoplatform.portal.mop.Visibility;
 import org.exoplatform.portal.mop.importer.ImportMode;
+import org.exoplatform.portal.mop.navigation.NavigationContext;
+import org.exoplatform.portal.mop.navigation.NodeContext;
 import org.exoplatform.portal.mop.page.PageContext;
 import org.exoplatform.portal.mop.page.PageKey;
 import org.exoplatform.portal.mop.service.LayoutService;
 import org.exoplatform.portal.mop.service.NavigationService;
 import org.exoplatform.portal.mop.user.UserNavigation;
 import org.exoplatform.portal.mop.user.UserNode;
+import org.exoplatform.portal.mop.user.UserNodeContext;
 import org.exoplatform.portal.mop.user.UserNodeFilterConfig;
 import org.exoplatform.portal.mop.user.UserNodeFilterConfig.Builder;
 import org.exoplatform.portal.mop.user.UserPortal;
@@ -394,11 +397,11 @@ public class UserPortalConfigService implements Startable {
       return null;
     } else {
       do {
-        if (isAccessiblePage(targetUserNode, username)) {
+        if (isAccessiblePageNoDraft(targetUserNode, username)) {
           return targetUserNode;
         } else if (CollectionUtils.isNotEmpty(targetUserNode.getChildren())) {
           UserNode childUserNode = getNodeOrFirstChildWithPage(targetUserNode.getChildren(), username);
-          if (isAccessiblePage(childUserNode, username)) {
+          if (isAccessiblePageNoDraft(childUserNode, username)) {
             return childUserNode;
           }
         }
@@ -421,18 +424,30 @@ public class UserPortalConfigService implements Startable {
     if (userPortalConfig == null) {
       return null;
     }
+    SiteKey siteKey = new SiteKey(SiteType.valueOf(siteType.toUpperCase()), siteName);
+
     UserPortal userPortal = userPortalConfig.getUserPortal();
-    UserNavigation navigation = userPortal.getNavigation(new SiteKey(SiteType.valueOf(siteType.toUpperCase()), siteName));
-    if (navigation == null) {
+    UserNavigation navigation = userPortal.getNavigation(siteKey);
+    NavigationContext navigationContext = getNavigationService().loadNavigation(siteKey);
+    if (navigationContext == null) {
       return null;
     }
-    Builder builder = UserNodeFilterConfig.builder().withReadCheck().withTemporalCheck();
+    Builder builder = UserNodeFilterConfig.builder().withReadCheckNoPage().withTemporalCheck();
     if (withVisibility) {
       builder.withVisibility(Visibility.DISPLAYED, Visibility.TEMPORAL);
     } else {
       builder.withoutVisibility();
     }
-    return userPortal.getNode(navigation, org.exoplatform.portal.mop.navigation.Scope.ALL, builder.build(), null);
+    UserNodeContext userNodeContext = new UserNodeContext(navigation, builder.build());
+    NodeContext<UserNode> nodeContext = getNavigationService().loadNode(userNodeContext,
+                                                                        navigationContext,
+                                                                        org.exoplatform.portal.mop.navigation.Scope.ALL,
+                                                                        null);
+    if (nodeContext != null) {
+      return nodeContext.getNode().filter();
+    } else {
+      return null;
+    }
   }
 
   public PortalConfig getDefaultSite(String username) {
@@ -508,7 +523,11 @@ public class UserPortalConfigService implements Startable {
         }
         if (globalUserNode != null) {
           if (validSiteDepth >= validGlobalDepth) {
-            return getNodeOrFirstChildWithPage(siteUserNode, username);
+            UserNode result = getNodeOrFirstChildWithPage(siteUserNode, username);
+            if (result == null) {
+              result = getNodeOrFirstChildWithPage(rootUserNode, username);
+            }
+            return result;
           } else {
             if (globalUserNode.getPageRef() == null
                 || getPage(globalUserNode.getPageRef(), username) == null) {
@@ -720,6 +739,10 @@ public class UserPortalConfigService implements Startable {
                  }
                })
                .toList();
+  }
+
+  private boolean isAccessiblePageNoDraft(UserNode userNode, String username) {
+    return isAccessiblePage(userNode, username) && userNode.getVisibility() != Visibility.DRAFT;
   }
 
   private boolean isAccessiblePage(UserNode userNode, String username) {

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/rest/NavigationRest.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/rest/NavigationRest.java
@@ -256,7 +256,7 @@ public class NavigationRest implements ResourceContainer {
 
   private static UserNodeFilterConfig getUserFilterConfig(Visibility[] visibilities, boolean temporalCheck) {
     UserNodeFilterConfig.Builder builder = UserNodeFilterConfig.builder();
-    builder.withReadWriteCheck().withVisibility(visibilities.length > 0 ? visibilities : DEFAULT_VISIBILITIES).withReadCheck();
+    builder.withReadCheckNoPage().withVisibility(visibilities.length > 0 ? visibilities : DEFAULT_VISIBILITIES).withReadCheckNoPage();
     if (temporalCheck) {
       builder.withTemporalCheck();
     }

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNode.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNode.java
@@ -70,7 +70,7 @@ public class UserNode {
     return context.getId();
   }
 
-  UserNode filter() {
+  public UserNode filter() {
     owner.filter(this);
     return this;
   }

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNodeContext.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNodeContext.java
@@ -25,7 +25,7 @@ import org.exoplatform.portal.mop.navigation.NodeModel;
 /**
  * @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
  */
-class UserNodeContext implements NodeModel<UserNode> {
+public class UserNodeContext implements NodeModel<UserNode> {
 
     /** The related navigation. */
     final UserNavigation navigation;
@@ -36,7 +36,7 @@ class UserNodeContext implements NodeModel<UserNode> {
     /** . */
     private UserNodeFilter filter;
 
-    UserNodeContext(UserNavigation navigation, UserNodeFilterConfig filterConfig) {
+    public UserNodeContext(UserNavigation navigation, UserNodeFilterConfig filterConfig) {
         this.filterConfig = filterConfig;
         this.navigation = navigation;
     }

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNodeFilter.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNodeFilter.java
@@ -32,7 +32,7 @@ import org.exoplatform.portal.mop.storage.PageStorage;
  * @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
  * @version $Revision$
  */
-class UserNodeFilter implements NodeFilter {
+public class UserNodeFilter implements NodeFilter {
 
   /** . */
   private final UserPortalImpl       userPortal;
@@ -53,30 +53,12 @@ class UserNodeFilter implements NodeFilter {
     this.config = config;
   }
 
-  private boolean canRead(NodeState state) {
-    PageKey pageRef = state.getPageRef();
-    if (pageRef != null) {
-      PageContext page = ExoContainerContext.getService(PageStorage.class).loadPage(pageRef);
-      if (page != null) {
-        UserACL userACL = ExoContainerContext.getService(UserACL.class);
-        return userACL.hasAccessPermission(page, userACL.getUserIdentity(userPortal.getUserName()));
-      }
-    }
-    return true;
+  @Override
+  public boolean isHideOnlyPage() {
+    return config != null && config.authorizationMode == UserNodeFilterConfig.AUTH_READ_NO_PAGE;
   }
 
-  private boolean canWrite(NodeState state) {
-    PageKey pageRef = state.getPageRef();
-    if (pageRef != null) {
-      PageContext page = ExoContainerContext.getService(PageStorage.class).loadPage(pageRef);
-      if (page != null) {
-        UserACL userACL = ExoContainerContext.getService(UserACL.class);
-        return userACL.hasEditPermission(page, userACL.getUserIdentity(userPortal.getUserName()));
-      }
-    }
-    return false;
-  }
-
+  @Override
   public boolean accept(int depth, String id, String name, NodeState state) {
     Visibility visibility = state.getVisibility();
 
@@ -133,5 +115,29 @@ class UserNodeFilter implements NodeFilter {
 
     //
     return true;
+  }
+
+  private boolean canRead(NodeState state) {
+    PageKey pageRef = state.getPageRef();
+    if (pageRef != null) {
+      PageContext page = ExoContainerContext.getService(PageStorage.class).loadPage(pageRef);
+      if (page != null) {
+        UserACL userACL = ExoContainerContext.getService(UserACL.class);
+        return userACL.hasAccessPermission(page, userACL.getUserIdentity(userPortal.getUserName()));
+      }
+    }
+    return true;
+  }
+
+  private boolean canWrite(NodeState state) {
+    PageKey pageRef = state.getPageRef();
+    if (pageRef != null) {
+      PageContext page = ExoContainerContext.getService(PageStorage.class).loadPage(pageRef);
+      if (page != null) {
+        UserACL userACL = ExoContainerContext.getService(UserACL.class);
+        return userACL.hasEditPermission(page, userACL.getUserIdentity(userPortal.getUserName()));
+      }
+    }
+    return false;
   }
 }

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNodeFilterConfig.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/user/UserNodeFilterConfig.java
@@ -41,6 +41,8 @@ public class UserNodeFilterConfig {
     /** . */
     public static final int AUTH_READ_WRITE = 2;
 
+    public static final int AUTH_READ_NO_PAGE = 3;
+
     /** . */
     final Set<Visibility> visibility;
 
@@ -166,6 +168,11 @@ public class UserNodeFilterConfig {
 
         public Builder withReadCheck() {
             this.withAuthorizationMode = AUTH_READ;
+            return this;
+        }
+
+        public Builder withReadCheckNoPage() {
+            this.withAuthorizationMode = AUTH_READ_NO_PAGE;
             return this;
         }
 

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
@@ -44,6 +44,7 @@ import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.portal.mop.EventType;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.mop.Utils;
 import org.exoplatform.portal.mop.Visibility;
 import org.exoplatform.portal.mop.importer.ImportMode;
 import org.exoplatform.portal.mop.navigation.NavigationContext;
@@ -745,6 +746,24 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
   }
 
   public void testGetSiteNodeOrGlobalNode() {
+    UserNode userNode = userPortalConfigService.getDefaultSiteNode("classic", null);
+    assertEquals("home", userNode.getURI());
+
+    Page homePage = layoutService.getPage(userNode.getPageRef());
+    String[] accessPermissions = homePage.getAccessPermissions();
+    try {
+      homePage.setAccessPermissions(new String[] {"*:/platform/administrators"});
+      layoutService.save(new PageContext(homePage.getPageKey(), Utils.toPageState(homePage)));
+
+      userNode = userPortalConfigService.getDefaultSiteNode("classic", null);
+      assertEquals("home/subnode", userNode.getURI());
+    } finally {
+      homePage.setAccessPermissions(accessPermissions);
+      layoutService.save(new PageContext(homePage.getPageKey(), Utils.toPageState(homePage)));
+    }
+  }
+
+  public void testGetSiteNodeNoHomePageAccess() {
     UserNode userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "home", null);
     assertEquals("home", userNode.getURI());
     userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "Notfound", null);

--- a/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/classic/navigation.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/classic/navigation.xml
@@ -31,8 +31,8 @@
       <page-reference>portal::classic::homepage</page-reference>
       <node>
         <name>subnode</name>
-        <label>#{portal.classic.home}</label>
-        <page-reference>portal::classic::homepage</page-reference>
+        <label>#{portal.classic.subnode}</label>
+        <page-reference>portal::classic::subnode</page-reference>
       </node>
     </node>
     <node>

--- a/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/classic/pages.xml
+++ b/component/portal/src/test/resources/org/exoplatform/portal/config/conf/portal/classic/pages.xml
@@ -67,40 +67,7 @@
   </page>
 
   <page>
-    <name>add-component-test-page</name>
-    <container>
-      <name>add-component-test-container</name>
-      <portlet-application>
-        <portlet>
-          <application-ref>web</application-ref>
-          <portlet-ref>BannerPortlet</portlet-ref>
-          <preferences>
-            <preference>
-              <name>template</name>
-              <value>par:/groovy/groovy/webui/component/UIBannerPortlet.gtmpl</value>
-              <read-only>false</read-only>
-            </preference>
-          </preferences>
-        </portlet>
-        <access-permissions>Everyone</access-permissions>
-        <show-info-bar>true</show-info-bar>
-      </portlet-application>
-      <portlet-application>
-        <portlet>
-          <application-ref>web</application-ref>
-          <portlet-ref>FooterPortlet</portlet-ref>
-          <preferences>
-            <preference>
-              <name>template</name>
-              <value>par:/groovy/groovy/webui/component/UIFooterPortlet.gtmpl</value>
-              <read-only>false</read-only>
-            </preference>
-          </preferences>
-        </portlet>
-        <access-permissions>Everyone</access-permissions>
-        <show-info-bar>true</show-info-bar>
-      </portlet-application>
-    </container>
+    <name>subnode</name>
   </page>
 
 </page-set>


### PR DESCRIPTION
Prior to this change, when accessing a sub page while the parent has a page with restricted access, then the page isn't displayed. This leads to the fact that administration site isn't accessible only to administrators knowing that its home page is accessible to administrators only . This change will allow to access the sub-page even when having a parent node with restricted access permission.

Resolves Meeds-io/meeds#2999