### PR TITLE
fix : setting default platform language to pt-br generates problems in interface - MEED-8665

### DIFF
--- a/component/resources/src/main/java/org/exoplatform/services/resources/impl/LocaleConfigServiceImpl.java
+++ b/component/resources/src/main/java/org/exoplatform/services/resources/impl/LocaleConfigServiceImpl.java
@@ -201,7 +201,7 @@ public class LocaleConfigServiceImpl implements LocaleConfigService {
       //
       String country = config.getLocale().getCountry();
       if (StringUtils.isNotBlank(country)) {
-        this.configs.put(config.getLanguage() + "_" + country, config);
+        this.configs.put(config.getLanguage() + "-" + country, config);
       } else {
         this.configs.put(config.getLanguage(), config);
       }

--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -37,7 +37,7 @@
   String language = rcontext.getLocale().getLanguage();
   String country = rcontext.getLocale().getCountry();
   if (country != null && country.length() > 0) {
-    language += "_" + country;
+    language += "-" + country;
   }
   String docBase =  rcontext.getRequestContextPath() ;
   String skin = uicomponent.getSkin();


### PR DESCRIPTION
Before this fixn there is an inconsistance between usage and storage of user locale and platform default locale Platform default locale use a _ to separate locale name and country but [rfc](https://datatracker.ietf.org/doc/html/rfc5646) requires to use -.

This lead to some inconsistancy in interface.
This commit ensure to use - everywhere a locale tag is used.

Resolves meeds-io/meeds#3159

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
