### PR TITLE
feat: Allow to decorate Organization Entities when fetched from Store - MEED-10149 - Meeds-io/MIPs#240

### DIFF
--- a/component/identity/src/main/java/io/meeds/services/organization/plugin/GroupDecoratorPlugin.java
+++ b/component/identity/src/main/java/io/meeds/services/organization/plugin/GroupDecoratorPlugin.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.services.organization.plugin;
+
+import org.exoplatform.services.organization.Group;
+
+@FunctionalInterface
+public interface GroupDecoratorPlugin extends OrganizationDecoratorPlugin<Group> {
+
+}

--- a/component/identity/src/main/java/io/meeds/services/organization/plugin/OrganizationDecoratorPlugin.java
+++ b/component/identity/src/main/java/io/meeds/services/organization/plugin/OrganizationDecoratorPlugin.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.services.organization.plugin;
+
+@FunctionalInterface
+public interface OrganizationDecoratorPlugin<T> {
+
+  T decorate(T obj);
+
+}

--- a/component/identity/src/main/java/io/meeds/services/organization/plugin/UserDecoratorPlugin.java
+++ b/component/identity/src/main/java/io/meeds/services/organization/plugin/UserDecoratorPlugin.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.services.organization.plugin;
+
+import org.exoplatform.services.organization.User;
+
+@FunctionalInterface
+public interface UserDecoratorPlugin extends OrganizationDecoratorPlugin<User> {
+
+}

--- a/component/identity/src/main/java/io/meeds/services/organization/plugin/UserProfileDecoratorPlugin.java
+++ b/component/identity/src/main/java/io/meeds/services/organization/plugin/UserProfileDecoratorPlugin.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.services.organization.plugin;
+
+import org.exoplatform.services.organization.UserProfile;
+
+@FunctionalInterface
+public interface UserProfileDecoratorPlugin extends OrganizationDecoratorPlugin<UserProfile> {
+
+}

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
@@ -41,27 +41,30 @@ import org.exoplatform.services.organization.GroupHandler;
 import org.exoplatform.services.organization.MembershipTypeHandler;
 import org.exoplatform.services.organization.NestedMembership;
 
+import io.meeds.services.organization.plugin.GroupDecoratorPlugin;
+
 import lombok.SneakyThrows;
 
 public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
 
-  public static final String       GROUP_LABEL       = "label";
+  public static final String         GROUP_LABEL       = "label";
 
-  public static final String       GROUP_DESCRIPTION = "description";
+  public static final String         GROUP_DESCRIPTION = "description";
 
-  public static final String       NESTED_GROUPS     = "nestedGroups";
+  public static final String         NESTED_GROUPS     = "nestedGroups";
 
-  public static final String       ENCLOSING_GROUPS  = "enclosingGroups";
+  public static final String         ENCLOSING_GROUPS  = "enclosingGroups";
 
-  private List<GroupEventListener> listeners_;
+  private List<GroupEventListener>   listeners_        = new ArrayList<>();
 
-  private static final String      CYCLIC_ID         = "org.gatein.portal.identity.LOOPED_GROUP_ID";
+  private List<GroupDecoratorPlugin> decoratorPlugins  = new ArrayList<>();
 
-  org.picketlink.idm.api.Group     rootGroup         = null;
+  private static final String        CYCLIC_ID         = "org.gatein.portal.identity.LOOPED_GROUP_ID";
+
+  org.picketlink.idm.api.Group       rootGroup         = null;
 
   public GroupDAOImpl(PicketLinkIDMOrganizationServiceImpl orgService, PicketLinkIDMService service) {
     super(orgService, service);
-    listeners_ = new ArrayList<GroupEventListener>();
   }
 
   public void addGroupEventListener(GroupEventListener listener) {
@@ -884,7 +887,11 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
       Tools.logMethodOut(log, LogLevel.TRACE, "convertGroup", group);
     }
 
