### PR TITLE
fix: Sanitize siteLabel before injecting into JavaScript - MEED-10098 - Meeds-io/MIPs#234

### DIFF
--- a/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
+++ b/web/portal/src/main/webapp/groovy/portal/webui/workspace/UIPortalApplication.gtmpl
@@ -176,7 +176,7 @@
      eXo.env.portal.productName = "<%=productName%>";
      eXo.env.portal.productLink = "<%=productLink%>";
      eXo.env.portal.siteId = '<%=siteId%>';
-     eXo.env.portal.siteLabel = '<%=rcontext.getSiteLabel() == null ? "" : rcontext.getSiteLabel()%>';
+     eXo.env.portal.siteLabel = '<%=rcontext.getSiteLabel() == null ? "" : rcontext.getSiteLabel().replaceAll("'", "\\\\'")%>';
      eXo.env.server.context = "<%=docBase%>";
      eXo.env.server.portalBaseURL = "<%=uicomponent.getBaseURL()%>";
      eXo.env.server.portalURLTemplate = "<%=uicomponent.getPortalURLTemplate()%>";


### PR DESCRIPTION
This change will fix JS error caused by apostrophes in portal siteLabel