### PR TITLE
feat: Allow to access pages without full path - MEED-9026 - Meeds-io/meeds#3286

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -489,56 +489,23 @@ public class UserPortalConfigService implements Startable {
       if (rootUserNode == null) {
         return null;
       } else {
-        UserNode globalRootUserNode = getSiteRootNode(PortalConfig.PORTAL_TYPE,
-                                                      globalPortal,
-                                                      username,
-                                                      false);
-        UserNode siteUserNode = rootUserNode;
-        UserNode globalUserNode = globalRootUserNode;
-        int validGlobalDepth = 0;
-        int validSiteDepth = 0;
-        int currentDepth = 0;
-
-        String[] nodeNames = Utils.parsePath(nodePath);
-        Iterator<String> iterator = Arrays.stream(nodeNames).iterator();
-        while (iterator.hasNext()
-               && (validSiteDepth == currentDepth
-                   || validGlobalDepth == currentDepth)) {
-          String path = iterator.next();
-          if (validSiteDepth == currentDepth) {
-            UserNode childUserNode = siteUserNode.getChild(path);
-            if (childUserNode != null) {
-              siteUserNode = childUserNode;
-              validSiteDepth++;
-            }
-          }
-          if (globalUserNode != null && validGlobalDepth == currentDepth) {
-            UserNode childGlobalUserNode = globalUserNode.getChild(path);
-            if (childGlobalUserNode != null) {
-              globalUserNode = childGlobalUserNode;
-              validGlobalDepth++;
-            }
-          }
-          currentDepth++;
+        UserNode exactUserNode = getExactUserNode(rootUserNode, nodePath, username);
+        boolean isDefaultPath = exactUserNode == null
+                                || exactUserNode.getParent() == null
+                                || exactUserNode.getParent().getId().equals(rootUserNode.getId());
+        if (isDefaultPath) {
+          String[] nodePathParts = nodePath.split("/");
+          return Arrays.asList(nodePathParts)
+                       .reversed()
+                       .stream()
+                       .map(nodeName -> getChildNodeWithName(rootUserNode,
+                                                             nodeName,
+                                                             username))
+                       .filter(Objects::nonNull)
+                       .findFirst()
+                       .orElse(exactUserNode);
         }
-        if (globalUserNode != null) {
-          if (validSiteDepth >= validGlobalDepth) {
-            UserNode result = getNodeOrFirstChildWithPage(siteUserNode, username);
-            if (result == null) {
-              result = getNodeOrFirstChildWithPage(rootUserNode, username);
-            }
-            return result;
-          } else {
-            if (globalUserNode.getPageRef() == null
-                || getPage(globalUserNode.getPageRef(), username) == null) {
-              return null;
-            } else {
-              return globalUserNode;
-            }
-          }
-        } else {
-          return getNodeOrFirstChildWithPage(siteUserNode, username);
-        }
+        return exactUserNode;
       }
     }
   }
@@ -692,6 +659,74 @@ public class UserPortalConfigService implements Startable {
       } finally {
         RequestLifeCycle.end();
       }
+    }
+  }
+
+  private UserNode getExactUserNode(UserNode rootUserNode, String nodePath, String username) { // NOSONAR
+    UserNode globalRootUserNode = getSiteRootNode(PortalConfig.PORTAL_TYPE,
+                                                  globalPortal,
+                                                  username,
+                                                  false);
+    UserNode siteUserNode = rootUserNode;
+    UserNode globalUserNode = globalRootUserNode;
+    int validGlobalDepth = 0;
+    int validSiteDepth = 0;
+    int currentDepth = 0;
+
+    String[] nodeNames = Utils.parsePath(nodePath);
+    Iterator<String> iterator = Arrays.stream(nodeNames).iterator();
+    while (iterator.hasNext()
+           && (validSiteDepth == currentDepth
+               || validGlobalDepth == currentDepth)) {
+      String path = iterator.next();
+      if (validSiteDepth == currentDepth) {
+        UserNode childUserNode = siteUserNode.getChild(path);
+        if (childUserNode != null) {
+          siteUserNode = childUserNode;
+          validSiteDepth++;
+        }
+      }
+      if (globalUserNode != null && validGlobalDepth == currentDepth) {
+        UserNode childGlobalUserNode = globalUserNode.getChild(path);
+        if (childGlobalUserNode != null) {
+          globalUserNode = childGlobalUserNode;
+          validGlobalDepth++;
+        }
+      }
+      currentDepth++;
+    }
+    if (globalUserNode != null) {
+      if (validSiteDepth >= validGlobalDepth) {
+        UserNode result = getNodeOrFirstChildWithPage(siteUserNode, username);
+        if (result == null) {
+          result = getNodeOrFirstChildWithPage(rootUserNode, username);
+        }
+        return result;
+      } else {
+        if (globalUserNode.getPageRef() == null
+            || getPage(globalUserNode.getPageRef(), username) == null) {
+          return null;
+        } else {
+          return globalUserNode;
+        }
+      }
+    } else {
+      return getNodeOrFirstChildWithPage(siteUserNode, username);
+    }
+  }
+
+  private UserNode getChildNodeWithName(UserNode userNode, String nodeName, String username) {
+    if (StringUtils.equals(userNode.getName(), nodeName)) {
+      return userNode;
+    } else if (userNode.getChildrenCount() > 0) {
+      return userNode.getChildren()
+                     .stream()
+                     .map(n -> getChildNodeWithName(n, nodeName, username))
+                     .filter(Objects::nonNull)
+                     .findFirst()
+                     .orElse(null);
+    } else {
+      return null;
     }
   }
 

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
@@ -783,6 +783,9 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
     userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "home/subnode", "john");
     assertEquals("home/subnode", userNode.getURI());
 
+    userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "subnode", "john");
+    assertEquals("home/subnode", userNode.getURI());
+
     userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "home/subnode2", "john");
     assertEquals("home/subnode2", userNode.getURI());
 


### PR DESCRIPTION
Prior to this change, when accessing to a page, the full tree path has to be provided to be able to access to the page. This change will allow to access a page without full path, but just its name in order to allow simplifying aliasing the page access.