### PR TITLE
fix: Fix gatein errors when postgres server startup - MEED-8510 - Meeds-io/meeds#3055 

### DIFF
--- a/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
+++ b/component/portal/src/main/resources/db/changelog/portal-rdbms.db.changelog-1.0.0.xml
@@ -403,7 +403,9 @@
       </sql>
   </changeSet>
 
-  <changeSet author="portal" id="1.0.0-42">
+  <changeSet author="portal" id="1.0.0-42" dbms="mysql">
+  <!-- Change 'CUSTOMIZATION' column Length in MySQL only in order to correspond to used Column length in Postgres which already uses OID Data Type -->
+    <validCheckSum>ANY</validCheckSum>
     <modifyDataType tableName="PORTAL_WINDOWS" columnName="CUSTOMIZATION" newDataType="LONGBLOB" />
   </changeSet>
 


### PR DESCRIPTION

Prior to this change, the PORTAL_WINDOWS table changeset changing the data type of CUSTOMIZATION field to "LONGBLOB" is not working for postgres dbms which causes some errors for postgres server startup. After this change, we apply this changeset only for mysql dbms case since for postgres dbms the CUSTOMIZATION field data type is already "oid" so no need to change it.

Resolves https://github.com/Meeds-io/meeds/issues/3055