### PR TITLE
fix : Impossible to require forgot password - MEED-9855

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
@@ -484,19 +484,13 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
 
     String tokenId = remindPasswordTokenService.createToken(user.getUserName(), FORGOT_PASSWORD_TOKEN);
 
-    Router router = webController.getRouter();
-    Map<QualifiedName, String> params = new HashMap<>();
-    params.put(WebAppController.HANDLER_PARAM, NAME);
-    params.put(TOKEN, tokenId);
-    params.put(LANG, I18N.toTagIdentifier(locale));
-
     StringBuilder url = new StringBuilder();
     url.append(req.getScheme()).append("://").append(req.getServerName());
     if (req.getServerPort() != 80 && req.getServerPort() != 443) {
       url.append(':').append(req.getServerPort());
     }
     url.append(container.getPortalContext().getContextPath());
-    url.append(router.render(params));
+    url.append(getPasswordRecoverURL(tokenId, I18N.toTagIdentifier(locale)));
 
     String emailBody = buildRecoverEmailBody(user, bundle, url.toString());
     String emailSubject = getEmailSubject(user, bundle);
@@ -594,44 +588,41 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
 
   @Override
   public String getOnboardingURL(String tokenId, String lang) {
-    Router router = webController.getRouter();
-    Map<QualifiedName, String> params = new HashMap<>();
-    params.put(WebAppController.HANDLER_PARAM, "on-boarding");
+    String passwordRecoveryPath = "/portal/on-boarding";
     if (tokenId != null) {
-      params.put(TOKEN, tokenId);
+      passwordRecoveryPath = "%s%stoken=%s".formatted(passwordRecoveryPath, passwordRecoveryPath.contains("?") ? "&" : "?", tokenId);
     }
     if (lang != null) {
-      params.put(LANG, lang);
+      passwordRecoveryPath = "%s%slang=%s".formatted(passwordRecoveryPath, passwordRecoveryPath.contains("?") ? "&" : "?", lang);
+
     }
-    return router.render(params);
+    return passwordRecoveryPath;
   }
 
   @Override
   public String getExternalRegistrationURL(String tokenId, String lang) {
-    Router router = webController.getRouter();
-    Map<QualifiedName, String> params = new HashMap<>();
-    params.put(WebAppController.HANDLER_PARAM, EXTERNAL_REGISTRATION_NAME);
+    String passwordRecoveryPath = "/portal/external-registration";
     if (tokenId != null) {
-      params.put(TOKEN, tokenId);
+      passwordRecoveryPath = "%s%stoken=%s".formatted(passwordRecoveryPath, passwordRecoveryPath.contains("?") ? "&" : "?", tokenId);
     }
     if (lang != null) {
-      params.put(LANG, lang);
+      passwordRecoveryPath = "%s%slang=%s".formatted(passwordRecoveryPath, passwordRecoveryPath.contains("?") ? "&" : "?", lang);
+
     }
-    return router.render(params);
+    return passwordRecoveryPath;
   }
 
   @Override
   public String getPasswordRecoverURL(String tokenId, String lang) {
-    Router router = webController.getRouter();
-    Map<QualifiedName, String> params = new HashMap<>();
-    params.put(WebAppController.HANDLER_PARAM, NAME);
+    String passwordRecoveryPath = "/portal/forgot-password";
     if (tokenId != null) {
-      params.put(TOKEN, tokenId);
+      passwordRecoveryPath = "%s%stoken=%s".formatted(passwordRecoveryPath, passwordRecoveryPath.contains("?") ? "&" : "?", tokenId);
     }
     if (lang != null) {
-      params.put(LANG, lang);
+      passwordRecoveryPath = "%s%slang=%s".formatted(passwordRecoveryPath, passwordRecoveryPath.contains("?") ? "&" : "?", lang);
+
     }
-    return router.render(params);
+    return passwordRecoveryPath;
   }
 
   @Override


### PR DESCRIPTION
Before this fix, the forgot password form is not accessible, the link to access is only /portal In addition the link in login form email is not complete

This is because the route for forgot-password have been removed from controller.xml because no more used, and it was used in PasswordRecoveryService This commit ensure to build the url without the route. It also apply for external-registration and on-boarding routes.

Resolves meeds-io/meeds#3747

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
