### PR TITLE
fix: Allow to update a disabled user - MEED-10113 - meeds-io/meeds#3974

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -164,10 +164,6 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
       Tools.logMethodIn(log, LogLevel.TRACE, "saveUser", new Object[] { "user", user, "broadcast", broadcast });
     }
 
-    if (user != null && !user.isEnabled()) {
-      throw new DisabledUserException(user.getUserName());
-    }
-
     IdentitySession session = service_.getIdentitySession();
     if (broadcast) {
       preSave(user, false);

--- a/component/identity/src/test/java/org/exoplatform/services/tck/organization/TestUserHandler.java
+++ b/component/identity/src/test/java/org/exoplatform/services/tck/organization/TestUserHandler.java
@@ -698,11 +698,11 @@ public class TestUserHandler extends AbstractOrganizationServiceTest
          try
          {
             uHandler.saveUser(u, true);
-            fail("A DisabledUserException was expected");
+            // no issue expected
          }
          catch (DisabledUserException e)
          {
-            // expected issue
+            fail("A DisabledUserException was not expected");
          }
 
          // Enable the user
@@ -725,8 +725,8 @@ public class TestUserHandler extends AbstractOrganizationServiceTest
       // Check the listener's counters
       assertEquals(1, listener.preSaveNew);
       assertEquals(1, listener.postSaveNew);
-      assertEquals(unsupportedOperation ? 2 : 3, listener.preSave);
-      assertEquals(unsupportedOperation ? 2 : 3, listener.postSave);
+      assertEquals(unsupportedOperation ? 3 : 4, listener.preSave);
+      assertEquals(unsupportedOperation ? 3 : 4, listener.postSave);
       assertEquals(unsupportedOperation ? 0 : 2, listener.preSetEnabled);
       assertEquals(unsupportedOperation ? 0 : 2, listener.postSetEnabled);
       assertEquals(1, listener.preDelete);
@@ -766,11 +766,12 @@ public class TestUserHandler extends AbstractOrganizationServiceTest
          try
          {
             uHandler.saveUser(u, true);
-            fail("A DisabledUserException was expected");
+            // no issue expected, as we allow to save disabled user
          }
          catch (DisabledUserException e)
          {
-            // expected issue
+            fail("A DisabledUserException is not expected");
+
          }
 
          try
@@ -818,8 +819,8 @@ public class TestUserHandler extends AbstractOrganizationServiceTest
       // Check the listener's counters
       assertEquals(1, listener.preSaveNew);
       assertEquals(1, listener.postSaveNew);
-      assertEquals(unsupportedOperation ? 1 : 2, listener.preSave);
-      assertEquals(unsupportedOperation ? 1 : 2, listener.postSave);
+      assertEquals(unsupportedOperation ? 2 : 3, listener.preSave);
+      assertEquals(unsupportedOperation ? 2 : 3, listener.postSave);
       assertEquals(unsupportedOperation ? 0 : 2, listener.preSetEnabled);
       assertEquals(unsupportedOperation ? 0 : 2, listener.postSetEnabled);
       assertEquals(1, listener.preDelete);

--- a/component/web/security/src/main/java/org/exoplatform/web/login/recovery/DefaultChangePasswordConnector.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/recovery/DefaultChangePasswordConnector.java
@@ -23,6 +23,7 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.web.security.security.CookieTokenService;
 
 public class DefaultChangePasswordConnector extends ChangePasswordConnector {
@@ -53,7 +54,7 @@ public class DefaultChangePasswordConnector extends ChangePasswordConnector {
   
   @Override
   public void changePassword(final String username, final String password) throws Exception {
-    User user = organizationService.getUserHandler().findUserByName(username);
+    User user = organizationService.getUserHandler().findUserByName(username, UserStatus.ANY);
     
     if (user.isInternalStore()) {
       changeInternalPassword(user, password);

--- a/component/web/security/src/test/java/org/exoplatform/web/login/recovery/DefaultChangePasswordConnectorTest.java
+++ b/component/web/security/src/test/java/org/exoplatform/web/login/recovery/DefaultChangePasswordConnectorTest.java
@@ -22,6 +22,7 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.services.organization.idm.PicketLinkIDMService;
 import org.exoplatform.services.organization.idm.UserDAOImpl;
 import org.exoplatform.services.organization.idm.UserImpl;
@@ -60,7 +61,7 @@ public class DefaultChangePasswordConnectorTest {
     userTest.setOriginatingStore(OrganizationService.INTERNAL_STORE);
     
     UserDAOImpl userHandler = Mockito.mock(UserDAOImpl.class);
-    Mockito.when(userHandler.findUserByName(userTest.getUserName())).thenReturn(userTest);
+    Mockito.when(userHandler.findUserByName(userTest.getUserName(), UserStatus.ANY)).thenReturn(userTest);
     Mockito.when(organizationService.getUserHandler()).thenReturn(userHandler);
     InitParams initParams = new InitParams();
 
@@ -93,7 +94,7 @@ public class DefaultChangePasswordConnectorTest {
     userTest.setOriginatingStore(OrganizationService.EXTERNAL_STORE);
     
     UserDAOImpl userHandler = Mockito.mock(UserDAOImpl.class);
-    Mockito.when(userHandler.findUserByName(userTest.getUserName())).thenReturn(userTest);
+    Mockito.when(userHandler.findUserByName(userTest.getUserName(), UserStatus.ANY)).thenReturn(userTest);
     Mockito.when(organizationService.getUserHandler()).thenReturn(userHandler);
 
     InitParams initParams = new InitParams();


### PR DESCRIPTION
Before this fix, when saving a disabled user, it generates a DisabledUserException. As there is no reason to prevent the modification of a disabled user, this commit remove the test when saving the user

Resolves meeds-io/meeds#3974

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
