### PR TITLE
Delegated admins cannot see memberships he must do - MEED-9985 - meeds-io/meeds#3869

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
@@ -599,10 +599,12 @@ public class UserRestResourcesV1 implements ResourceContainer {
                                               .collect(Collectors.toSet());
 
       Identity userIdentity = userACL.getUserIdentity(userName);
-      List<MembershipEntry> memberships = userIdentity.getMemberships().stream().toList();
+      List<MembershipEntry> memberships = userIdentity.getMemberships()
+                                                      .stream()
+                                                      .filter(m -> groupIds.contains(m.getGroup()))
+                                                      .toList();
       totalSize = memberships.size();
       memberships = memberships.stream()
-                                .filter(m -> groupIds.contains(m.getGroup()))
                                 .skip(offset)
                                 .limit(limit)
                                 .toList();

--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
@@ -599,13 +599,13 @@ public class UserRestResourcesV1 implements ResourceContainer {
                                               .collect(Collectors.toSet());
 
       Identity userIdentity = userACL.getUserIdentity(userName);
-      List<MembershipEntry> memberships = userIdentity.getMemberships()
-                                                      .stream()
-                                                      .filter(m -> groupIds.contains(m.getGroup()))
-                                                      .skip(offset)
-                                                      .limit(limit)
-                                                      .toList();
+      List<MembershipEntry> memberships = userIdentity.getMemberships().stream().toList();
       totalSize = memberships.size();
+      memberships = memberships.stream()
+                                .filter(m -> groupIds.contains(m.getGroup()))
+                                .skip(offset)
+                                .limit(limit)
+                                .toList();
       memberships.forEach(m -> {
         try {
           Group group = organizationService.getGroupHandler().findGroupById(m.getGroup());


### PR DESCRIPTION
Before this change, as a delegated admin * in platform/delegated and manager of an organization group), it must be possible to see any memberships of a user from the fact that he is manager of the group and when check membership of himself, the list is limited to a number of memberships. Not all memberships are listed. To fix this problem, return the size of the list before filtering the total membership list. After this change, the load more button is displayed and the drawer behaves the same as the admin window.