### PR TITLE
fix: Make mail input at login time case insensitive - MEED-8316 - Meeds-io/meeds#2791

### DIFF
--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/hibernate/PatchedHibernateIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/hibernate/PatchedHibernateIdentityStoreImpl.java
@@ -2013,12 +2013,18 @@ public class PatchedHibernateIdentityStoreImpl implements IdentityStore, Seriali
 
     if (attrDuctTypeText) {
       for (int i = 0; i < attribute.getValues().size(); i++) {
-        String paramName = " :value" + i;
-        queryString.append(" and").append(paramName).append(" = any elements(a.textValues)");
-
+        String paramName = ":value" + i;
+        if ("email".equals(attribute.getName())) {
+          queryString.append(" AND EXISTS (");
+          queryString.append(" SELECT 1 FROM a.textValues textValue");
+          queryString.append(" WHERE LOWER(textValue) = LOWER(").append(paramName).append(")");
+          queryString.append(")");
+        } else {
+          queryString.append(" AND ").append(paramName).append(" = ANY elements(a.textValues)");
+        }
       }
     } else {
-      queryString.append(" and :value = a.binaryValue");
+      queryString.append(" AND :value = a.binaryValue");
     }
 
     Query<HibernateIdentityObjectAttribute> q = session.createQuery(queryString.toString(), HibernateIdentityObjectAttribute.class)


### PR DESCRIPTION
Before this change, when create user with an email containing upper case chars and this user try to connect to plf by mail and type it in lower case, this user can't connect. To fix this problem, add a condition in the query if it is connected by email then the search for this email is done by lower case. After this change, email input is case insensitive for internal and external users.