### PR TITLE
fix: Unable to reload page configuration when addons add another page in the portal - MEED-9696

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/NewPortalConfigListener.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/NewPortalConfigListener.java
@@ -248,6 +248,15 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
                                                null;
   }
 
+  public List<NewPortalConfig> getPortalConfigs(String type, String name) {
+    return CollectionUtils.isNotEmpty(configs) ? configs.stream()
+                                                        .filter(c -> StringUtils.equalsIgnoreCase(c.getOwnerType(), type)
+                                                            && CollectionUtils.isNotEmpty(c.getPredefinedOwner())
+                                                            && c.getPredefinedOwner().contains(name))
+                                                        .toList() :
+           Collections.emptyList();
+  }
+
   /**
    * @deprecated Site Templates has been changed to be stored in database to
    *             make it dynamically managed by UI rather than statis pages and

--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -173,35 +173,37 @@ public class UserPortalConfigService implements Startable {
     if (!canRestore(type, name)) {
       return false;
     }
-    NewPortalConfig config = newPortalConfigListener.getPortalConfig(type, name);
-    config = config.clone();
-    config.setImportMode(importMode.name());
-    config.setOverrideMode(true);
-    HashSet<String> ownerName = new HashSet<>();
-    ownerName.add(name);
-    config.setPredefinedOwner(ownerName);
-    if (restoreSiteLayout) {
-      PortalConfig previousSite = layoutService.getPortalConfig(type, name);
-      newPortalConfigListener.initPortalConfigDB(config, true);
-      PortalConfig site = layoutService.getPortalConfig(type, name);
-      if (previousSite != null) {
-        // Preserve previous version or properties
-        site.setLabel(previousSite.getLabel());
-        site.setDescription(previousSite.getDescription());
-        site.setAccessPermissions(previousSite.getAccessPermissions());
-        site.setEditPermission(previousSite.getEditPermission());
-        site.setDisplayed(previousSite.isDisplayed());
-        site.setDisplayOrder(previousSite.getDisplayOrder());
-        site.setIcon(previousSite.getIcon());
-        site.setProperties(previousSite.getProperties());
-        layoutService.save(site);
+    List<NewPortalConfig> configs = newPortalConfigListener.getPortalConfigs(type, name);
+    for(NewPortalConfig config : configs) {
+      config = config.clone();
+      config.setImportMode(importMode.name());
+      config.setOverrideMode(true);
+      HashSet<String> ownerName = new HashSet<>();
+      ownerName.add(name);
+      config.setPredefinedOwner(ownerName);
+      if (restoreSiteLayout) {
+        PortalConfig previousSite = layoutService.getPortalConfig(type, name);
+        newPortalConfigListener.initPortalConfigDB(config, true);
+        PortalConfig site = layoutService.getPortalConfig(type, name);
+        if (previousSite != null) {
+          // Preserve previous version or properties
+          site.setLabel(previousSite.getLabel());
+          site.setDescription(previousSite.getDescription());
+          site.setAccessPermissions(previousSite.getAccessPermissions());
+          site.setEditPermission(previousSite.getEditPermission());
+          site.setDisplayed(previousSite.isDisplayed());
+          site.setDisplayOrder(previousSite.getDisplayOrder());
+          site.setIcon(previousSite.getIcon());
+          site.setProperties(previousSite.getProperties());
+          layoutService.save(site);
+        }
       }
-    }
-    if (restorePages) {
-      newPortalConfigListener.initPageDB(config, true);
-    }
-    if (restoreNavigationTree) {
-      newPortalConfigListener.initPageNavigationDB(config, true);
+      if (restorePages) {
+        newPortalConfigListener.initPageDB(config, true);
+      }
+      if (restoreNavigationTree) {
+        newPortalConfigListener.initPageNavigationDB(config, true);
+      }
     }
     return true;
   }


### PR DESCRIPTION
Before this fix, when pages are configured in at least two pages/navigation.xml, only the first one is reload when using Reload Page configuration feature. This is because, when searching PortalConfig, we treat only the first one. This commit updates it to iterate on each existing portal configs, so that, all pages are correctly reloaded

Resolves meeds-io/meeds#3630

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
