### PR TITLE
fix: Have relevant and unique page title - MEED-9029 - Meeds-io/meeds#2914. 

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -57,21 +57,19 @@
       remoteScripts.put(module);
     }
   }
-  def title = rcontext.getTitle();
 
   BrandingService brandingService = uicomponent.getApplicationComponent(BrandingService.class);
   SiteKey siteKey = portal.getSiteKey();
   String siteName = siteKey.getName();
   String siteType = siteKey.getTypeName();
-  if (siteKey.getType() == org.exoplatform.portal.mop.SiteType.PORTAL) {
-    ResourceBundleService resourceBundleService = uicomponent.getApplicationComponent(ResourceBundleService.class);
-    ResourceBundle bundle = resourceBundleService.getResourceBundle("locale.portlet.Portlets", rcontext.getLocale());
-    if ("public".equals(siteName)) {
-      title = brandingService.getCompanyName() + " - " + bundle.getString("publicSite.title.suffix");
-    } else if ("administration".equals(siteName)) {
-      title = title + " - " + brandingService.getCompanyName();
-    }
+  String companyName = brandingService.getCompanyName();
+  String metaPortalName = rcontext.getMetaPortal();
+  
+  def title = rcontext.getTitle() + " - ";
+  if (!metaPortalName.equals(siteName)) {
+    title = title + rcontext.getSiteLabel() + " - ";
   }
+  title = title + companyName;
 
   def metaInformation = rcontext.getMetaInformation();
 


### PR DESCRIPTION
Before this change, when accessing the Home page of Space1 and to the Home page of Space2, the title of the pages is the same for both spaces (Home) but they have two different contents and addresses. To fix this problem, modify the existing title by adding the siteLabel if the metaPortalName is different from siteName and then add the companyName. After this change, the title is equal to title+siteLabel+companyName if the siteName is different from siteName, otherwise it is equal to title+companyName.
Resolves https://github.com/Meeds-io/meeds/issues/2914