### PR TITLE
fix: Delete useless Dependent class - Meeds-io/meeds#3365

### DIFF
--- a/component/api/pom.xml
+++ b/component/api/pom.xml
@@ -215,7 +215,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
     <!-- Spring base artifacts -->
     <dependency>

--- a/component/web/resources/src/main/java/org/gatein/portal/controller/resource/ScriptContent.java
+++ b/component/web/resources/src/main/java/org/gatein/portal/controller/resource/ScriptContent.java
@@ -20,7 +20,7 @@ package org.gatein.portal.controller.resource;
 
 import java.io.File;
 
-import com.mchange.io.FileUtils;
+import org.exoplatform.commons.utils.IOUtil;
 
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -62,7 +62,7 @@ public class ScriptContent {
     if (this.bytes != null && this.bytes.length > 0) {
       return this.bytes;
     } else if (file != null) {
-      return FileUtils.getBytes(file);
+      return IOUtil.getFileContentAsBytes(file.getAbsolutePath());
     } else {
       return null; // NOSONAR
     }

--- a/component/web/resources/src/main/java/org/gatein/portal/controller/resource/ScriptLoader.java
+++ b/component/web/resources/src/main/java/org/gatein/portal/controller/resource/ScriptLoader.java
@@ -169,8 +169,7 @@ public class ScriptLoader implements Loader<ScriptKey, ScriptContent, Object> {
     options.setWarningLevel(DiagnosticGroups.NON_STANDARD_JSDOC, CheckLevel.OFF);
     options.setStrictModeInput(false);
     options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2021);
-    options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5);
-    options.setExternExports(true);
+    options.setLanguageOut(CompilerOptions.LanguageMode.STABLE);
     level.setOptionsForCompilationLevel(options);
 
     StringWriter code = new StringWriter();


### PR DESCRIPTION
This change will remove usage of `com.mchange.io.FileUtils` class and will upgrade `closer-compiler` jar used to minify static resources.