### PR TITLE
fix: Prevent NPE by checking for null Page ID before parsing in PageKey - MEED-8821 - Meeds-io/MIPs#180

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/config/model/Page.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/Page.java
@@ -129,7 +129,7 @@ public class Page extends Container {
   }
 
   public PageKey getPageKey() {
-    if (pageKey == null) {
+    if (pageKey == null && getPageId() != null) {
       pageKey = PageKey.parse(getPageId());
     }
     return pageKey;


### PR DESCRIPTION
This PR will prevent NPE by checking for null Page ID before parsing in PageKey