### PR TITLE
fix : UI Is not rtl-ized when Arabic (Oman) language choose - MEED-8708

### DIFF
--- a/component/api/src/main/java/org/exoplatform/services/resources/LocaleContextInfo.java
+++ b/component/api/src/main/java/org/exoplatform/services/resources/LocaleContextInfo.java
@@ -245,6 +245,6 @@ public class LocaleContextInfo {
         if (locale.getCountry().length() == 0)
             return locale.getLanguage();
 
-        return locale.getLanguage() + "_" + locale.getCountry();
+        return locale.getLanguage() + "-" + locale.getCountry();
     }
 }


### PR DESCRIPTION
Before this fix, when user changes language to Arabic Omar, the is displayed left to right instead of rigth to left It comes for the compute of locale tag name which should be with a '-' instead a '_'. In LocaleContextInfo, a '_' was staying, and this commit replace it by a '-'

Resolves meeds-io/meeds#3196

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