-    return group;
+    Group result = group;
+    for (GroupDecoratorPlugin decoratorPlugin : decoratorPlugins) {
+      result = decoratorPlugin.decorate(result);
+    }
+    return result;
   }
 
   /**
@@ -1235,6 +1242,10 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
     } finally {
       orgService.flush();
     }
+  }
+
+  public void addDecoratorPlugin(GroupDecoratorPlugin decoratorPlugin) {
+    decoratorPlugins.add(decoratorPlugin);
   }
 
   @SneakyThrows

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/IDMUserListAccess.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/IDMUserListAccess.java
@@ -116,7 +116,7 @@ public class IDMUserListAccess implements ListAccess<User>, Serializable {
             User gtnUser = null;
             if (loadUserAttributes) {
               gtnUser = new UserImpl(user.getId());
-              ((UserDAOImpl) getOrganizationService().getUserHandler()).populateUser(gtnUser, getIDMService().getIdentitySession());
+              gtnUser = ((UserDAOImpl) getOrganizationService().getUserHandler()).populateUser(gtnUser, getIDMService().getIdentitySession());
             } else {
               gtnUser = getOrganizationService().getUserHandler().createUserInstance(user.getId());
             }

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/PicketLinkIDMOrganizationServiceImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/PicketLinkIDMOrganizationServiceImpl.java
@@ -33,6 +33,7 @@ import org.picketlink.idm.spi.configuration.metadata.IdentityStoreMappingMetaDat
 import org.picocontainer.Startable;
 
 import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.component.ComponentPlugin;
 import org.exoplatform.container.component.ComponentRequestLifecycle;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.container.xml.InitParams;
@@ -44,6 +45,9 @@ import org.exoplatform.services.organization.idm.cache.CacheableMembershipHandle
 import org.exoplatform.services.organization.idm.cache.CacheableMembershipTypeHandlerImpl;
 import org.exoplatform.services.organization.idm.cache.CacheableUserHandlerImpl;
 import org.exoplatform.services.organization.idm.cache.CacheableUserProfileHandlerImpl;
+
+import io.meeds.services.organization.plugin.GroupDecoratorPlugin;
+import io.meeds.services.organization.plugin.OrganizationDecoratorPlugin;
 
 /**
  * OrganizationService implementation using PicketLink
@@ -296,6 +300,13 @@ public class PicketLinkIDMOrganizationServiceImpl extends BaseOrganizationServic
 
   public void setConfiguration(Config configuration) {
     this.configuration = configuration;
+  }
+
+  public void addDecoratorPlugin(OrganizationDecoratorPlugin<?> plugin) throws Exception {
+    switch (plugin) {
+    case GroupDecoratorPlugin groupDecoratorPlugin -> ((GroupDAOImpl) groupDAO_).addDecoratorPlugin(groupDecoratorPlugin);
+    default -> throw new IllegalArgumentException("Unexpected plugin class: %s".formatted(plugin));
+    };
   }
 
   private void initConfiguration(InitParams params) {

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -21,20 +21,38 @@ package org.exoplatform.services.organization.idm;
 import static org.exoplatform.services.organization.idm.EntityMapperUtils.ORIGINATING_STORE;
 
 import java.text.DateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import org.exoplatform.services.log.LogLevel;
-import org.picketlink.idm.api.*;
+import org.picketlink.idm.api.Attribute;
+import org.picketlink.idm.api.AttributesManager;
+import org.picketlink.idm.api.IdentitySession;
 import org.picketlink.idm.api.query.UserQueryBuilder;
 import org.picketlink.idm.impl.api.SimpleAttribute;
 import org.picketlink.idm.impl.api.model.SimpleUser;
 
 import org.exoplatform.commons.utils.LazyPageList;
 import org.exoplatform.commons.utils.ListAccess;
-import org.exoplatform.container.*;
-import org.exoplatform.services.organization.*;
+import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.RootContainer;
+import org.exoplatform.services.log.LogLevel;
+import org.exoplatform.services.organization.DisabledUserException;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.Query;
 import org.exoplatform.services.organization.User;
+import org.exoplatform.services.organization.UserEventListener;
+import org.exoplatform.services.organization.UserHandler;
+import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.services.organization.externalstore.IDMExternalStoreService;
+
+import io.meeds.services.organization.plugin.GroupDecoratorPlugin;
+import io.meeds.services.organization.plugin.UserDecoratorPlugin;
 
 public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
 
@@ -66,6 +84,8 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
   public static final Set<String> USER_NON_PROFILE_KEYS;
 
   public static final DateFormat  dateFormat           = DateFormat.getInstance();
+
+  private List<UserDecoratorPlugin> decoratorPlugins           = new ArrayList<>();
 
   static {
     Set<String> keys = new HashSet<String>();
@@ -554,7 +574,7 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
 
     if (plUser != null) {
       user = new UserImpl(plUser.getId());
-      populateUser(user, session);
+      user = populateUser(user, session);
 
       if (disableUserActived() && !userStatus.matches(user.isEnabled())) {
         user = null;
@@ -826,7 +846,7 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
     }
 
     User user = new UserImpl(u.getId());
-    populateUser(user, session);
+    user = populateUser(user, session);
 
     if (disableUserActived()) {
       return userStatus.matches(user.isEnabled()) ? user : null;
@@ -835,7 +855,11 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
     }
   }
 
-  public void populateUser(User user, IdentitySession session) throws Exception {
+  public void addDecoratorPlugin(UserDecoratorPlugin decoratorPlugin) {
+    decoratorPlugins.add(decoratorPlugin);
+  }
+
+  public User populateUser(User user, IdentitySession session) throws Exception {
     AttributesManager am = session.getAttributesManager();
 
     Map<String, Attribute> attrs = null;
@@ -848,12 +872,16 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
 
     }
     if (attrs == null) {
-      return;
+      return user;
     } else {
       EntityMapperUtils.populateUser(user, attrs);
       if (attrs.containsKey(USER_PASSWORD)) {
         user.setPassword(attrs.get(USER_PASSWORD).getValue().toString());
       }
+      for (UserDecoratorPlugin decoratorPlugin : decoratorPlugins) {
+        user = decoratorPlugin.decorate(user);
+      }
+      return user;
     }
   }
 

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserProfileDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserProfileDAOImpl.java
@@ -29,6 +29,9 @@ import java.util.Set;
 
 import javax.naming.InvalidNameException;
 
+import org.picketlink.idm.api.Attribute;
+import org.picketlink.idm.impl.api.SimpleAttribute;
+
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserHandler;
@@ -37,18 +40,19 @@ import org.exoplatform.services.organization.UserProfileEventListener;
 import org.exoplatform.services.organization.UserProfileHandler;
 import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.services.organization.impl.UserProfileImpl;
-import org.picketlink.idm.api.Attribute;
-import org.picketlink.idm.impl.api.SimpleAttribute;
+
+import io.meeds.services.organization.plugin.UserProfileDecoratorPlugin;
 
 public class UserProfileDAOImpl extends AbstractDAOImpl implements UserProfileHandler {
 
-    private static final UserProfile       NOT_FOUND = new UserProfileImpl();
+  private static final UserProfile         NOT_FOUND        = new UserProfileImpl();
 
-    private List<UserProfileEventListener> listeners;
+  private List<UserProfileEventListener>   listeners        = new ArrayList<>();
+
+  private List<UserProfileDecoratorPlugin> decoratorPlugins = new ArrayList<>();
 
     public UserProfileDAOImpl(PicketLinkIDMOrganizationServiceImpl orgService, PicketLinkIDMService service) {
         super(orgService, service);
-        listeners = new ArrayList<>();
     }
 
     public void addUserProfileEventListener(UserProfileEventListener listener) {
@@ -176,6 +180,10 @@ public class UserProfileDAOImpl extends AbstractDAOImpl implements UserProfileHa
         return profiles;
     }
 
+    public void addDecoratorPlugin(UserProfileDecoratorPlugin decoratorPlugin) {
+      decoratorPlugins.add(decoratorPlugin);
+    }
+
     private void preSave(UserProfile profile, boolean isNew) throws Exception {
         for (UserProfileEventListener listener : listeners) {
             listener.preSave(profile, isNew);
@@ -252,7 +260,9 @@ public class UserProfileDAOImpl extends AbstractDAOImpl implements UserProfileHa
         }
 
         UserProfile profile = new UserProfileImpl(userName, filteredAttrs);
-
+        for (UserProfileDecoratorPlugin decoratorPlugin : decoratorPlugins) {
+          profile = decoratorPlugin.decorate(profile);
+        }
         return profile;
 
     }


### PR DESCRIPTION
This change will allow to decorate fetched IMD Objects from store using component plugins before cached. In fact, this extension mechanism will allow to store further information about `User`, `UserProfile` and `Group` in a different Storage services sych as in social with different Spaces and Identity Management.