### PR TITLE
feat: Improve Based Spring Integration Test Root Class - Meeds-io/meeds#3313

### DIFF
--- a/component/api/src/main/java/io/meeds/portal/permlink/service/PermanentLinkService.java
+++ b/component/api/src/main/java/io/meeds/portal/permlink/service/PermanentLinkService.java
@@ -23,6 +23,7 @@ import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.services.security.Identity;
 
 import io.meeds.portal.permlink.model.PermanentLinkObject;
+import io.meeds.portal.permlink.plugin.PermanentLinkPlugin;
 
 /**
  * A service to get permanent link to an object in order to reference it
@@ -54,5 +55,10 @@ public interface PermanentLinkService {
    * @throws ObjectNotFoundException
    */
   String getLink(PermanentLinkObject object) throws ObjectNotFoundException;
+
+  /**
+   * @param plugin {@link PermanentLinkPlugin}
+   */
+  void addPlugin(PermanentLinkPlugin plugin);
 
 }

--- a/component/common/src/main/java/io/meeds/spring/kernel/KernelContainerLifecyclePlugin.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/KernelContainerLifecyclePlugin.java
@@ -127,7 +127,7 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
     LOG.info("2. Add Spring Beans of all contexts into Kernel");
     addSpringToKernel(portalContainer, springBeansByContext);
     LOG.info("3. Add Spring Beans into each other context");
-    addSpringToEachOther(springBeansByContext);
+    addSpringToEachOther(portalContainer, springBeansByContext);
     LOG.info("End spring integration with Kernel Container within {}ms", System.currentTimeMillis() - start);
   }
 
@@ -188,7 +188,8 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
     });
   }
 
