### PR TITLE
fix: unable to apply negative margin in ModelStyle - MEED-9838 -  meeds-io/meeds#3779

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/config/model/ModelStyle.java
+++ b/component/api/src/main/java/org/exoplatform/portal/config/model/ModelStyle.java
@@ -110,28 +110,28 @@ public class ModelStyle implements Serializable {
   public String getCssClass(String existingCssClass, boolean sectionStyle, int diff) { // NOSONAR
     StringBuilder cssClass = new StringBuilder();
     if (!sectionStyle) {
-      if (marginTop != null && marginTop >= 0 && !StringUtils.contains(existingCssClass, "mt-")) {
+      if (marginTop != null && !StringUtils.contains(existingCssClass, "mt-")) {
         cssClass.append(" mt-");
         if (marginTop < diff) {
           cssClass.append("n");
         }
         cssClass.append(Math.abs((marginTop - diff) / 4));
       }
-      if (marginBottom != null && marginBottom >= 0 && !StringUtils.contains(existingCssClass, "mb-")) {
+      if (marginBottom != null && !StringUtils.contains(existingCssClass, "mb-")) {
         cssClass.append(" mb-");
         if (marginBottom < diff) {
           cssClass.append("n");
         }
         cssClass.append(Math.abs((marginBottom - diff) / 4));
       }
-      if (marginRight != null && marginRight >= 0 && !StringUtils.contains(existingCssClass, "me-")) {
+      if (marginRight != null && !StringUtils.contains(existingCssClass, "me-")) {
         cssClass.append(" me-");
         if (marginRight < diff) {
           cssClass.append("n");
         }
         cssClass.append(Math.abs((marginRight - diff) / 4));
       }
-      if (marginLeft != null && marginLeft >= 0 && !StringUtils.contains(existingCssClass, "ms-")) {
+      if (marginLeft != null && !StringUtils.contains(existingCssClass, "ms-")) {
         cssClass.append(" ms-");
         if (marginLeft < diff) {
           cssClass.append("n");


### PR DESCRIPTION
Before this fix, it was not possible to apply negative margin. This is due to Computing in ModelStle which ignore negative margin. This commit remove the test ignoring negative margin

Resolves meeds-io/meeds#3779

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
