### PR TITLE
fix: Providing an alternative text for the image near the form - MEED-9008 - Meeds-io/meeds#3279.

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/branding/BrandingService.java
+++ b/component/api/src/main/java/org/exoplatform/portal/branding/BrandingService.java
@@ -114,6 +114,11 @@ public interface BrandingService {
   String getLoginBackgroundTextColor();
 
   /**
+   * @return Login alt Text displayed on the Background
+   */
+  String getLoginBackgroundAltText();
+
+  /**
    * @return {@link Logo} URL to retrieve logo image
    */
   String getLogoPath();
@@ -216,6 +221,9 @@ public interface BrandingService {
    * @param textColor text color in hex representation like #fff
    */
   void updateLoginBackgroundTextColor(String textColor);
+
+
+  void updateLoginBackgroundAltText(String altText);
 
   /**
    * @return {@link Map} with variable name as key and variable value as map

--- a/component/api/src/main/java/org/exoplatform/portal/branding/model/Branding.java
+++ b/component/api/src/main/java/org/exoplatform/portal/branding/model/Branding.java
@@ -81,6 +81,10 @@ public class Branding implements Serializable {
 
   @Getter
   @Setter
+  private String              loginBackgroundAltText;
+
+  @Getter
+  @Setter
   private Background          pageBackground;
 
   @Getter

--- a/component/portal/src/main/java/org/exoplatform/portal/branding/BrandingServiceImpl.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/branding/BrandingServiceImpl.java
@@ -117,6 +117,8 @@ public class BrandingServiceImpl implements BrandingService, Startable {
 
   public static final String   BRANDING_LOGIN_TEXT_COLOR_KEY      = "authentication.loginBackgroundTextColor";
 
+  public static final String   BRANDING_LOGIN_ALT_TEXT_KEY        = "authentication.loginBackgroundAltText";
+
   public static final String   BRANDING_TITLE_SETTING_KEY         = "authentication.title.";
 
   public static final String   BRANDING_SUBTITLE_SETTING_KEY      = "authentication.subtitle.";
@@ -326,6 +328,7 @@ public class BrandingServiceImpl implements BrandingService, Startable {
     branding.setSideBarBackground(getSideBarBackground());
     branding.setDrawerBackground(getDrawerBackground());
     branding.setLoginBackgroundTextColor(getLoginBackgroundTextColor());
+    branding.setLoginBackgroundAltText(getLoginBackgroundAltText());
     branding.setPageBackground(getPageBackground());
     branding.setPageBackgroundColor(getPageBackgroundColor());
     branding.setPageBackgroundPosition(getPageBackgroundPosition());
@@ -402,6 +405,7 @@ public class BrandingServiceImpl implements BrandingService, Startable {
       updateSideBarBackground(branding.getSideBarBackground(), false);
       updateDrawerBackground(branding.getDrawerBackground(), false);
       updateLoginBackgroundTextColor(branding.getLoginBackgroundTextColor(), false);
+      updateLoginBackgroundAltText(branding.getLoginBackgroundAltText(), false);
       updatePageBackground(branding.getPageBackground(), false);
       updatePageBackgroundColor(branding.getPageBackgroundColor(), false);
       updatePageBackgroundSize(branding.getPageBackgroundSize(), false);
@@ -505,6 +509,11 @@ public class BrandingServiceImpl implements BrandingService, Startable {
   }
 
   @Override
+  public String getLoginBackgroundAltText() {
+    return getPropertyValue(BRANDING_LOGIN_ALT_TEXT_KEY);
+  }
+
+  @Override
   public void updateCompanyName(String companyName) {
     updateCompanyName(companyName, true);
   }
@@ -522,6 +531,11 @@ public class BrandingServiceImpl implements BrandingService, Startable {
   @Override
   public void updateLoginBackgroundTextColor(String textColor) {
     updateLoginBackgroundTextColor(textColor, true);
+  }
+
+  @Override
+  public void updateLoginBackgroundAltText(String altText) {
+    updateLoginBackgroundAltText(altText, true);
   }
 
   @Override
@@ -970,6 +984,10 @@ public class BrandingServiceImpl implements BrandingService, Startable {
 
   private void updateLoginBackgroundTextColor(String textColor, boolean updateLastUpdatedTime) {
     updatePropertyValue(BRANDING_LOGIN_TEXT_COLOR_KEY, textColor, updateLastUpdatedTime);
+  }
+
+  private void updateLoginBackgroundAltText(String altText, boolean updateLastUpdatedTime) {
+    updatePropertyValue(BRANDING_LOGIN_ALT_TEXT_KEY, altText, updateLastUpdatedTime);
   }
 
   private void updatePageBackgroundColor(String color, boolean updateLastUpdatedTime) {

--- a/component/web/resources/src/main/java/org/exoplatform/web/application/JspBasedWebHandler.java
+++ b/component/web/resources/src/main/java/org/exoplatform/web/application/JspBasedWebHandler.java
@@ -117,6 +117,7 @@ public abstract class JspBasedWebHandler extends WebRequestHandler {
     params.put("authenticationTextColor", brandingService.getLoginBackgroundTextColor());
     params.put("authenticationTitle", brandingService.getLoginTitle(locale));
     params.put("authenticationSubtitle", brandingService.getLoginSubtitle(locale));
+    params.put("loginBackgroundAltText", brandingService.getLoginBackgroundAltText());
 
     if (extendUIParameters != null) {
       extendUIParameters.accept(params);


### PR DESCRIPTION
Before this change, when access to login page, the image near the form can provide information but it has an empty alt. To fix this problem, add the textrea to create the value of alt and adapt it in the code to retrieve it from the login page and insert it into the image near. After this change, the alternative text field is displayed correctly in the drawer Change background in the administration page and the alt has the value added by this text field.