-  public static void addSpringToEachOther(Map<String, Map<String, BeanDefinition>> springBeansByContext) {
+  public static void addSpringToEachOther(PortalContainer portalContainer,
+                                          Map<String, Map<String, BeanDefinition>> springBeansByContext) {
     springContexts.forEach((senderServletContextName, senderApplicationContext) -> {
       Map<String, BeanDefinition> beansMap = springBeansByContext.get(senderServletContextName);
       springBeanRegistries.entrySet()
@@ -196,7 +197,8 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
                           .filter(e -> !StringUtils.equals(senderServletContextName, e.getKey()))
                           .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
                           .forEach((receiverServletContextName,
-                                    receiverBeanRegistry) -> addSpringBeansToEachOtherContexts(senderServletContextName,
+                                    receiverBeanRegistry) -> addSpringBeansToEachOtherContexts(portalContainer,
+                                                                                               senderServletContextName,
                                                                                                receiverServletContextName,
                                                                                                senderApplicationContext,
                                                                                                receiverBeanRegistry,
@@ -251,7 +253,8 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
-  private static void addSpringBeansToEachOtherContexts(String senderServletContextName,
+  private static void addSpringBeansToEachOtherContexts(PortalContainer portalContainer,
+                                                        String senderServletContextName,
                                                         String receiverServletContextName,
                                                         ApplicationContext senderApplicationContext,
                                                         BeanDefinitionRegistry receiverBeanRegistry,
@@ -271,6 +274,8 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
                   receiverServletContextName);
         RootBeanDefinition receiverBeanDefinition = createBeanDefinition(beanName,
                                                                          beanClassNameInterface,
+                                                                         senderBeanDefinition,
+                                                                         portalContainer,
                                                                          senderApplicationContext,
                                                                          receiverServletContextName);
         receiverBeanRegistry.registerBeanDefinition(beanClassNameInterface.getName(), receiverBeanDefinition);
@@ -301,18 +306,24 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
 
   private static RootBeanDefinition createBeanDefinition(String beanName,
                                                          Class<Object> beanClassName,
+                                                         BeanDefinition originatingBeanDefinition,
+                                                         PortalContainer portalContainer,
                                                          ApplicationContext senderApplicationContext,
                                                          String receiverServletContextName) {
     RootBeanDefinition receiverBeanDefinition = new RootBeanDefinition(beanClassName,
                                                                        () -> getBeanInstance(senderApplicationContext,
+                                                                                             portalContainer,
                                                                                              beanName,
+                                                                                             beanClassName,
                                                                                              receiverServletContextName));
     receiverBeanDefinition.setLazyInit(true);
     receiverBeanDefinition.setAutowireCandidate(true);
-    receiverBeanDefinition.setAutowireMode(AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE);
+    receiverBeanDefinition.setSynthetic(true);
+    receiverBeanDefinition.setAutowireMode(AutowireCapableBeanFactory.AUTOWIRE_NO);
     receiverBeanDefinition.setScope(ConfigurableBeanFactory.SCOPE_SINGLETON);
     receiverBeanDefinition.setDependencyCheck(AbstractBeanDefinition.DEPENDENCY_CHECK_NONE);
     receiverBeanDefinition.setBeanClass(beanClassName);
+    receiverBeanDefinition.setOriginatingBeanDefinition(originatingBeanDefinition);
     return receiverBeanDefinition;
   }
 
@@ -409,6 +420,24 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
            && !StringUtils.equals(componentClass.getName(), "org.exoplatform.commons.cluster.StartableClusterAware");
   }
 
+  private static Object getBeanInstance(ApplicationContext applicationContext,
+                                        PortalContainer portalContainer,
+                                        String beanName,
+                                        Class<Object> beanClassName,
+                                        String contextName) {
+    boolean beanExistsInKernel = portalContainer.getComponentAdapter(beanClassName) != null;
+    LOG.trace("Retrieve Bean with name '{}' from Kernel Container using class '{}' in detstination to '{}'. Found = {}",
+              beanName,
+              beanClassName,
+              contextName,
+              beanExistsInKernel);
+    if (beanExistsInKernel) {
+      return portalContainer.getComponentInstanceOfType(beanClassName);
+    } else {
+      return getBeanInstance(applicationContext, beanName, contextName);
+    }
+  }
+
   private static Object getBeanInstance(ApplicationContext applicationContext, String beanName, String contextName) {
     LOG.trace("Retrieve Bean with name '{}' from Spring to Kernel using Application context '{}' in detstination to '{}'",
               beanName,
@@ -421,8 +450,7 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
     LOG.trace("Getting Kernel Service '{}' requested by a Spring Bean.",
               keyClass);
     try {
-      T instance =
-                 portalContainer.getComponentInstanceOfType(keyClass);
+      T instance = portalContainer.getComponentInstanceOfType(keyClass);
       if (instance == null) {
         LOG.trace("Kernel Service '{}' requested by a Spring Bean wasn't",
                   keyClass);

--- a/component/identity/src/main/resources/conf/portal/configuration.xml
+++ b/component/identity/src/main/resources/conf/portal/configuration.xml
@@ -8,4 +8,9 @@
     <key>org.exoplatform.services.security.Authenticator</key>
     <type>org.exoplatform.services.organization.auth.OrganizationAuthenticatorImpl</type>
   </component>
+
+  <component>
+    <type>org.exoplatform.services.security.IdentityRegistry</type>
+  </component>
+
 </configuration>

--- a/component/portal/src/main/java/io/meeds/portal/permlink/service/PermanentLinkServiceImpl.java
+++ b/component/portal/src/main/java/io/meeds/portal/permlink/service/PermanentLinkServiceImpl.java
@@ -25,10 +25,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Function;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.codec.binary.Base64;
@@ -80,7 +79,7 @@ public class PermanentLinkServiceImpl implements PermanentLinkService, Startable
   /**
    * {@link Map} of Object Type with associated plugin
    */
-  private Map<String, PermanentLinkPlugin> plugins;
+  private Map<String, PermanentLinkPlugin> plugins                  = new ConcurrentHashMap<>();
 
   @Getter
   private String                           salt;
@@ -153,15 +152,15 @@ public class PermanentLinkServiceImpl implements PermanentLinkService, Startable
     }
   }
 
+  protected void initPlugins() {
+    container.getComponentInstancesOfType(PermanentLinkPlugin.class)
+             .stream()
+             .forEach(p -> plugins.put(p.getObjectType(), p));
+  }
+
   @Override
   public void addPlugin(PermanentLinkPlugin plugin) {
     plugins.put(plugin.getObjectType(), plugin);
-  }
-
-  protected void initPlugins() {
-    plugins = container.getComponentInstancesOfType(PermanentLinkPlugin.class)
-                       .stream()
-                       .collect(Collectors.toMap(PermanentLinkPlugin::getObjectType, Function.identity()));
   }
 
   protected void initSalt() {

--- a/component/portal/src/main/java/io/meeds/portal/permlink/service/PermanentLinkServiceImpl.java
+++ b/component/portal/src/main/java/io/meeds/portal/permlink/service/PermanentLinkServiceImpl.java
@@ -153,6 +153,11 @@ public class PermanentLinkServiceImpl implements PermanentLinkService, Startable
     }
   }
 
+  @Override
+  public void addPlugin(PermanentLinkPlugin plugin) {
+    plugins.put(plugin.getObjectType(), plugin);
+  }
+
   protected void initPlugins() {
     plugins = container.getComponentInstancesOfType(PermanentLinkPlugin.class)
                        .stream()

--- a/component/test/core/pom.xml
+++ b/component/test/core/pom.xml
@@ -30,7 +30,7 @@
   <name>Meeds Portal Component Core Test</name>
 
   <properties>
-    <exo.test.coverage.ratio>0.32</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.31</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/component/test/core/src/main/java/io/meeds/kernel/test/AbstractSpringTest.java
+++ b/component/test/core/src/main/java/io/meeds/kernel/test/AbstractSpringTest.java
@@ -19,39 +19,58 @@
  */
 package io.meeds.kernel.test;
 
+import java.util.Objects;
+
+import org.apache.commons.lang3.ObjectUtils;
+
 import org.exoplatform.component.test.ConfigurationUnit;
 import org.exoplatform.component.test.ConfiguredBy;
 import org.exoplatform.component.test.ContainerScope;
 import org.exoplatform.component.test.KernelBootstrap;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.RootContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 
 import lombok.Getter;
 import lombok.Setter;
 
 @ConfiguredBy({
-  @ConfigurationUnit(scope = ContainerScope.ROOT,
-      path = "conf/configuration.xml"),
-  @ConfigurationUnit(scope = ContainerScope.PORTAL,
-      path = "conf/portal/configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
 })
 public abstract class AbstractSpringTest {
 
   @Setter
   @Getter
-  private static Class<?>                      testClass;
+  private static Class<?>        testClass;
 
-  private static KernelBootstrap               bootstrap;
+  private static KernelBootstrap bootstrap;
 
   public static PortalContainer bootContainer(Class<?> clazz) {
+    Class<? extends Object> bootTestClass = ObjectUtils.firstNonNull(clazz,
+                                                                     testClass,
+                                                                     AbstractSpringTest.class);
     if (isPortalContainerPresent()) {
-      return PortalContainer.getInstanceIfPresent();
+      if (isPortalContainerIncludingSpring(bootTestClass)) {
+        PortalContainer container = PortalContainer.getInstanceIfPresent();
+        ExoContainerContext.setCurrentContainer(container);
+        return container;
+      } else {
+        RootContainer rootContainer = RootContainer.getInstance();
+        rootContainer.stop();
+        rootContainer.dispose();
+        RootContainer.setInstance(null);
+        PortalContainer.setInstance(null);
+      }
     }
     bootstrap = new KernelBootstrap(Thread.currentThread().getContextClassLoader());
-    bootstrap.addConfiguration(clazz);
+    bootstrap.addConfiguration(bootTestClass);
     bootstrap.boot();
-    return bootstrap.getContainer();
+    PortalContainer container = bootstrap.getContainer();
+    ExoContainerContext.setCurrentContainer(container);
+    container.registerComponentInstance(SpringLoadFlag.class);
+    return container;
   }
 
   public PortalContainer getContainer() {
@@ -59,9 +78,15 @@ public abstract class AbstractSpringTest {
   }
 
   protected PortalContainer bootContainer() {
-    PortalContainer container = bootContainer(getClass());
-    ExoContainerContext.setCurrentContainer(container);
-    return container;
+    if (isPortalContainerPresent()) {
+      PortalContainer container = PortalContainer.getInstanceIfPresent();
+      ExoContainerContext.setCurrentContainer(container);
+      return container;
+    } else {
+      PortalContainer container = bootContainer(getClass());
+      ExoContainerContext.setCurrentContainer(container);
+      return container;
+    }
   }
 
   protected void begin() {
@@ -97,4 +122,18 @@ public abstract class AbstractSpringTest {
     return ExoContainerContext.getCurrentContainerIfPresent() != null && PortalContainer.getInstanceIfPresent() != null;
   }
 
+  protected static boolean isPortalContainerIncludingSpring(Class<?> testClass) {
+    SpringLoadFlag springLoadFlag = isPortalContainerPresent() ? PortalContainer.getInstance()
+                                                                                .getComponentInstanceOfType(SpringLoadFlag.class) :
+                                                               null;
+    return springLoadFlag != null && Objects.equals(testClass, springLoadFlag.getTestClass());
+  }
+
+  public class SpringLoadFlag { // NOSONAR
+
+    @Getter
+    @Setter
+    private Class<?> testClass;
+
+  }
 }


### PR DESCRIPTION
This change will allow to restart automatically the `PortalCotnainer` in
Test context when the Spring Context isn't initialized in
`PortalContainer` in order to allow using Spring based
`Beans/Components` in Integration Tests.
In addition, this change will explicitly add a component definition of
`org.exoplatform.services.security.IdentityRegistry` which will allow to
reference it in `Autowired` annotation injection.
In addition, this change will allow to inject `PermanentLinkService`
plugins through methods to avoid cyclic beans definition in some cases
(portal depends on context and then the Spring context depends on
Kernel).

Resolves Meeds-io/meeds#3313