### PR TITLE
fix: Group name starting with number not found in suggester - MEED-9552 - meeds-io/meeds#3562

### DIFF
--- a/component/identity/src/main/java/org/picketlink/idm/impl/store/hibernate/PatchedHibernateIdentityStoreImpl.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/store/hibernate/PatchedHibernateIdentityStoreImpl.java
@@ -644,7 +644,7 @@ public class PatchedHibernateIdentityStoreImpl implements IdentityStore, Seriali
 
     Session hibernateSession = getHibernateSession(ctx);
     try {
-      StringBuilder hqlBuilderSelect = new StringBuilder("select distinct io from HibernateIdentityObject io");
+      StringBuilder hqlBuilderSelect = new StringBuilder("select distinct io from HibernateIdentityObject io LEFT JOIN io.attributes attr LEFT JOIN attr.textValues val");
       Map<String, Object> queryParams = new HashMap<>();
 
       StringBuilder hqlBuilderConditions = new StringBuilder(" where io.realm=:realm");
@@ -671,9 +671,9 @@ public class PatchedHibernateIdentityStoreImpl implements IdentityStore, Seriali
         }
         if (isAllowNotCaseSensitiveSearch()) {
           attrValue = attrValue.toLowerCase();
-          hqlBuilderConditions.append(" and lower(io.name) " + operator + " :ioName");
+          hqlBuilderConditions.append(" and ( lower(io.name) " + operator + " :ioName OR ((attr.name) = 'label' AND lower(val) " + operator + " :ioName))");
         } else {
-          hqlBuilderConditions.append(" and io.name " + operator + " :ioName");
+          hqlBuilderConditions.append(" and ( io.name " + operator + " :ioName OR ((attr.name) = 'label' AND val " + operator + " :ioName))");
         }
         queryParams.put("ioName", attrValue);
       }


### PR DESCRIPTION
before this change, when create a sub group under organization/platform whose label start with a number then go to spaces menu and clic on sync icon related to spacex then clic on group members and enter the number write in the label only or complete the whole title, no group found. To fix this problem, add search by label to the query. After this change, related group is displayed in results by typing numbers.
Resolves https://github.com/Meeds-io/meeds/issues/3562
