### PR TITLE
feat: Centralize ACL Checks in UserACL Service using plugins - MEED-8962 - Meeds-io/MIPs#192

### DIFF
--- a/component/portal/src/main/java/io/meeds/portal/plugin/AclPlugin.java
+++ b/component/portal/src/main/java/io/meeds/portal/plugin/AclPlugin.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.portal.plugin;
+
+import org.exoplatform.services.security.Identity;
+
+public interface AclPlugin {
+
+  static final String VIEW_PERMISSION_TYPE   = "VIEW";
+
+  static final String EDIT_PERMISSION_TYPE   = "EDIT";
+
+  static final String DELETE_PERMISSION_TYPE = "DELETE";
+
+  String getObjectType();
+
+  /**
+   * @param objectId Object identifier
+   * @param permissionType Permission Type, can be : VIEW, EDIT or DELETE. This
+   *          parameter can be a custom permission type too, which may be
+   *          compatible with some plugins only
+   * @param identity User ACL Identity. This will be null when anonymous user
+   * @return true if the user can view the identified object
+   */
+  boolean hasPermission(String objectId, String permissionType, Identity identity);
+
+}

--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserACL.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserACL.java
@@ -43,6 +43,8 @@ import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.services.security.IdentityRegistry;
 
+import io.meeds.portal.plugin.AclPlugin;
+
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -77,6 +79,8 @@ public class UserACL {
   @Getter
   @Setter
   private String                             adminMSType;
+
+  private Map<String, AclPlugin>             aclPlugins             = new HashMap<>();
 
   private Map<String, GroupVisibilityPlugin> groupVisibilityPlugins = new HashMap<>();
 
@@ -412,6 +416,55 @@ public class UserACL {
   public boolean isAnonymousUser(String username) {
     return StringUtils.isBlank(username) || IdentityConstants.ANONIM.equals(username)
            || IdentityConstants.SYSTEM.equals(username);
+  }
+
+  public boolean hasAccessPermission(String objectType,
+                                     String objectId,
+                                     String username) {
+    return hasPermission(objectType,
+                         objectId,
+                         AclPlugin.VIEW_PERMISSION_TYPE,
+                         username);
+  }
+
+  public boolean hasEditPermission(String objectType,
+                                   String objectId,
+                                   String username) {
+    return hasPermission(objectType,
+                         objectId,
+                         AclPlugin.EDIT_PERMISSION_TYPE,
+                         username);
+  }
+
+  public boolean hasDeletePermission(String objectType,
+                                     String objectId,
+                                     String username) {
+    return hasPermission(objectType,
+                         objectId,
+                         AclPlugin.DELETE_PERMISSION_TYPE,
+                         username);
+  }
+
+  public boolean hasPermission(String objectType,
+                               String objectId,
+                               String permissionType,
+                               String username) {
+    AclPlugin aclPlugin = getAclPlugin(objectType);
+    return aclPlugin.hasPermission(objectId,
+                                   permissionType,
+                                   StringUtils.isBlank(username) ? null : getUserIdentity(username));
+  }
+
+  public void addAclPlugin(AclPlugin aclPlugin) {
+    this.aclPlugins.put(aclPlugin.getObjectType(), aclPlugin);
+  }
+
+  public AclPlugin getAclPlugin(String objectType) {
+    AclPlugin aclPlugin = this.aclPlugins.get(objectType);
+    if (aclPlugin == null) {
+      throw new IllegalArgumentException(String.format("ACL Plugin of type '%s' doesn't exist", objectType));
+    }
+    return aclPlugin;
   }
 
   public Authenticator getAuthenticator() {


### PR DESCRIPTION
This change will allow to centralize ACL checks using UserACL Service through plugins that will be injected by each Third party Service layer. This will allow to use ACL checks switch Object Types in business Logic of Content Linking.