### PR TITLE
feat: Delete HSTS HTTP Header from Spring REST calls - Meeds-io/meeds#3502

### DIFF
--- a/component/web/security/src/main/java/io/meeds/spring/web/security/WebSecurityConfiguration.java
+++ b/component/web/security/src/main/java/io/meeds/spring/web/security/WebSecurityConfiguration.java
@@ -36,9 +36,10 @@ import org.springframework.security.config.annotation.web.configurers.CsrfConfig
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.CacheControlConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.ContentTypeOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.HstsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.XXssConfig;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.config.annotation.web.configurers.JeeConfigurer;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -88,6 +89,7 @@ public class WebSecurityConfiguration implements ServletContextAware {
                  headers.frameOptions(FrameOptionsConfig::disable);
                  headers.xssProtection(XXssConfig::disable);
                  headers.contentTypeOptions(ContentTypeOptionsConfig::disable);
+                 headers.httpStrictTransportSecurity(HstsConfig::disable);
                })
                .authorizeHttpRequests(customizer -> {
                  try {


### PR DESCRIPTION
Prior to this change, The HSTS HTTP Header is usually managed via Front-End Server (NGinx or Apache HTTPD). The Spring Security default configuration in Meeds doesn't disable HSTS HTTP Header which will need an additional configuration to add into Front-End server to replace it.
This change will ease the Font-End server configuration by disabling HSTS HTTP Header from Spring Security Default configuration.