### PR TITLE
fix: adjust condition to redirect correctly to subpages - MEED-9940 

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -730,7 +730,7 @@ public class UserPortalConfigService implements Startable {
       }
       currentDepth++;
     }
-    if (currentDepth > validSiteDepth && currentDepth > validGlobalDepth) {
+    if (validSiteDepth == 0 && validGlobalDepth == 0) {
       // Page not found in the current site and in the Global site
       return null;
     }


### PR DESCRIPTION
Corrected the check when a navigation is not found in the current site and in the global site, to correctly redirect to the predefined navigation and its sub-pages when requested.
