### PR TITLE
fix: add default timeout for jndi ldap connexion - MEED-9299

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
@@ -323,6 +323,11 @@
             <name>pagedResultsExtensionSupported</name>
             <value>${exo.ldap.search.pagedResult.enabled:true}</value>
           </option>
+          <option>
+            <name>customJNDIConnectionParameters</name>
+            <value>com.sun.jndi.ldap.read.timeout=${com.sun.jndi.ldap.read.timeout:60000}</value>
+            <value>com.sun.jndi.ldap.connect.timeout=${com.sun.jndi.ldap.connect.timeout:60000}</value>
+          </option>
         </options>
       </identity-store>
     </identity-stores>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
@@ -348,6 +348,11 @@
             <name>pagedResultsExtensionSupported</name>
             <value>${exo.ldap.search.pagedResult.enabled:true}</value>
           </option>
+          <option>
+            <name>customJNDIConnectionParameters</name>
+            <value>com.sun.jndi.ldap.read.timeout=${com.sun.jndi.ldap.read.timeout:60000}</value>
+            <value>com.sun.jndi.ldap.connect.timeout=${com.sun.jndi.ldap.connect.timeout:60000}</value>
+          </option>
         </options>
       </identity-store>
     </identity-stores>


### PR DESCRIPTION
Before this fix, jndi ldap connexion have no timeout set (default java behaviour) This commit ensure to add configuration to set a read timeout and a connect timeout to prevent blocking threads in some specific cases

Resolves meeds-io/meeds#3414

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
