### PR TITLE
fix : Make OIDC logout working when end_session_endpoint is present in configuration - MEED-10192 - meeds-io/meeds#4024

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/logout/LogoutHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/logout/LogoutHandler.java
@@ -1,0 +1,95 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.web.logout;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.exoplatform.web.ControllerContext;
+import org.exoplatform.web.WebAppController;
+import org.exoplatform.web.WebRequestHandler;
+import org.exoplatform.web.login.LoginUtils;
+import org.exoplatform.web.login.LogoutControl;
+import org.exoplatform.web.security.PortalToken;
+import org.exoplatform.web.security.security.AbstractTokenService;
+import org.exoplatform.web.security.security.CookieTokenService;
+import org.gatein.wci.ServletContainerFactory;
+
+public class LogoutHandler extends WebRequestHandler {
+
+  @Override
+  public String getHandlerName() {
+    return "logout";
+  }
+
+  @Override
+  protected boolean getRequiresLifeCycle() {
+    return true;
+  }
+
+  @Override
+  public void onInit(WebAppController controller, ServletConfig servletConfig) {
+
+  }
+
+  @Override
+  public boolean execute(ControllerContext context) throws Exception { // NOSONAR
+    HttpServletRequest request = context.getRequest();
+    HttpServletResponse response = context.getResponse();
+
+    // Delete the token from store
+    String token = getTokenCookie(request);
+    if (token != null) {
+      AbstractTokenService<PortalToken, String> tokenService = AbstractTokenService.getInstance(CookieTokenService.class);
+      tokenService.deleteToken(token);
+    }
+
+    LogoutControl.wantLogout();
+
+    ServletContainerFactory.getServletContainer().logout(request, response);
+
+
+
+    Cookie cookie = new Cookie(LoginUtils.COOKIE_NAME, "");
+    cookie.setPath(request.getContextPath());
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+
+    response.sendRedirect("/");
+
+
+
+    return true;
+  }
+
+private String getTokenCookie(HttpServletRequest req) {
+  Cookie[] cookies = req.getCookies();
+  if (cookies != null) {
+    for (Cookie cookie : cookies) {
+      if (LoginUtils.COOKIE_NAME.equals(cookie.getName())) {
+        return cookie.getValue();
+      }
+    }
+  }
+  return null;
+}
+
+
+}

--- a/web/portal/src/main/webapp/WEB-INF/conf/portal/controller-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/portal/controller-configuration.xml
@@ -118,6 +118,11 @@
       </init-params>
     </component-plugin>
     <component-plugin>
+      <name>LogoutHandler</name>
+      <set-method>register</set-method>
+      <type>org.exoplatform.web.logout.LogoutHandler</type>
+    </component-plugin>
+    <component-plugin>
       <name>DownloadHandler</name>
       <set-method>register</set-method>
       <type>org.exoplatform.web.handler.DownloadHandler</type>


### PR DESCRIPTION
Before this fix, when using OIDC, some IDP provide a endsession_endpoint url, to make a logout on the IDP after being loggued out from the SP, and eXo do not use this url This commit ensure to send the user in this url if existing and if property exo.oauth.openid.propagate.logout is set to true To achieve this modification, this commit create a new handler in the platform to manage the logout : LogoutHandler on /portal/logout. The old logout code (UIPortal.LogoutActionListener) is removed

Resolves meeds-io/meeds#4024

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
