### PR TITLE
fix: Allow to update a disabled user - MEED-10113 - meeds-io/meeds#3974

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -164,10 +164,6 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
       Tools.logMethodIn(log, LogLevel.TRACE, "saveUser", new Object[] { "user", user, "broadcast", broadcast });
     }
 
-    if (user != null && !user.isEnabled()) {
-      throw new DisabledUserException(user.getUserName());
-    }
-
     IdentitySession session = service_.getIdentitySession();
     if (broadcast) {
       preSave(user, false);

--- a/component/identity/src/test/java/org/exoplatform/services/tck/organization/TestUserHandler.java
+++ b/component/identity/src/test/java/org/exoplatform/services/tck/organization/TestUserHandler.java
@@ -698,11 +698,11 @@ public class TestUserHandler extends AbstractOrganizationServiceTest
          try
          {
             uHandler.saveUser(u, true);
-            fail("A DisabledUserException was expected");
+            // no issue expected
          }
          catch (DisabledUserException e)
          {
-            // expected issue
+            fail("A DisabledUserException was not expected");
          }
 
          // Enable the user
@@ -725,8 +725,8 @@ public class TestUserHandler extends AbstractOrganizationServiceTest
       // Check the listener's counters
       assertEquals(1, listener.preSaveNew);
       assertEquals(1, listener.postSaveNew);
-      assertEquals(unsupportedOperation ? 2 : 3, listener.preSave);
-      assertEquals(unsupportedOperation ? 2 : 3, listener.postSave);
+      assertEquals(unsupportedOperation ? 3 : 4, listener.preSave);
+      assertEquals(unsupportedOperation ? 3 : 4, listener.postSave);
       assertEquals(unsupportedOperation ? 0 : 2, listener.preSetEnabled);
       assertEquals(unsupportedOperation ? 0 : 2, listener.postSetEnabled);
       assertEquals(1, listener.preDelete);
@@ -766,11 +766,12 @@ public class TestUserHandler extends AbstractOrganizationServiceTest
          try
          {
             uHandler.saveUser(u, true);
-            fail("A DisabledUserException was expected");
+            // no issue expected, as we allow to save disabled user
          }
          catch (DisabledUserException e)
          {
-            // expected issue
+            fail("A DisabledUserException is not expected");
+
          }
 
          try
@@ -818,8 +819,8 @@ public class TestUserHandler extends AbstractOrganizationServiceTest
       // Check the listener's counters
       assertEquals(1, listener.preSaveNew);
       assertEquals(1, listener.postSaveNew);
-      assertEquals(unsupportedOperation ? 1 : 2, listener.preSave);
-      assertEquals(unsupportedOperation ? 1 : 2, listener.postSave);
+      assertEquals(unsupportedOperation ? 2 : 3, listener.preSave);
+      assertEquals(unsupportedOperation ? 2 : 3, listener.postSave);
       assertEquals(unsupportedOperation ? 0 : 2, listener.preSetEnabled);
       assertEquals(unsupportedOperation ? 0 : 2, listener.postSetEnabled);
       assertEquals(1, listener.preDelete);


### PR DESCRIPTION
Before this fix, when saving a disabled user, it generates a DisabledUserException. As there is no reason to prevent the modification of a disabled user, this commit remove the test when saving the user

Resolves meeds-io/meeds#3974

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
