### PR TITLE
fix: just after creation, external user is seen as internal user - MEED-8716

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/register/ExternalRegisterHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/register/ExternalRegisterHandler.java
@@ -45,6 +45,7 @@ import jakarta.servlet.http.HttpSession;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.container.component.ComponentRequestLifecycle;
 import org.json.JSONObject;
 
 import org.exoplatform.commons.utils.ListAccess;
@@ -402,6 +403,7 @@ public class ExternalRegisterHandler extends JspBasedWebHandler {
     if (!isAdministrator && securitySettingService.isRegistrationExternalUser()) {
       // Avoid incoherence by indicating an admin user As external
       deleteFromInternalUsersGroup(login);
+      restartTransaction();
       addToExternalUsersGroup(login);
     }
     return login;
@@ -641,5 +643,4 @@ public class ExternalRegisterHandler extends JspBasedWebHandler {
     user.setPassword(password);
     return user;
   }
-
 }

--- a/component/web/security/src/main/java/org/exoplatform/web/register/ExternalRegisterHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/register/ExternalRegisterHandler.java
@@ -45,7 +45,6 @@ import jakarta.servlet.http.HttpSession;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.container.component.ComponentRequestLifecycle;
 import org.json.JSONObject;
 
 import org.exoplatform.commons.utils.ListAccess;


### PR DESCRIPTION
Before this fix, after external user creation, he is automatically loggued into the platform and have outdated rights : he is still platform/users (but not in database)

During external user creation, we have 3 steps
1. Create user (he is automatically added in /platform/users by listeners)
2. deleteFromInternalUsersGroup (remove him from /platform/users)
3. addToExternalUsersGroup (add him in /platform/externals. This action runs SocialMembershipListenerImpl which add user in space he is invited)

The step 3. fire an asynchronous listener GamificationGenericListener on event joinSpace. This listener read user membership in database and put it in cache.

Currently, when the GamificationGenericListener read membership, the /platform/users group is still not persisted in database, and so, see the user as member of /platform/users. As membership are cached, when the user logs in, memberships are still /platform/users

This commit ensure to restart the transaction after deleteFromInternalUsersGroup and before addToExternalUsersGroup, so that deletion of membership /platform/users is persisted before step.