### PR TITLE
fix : user can logs using wildcard - MEED-8649

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -281,6 +281,8 @@ public class LoginHandler extends JspBasedWebHandler {
   private String getUserNameByEmail(String identifier,
                                     ControllerContext context,
                                     StringBuilder loginPath) throws Exception {
+    //in login context, we do not allow search by email with wildcard
+    identifier=identifier.replace("*","");
     UserHandler userHandler = organizationService.getUserHandler();
     if (userHandler != null) {
       Query emailQuery = new Query();

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryHandler.java
@@ -245,6 +245,8 @@ public class PasswordRecoveryHandler extends JspBasedWebHandler {
     User user = organizationService.getUserHandler().findUserByName(usernameOrEmail, UserStatus.ANY);
     if (user == null && usernameOrEmail.contains("@")) {
       Query query = new Query();
+      //in passwordRecovery context, we do not allow search by email with wildcard
+      usernameOrEmail=usernameOrEmail.replace("*","");
       query.setEmail(usernameOrEmail);
       ListAccess<User> list = organizationService.getUserHandler().findUsersByQuery(query, UserStatus.ANY);
       if (list != null && list.getSize() > 0) {


### PR DESCRIPTION
Before this fix, a user can log into the platform by using wildcard in his username. In addition, he can request for a password reset email with the same action

This commit ensure to remove wild card in this 2 cases

Resolves meeds-io/si#4

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
