### PR TITLE
fix: Adjust the title page- MEED-10059 - meeds-io/meeds#3930

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -66,7 +66,7 @@
   String metaPortalName = rcontext.getMetaPortal();
   
   def title = rcontext.getTitle() + " - ";
-  if (!metaPortalName.equals(siteName)) {
+  if (!metaPortalName.equals(siteName) && !siteName.equals('global') ) {
     title = title + rcontext.getSiteLabel() + " - ";
   }
   title = title + companyName;


### PR DESCRIPTION
Before this change, the title of the login page contained the word “global.” For accessibility reasons, the title must be updated and no longer contain this word. This change will resolve this issue.