### PR TITLE
fix: forgot-password url have twice /portal in url - MEED-9980 - meeds-io/meeds#3864

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/PasswordRecoveryServiceImpl.java
@@ -614,7 +614,7 @@ public class PasswordRecoveryServiceImpl implements PasswordRecoveryService {
 
   @Override
   public String getPasswordRecoverURL(String tokenId, String lang) {
-    String passwordRecoveryPath = "/portal/forgot-password";
+    String passwordRecoveryPath = "/forgot-password";
     if (tokenId != null) {
       passwordRecoveryPath = "%s%stoken=%s".formatted(passwordRecoveryPath, passwordRecoveryPath.contains("?") ? "&" : "?", tokenId);
     }


### PR DESCRIPTION
Before this fix, for forgotPassword url generation, the url is generated with twice /portal This commit removed the uneeded one when the url is generated

Resolves meeds-io/meeds#3864

(cherry picked from commit e78c4ce48eab32870eeef4a02e44d24efb43c6a1)