### PR TITLE
fix: Redirect to login page when requesting anonymously a restricted global page - MEED-9940

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -418,7 +418,7 @@ public class UserPortalConfigService implements Startable {
       do {
         if (isAccessiblePageNoDraft(targetUserNode, username)) {
           return targetUserNode;
-        } else if (CollectionUtils.isNotEmpty(targetUserNode.getChildren())) {
+        } else if (StringUtils.isNotBlank(username) && CollectionUtils.isNotEmpty(targetUserNode.getChildren())) {
           UserNode childUserNode = getNodeOrFirstChildWithPage(targetUserNode.getChildren(), username);
           if (isAccessiblePageNoDraft(childUserNode, username)) {
             return childUserNode;
@@ -730,6 +730,10 @@ public class UserPortalConfigService implements Startable {
       }
       currentDepth++;
     }
+    if (currentDepth > validSiteDepth && currentDepth > validGlobalDepth) {
+      // Page not found in the current site and in the Global site
+      return null;
+    }
     if (globalUserNode != null) {
       if (validSiteDepth >= validGlobalDepth) {
         UserNode result = getNodeOrFirstChildWithPage(siteUserNode, username);
@@ -774,7 +778,7 @@ public class UserPortalConfigService implements Startable {
                     .map(node -> {
                       if (isAccessiblePage(node, username)) {
                         return node;
-                      } else if (CollectionUtils.isNotEmpty(node.getChildren())) {
+                      } else if (StringUtils.isNotBlank(username) && CollectionUtils.isNotEmpty(node.getChildren())) {
                         return getNodeOrFirstChildWithPage(node.getChildren(), username);
                       }
                       return null;

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestUserPortalConfigService.java
@@ -734,14 +734,15 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
   }
 
   public void testGetDefaultSitePath() {
-    assertEquals(DEFAULT_CLASSIC_HOME, userPortalConfigService.getDefaultSitePath("classic", null));
+    assertNull( userPortalConfigService.getDefaultSitePath("classic", null));
     assertEquals(DEFAULT_CLASSIC_HOME, userPortalConfigService.getDefaultSitePath("classic", "NotExisting"));
     assertEquals(DEFAULT_CLASSIC_HOME, userPortalConfigService.getDefaultSitePath("classic", "john"));
     assertEquals(DEFAULT_CLASSIC_HOME, userPortalConfigService.getDefaultSitePath("classic", "james"));
   }
 
   public void testGetSiteNodeOrGlobalNode() {
-    UserNode userNode = userPortalConfigService.getDefaultSiteNode("classic", null);
+    UserNode userNode = userPortalConfigService.getDefaultSiteNode("classic", "mary");
+    assertNotNull(userNode);
     assertEquals("home", userNode.getURI());
 
     Page homePage = layoutService.getPage(userNode.getPageRef());
@@ -750,7 +751,7 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
       homePage.setAccessPermissions(new String[] {"*:/platform/administrators"});
       layoutService.save(new PageContext(homePage.getPageKey(), Utils.toPageState(homePage)));
 
-      userNode = userPortalConfigService.getDefaultSiteNode("classic", null);
+      userNode = userPortalConfigService.getDefaultSiteNode("classic", "mary");
       assertEquals("home/subnode", userNode.getURI());
     } finally {
       homePage.setAccessPermissions(accessPermissions);
@@ -762,16 +763,16 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
     UserNode userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "home", null);
     assertEquals("home", userNode.getURI());
     userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "Notfound", null);
-    assertEquals("home", userNode.getURI());
+    assertNull(userNode); // No node is returned for anonymous users if the requested one is not found or inaccessible
 
     userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "webexplorer", null);
-    assertEquals("home", userNode.getURI());
+    assertNull(userNode);
 
     userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "home", "NotExisting");
     assertEquals("home", userNode.getURI());
 
     userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "webexplorer", "NotExisting");
-    assertEquals("home", userNode.getURI());
+    assertNull(userNode);
 
     userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "home", "john");
     assertEquals("home", userNode.getURI());
@@ -801,7 +802,7 @@ public class TestUserPortalConfigService extends AbstractConfigTest {
     assertEquals("webexplorer", userNode.getURI());
 
     userNode = userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "classic", "webexplorer", null);
-    assertEquals("home", userNode.getURI());
+    assertNull(userNode);
 
     assertNull(userPortalConfigService.getSiteNodeOrGlobalNode(SiteType.PORTAL.getName(), "NotFound", "home/subnode233", "mary"));
   }


### PR DESCRIPTION
When requesting a global page anonymously, the first accessible page is returned and we have some issues in the display (Login page with some alerts from the inaccessible page)
The fix : 
 - Anonymous user : if the page is not found or restricted, the request is redirected to the login page
 - Logged-in user : if the page is not found , a Page not found page is displayed. Otherwise, we preserve the current behavior of user redirections. 