### PR TITLE
feat: Review the operation Create User - MEED-10151 - Meeds-io/MIPs#242

### DIFF
--- a/component/identity/src/main/java/io/meeds/portal/identity/job/UserAutomaticDeactivationJob.java
+++ b/component/identity/src/main/java/io/meeds/portal/identity/job/UserAutomaticDeactivationJob.java
@@ -15,19 +15,17 @@
  */
 package io.meeds.portal.identity.job;
 
-import io.meeds.common.ContainerTransactional;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.UserHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+
+import org.exoplatform.services.organization.OrganizationService;
+
+import io.meeds.common.ContainerTransactional;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Scheduled job responsible for automatically deactivating inactive users.
@@ -61,13 +59,16 @@ public class UserAutomaticDeactivationJob {
   @Value("${social.user.inactive.period.days:180}")
   private int                 inactiveDays;
 
+  @Value("${social.user.inactive.groupId:}")
+  private String              groupId;
+
   @Scheduled(cron = "${social.UserAutomaticDeactivationJob.expression:0 15 23 ? * *}")
   @ContainerTransactional
   public void deactivateUsersInactive() {
     log.info("Starting automatic user deactivation job (inactiveDays={})", inactiveDays);
     try {
       int deactivatedCount = organizationService.getUserHandler()
-                                                .disableInactiveUsers(inactiveDays);
+                                                .disableInactiveUsers(groupId, inactiveDays);
       if (deactivatedCount != 0) {
         log.info("Automatic user deactivation job finished. {} users disabled",
                  deactivatedCount);

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 import org.picketlink.idm.api.Attribute;
 import org.picketlink.idm.api.AttributesManager;
@@ -493,7 +495,7 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
   }
 
   @Override
-  public int disableInactiveUsers(int inactiveDays) {
+  public int disableInactiveUsers(String groupId, int inactiveDays) {
     long sinceTime = ZonedDateTime.now().minusDays(inactiveDays).toEpochSecond() * 1000;
     try (Session session = ((PicketLinkIDMServiceImpl) service_).getHibernateService().openSession()) {
       int disabledCount = 0;
@@ -501,19 +503,26 @@ public class UserDAOImpl extends AbstractDAOImpl implements UserHandler {
       int limit = 100;
       List<Tuple> result;
       do {
-        org.hibernate.query.Query<Tuple> sqlQuery = session.createNamedQuery("HibernateIdentityObject.findEnabledIdentitiesSortByLastLoginTime", Tuple.class);
-        sqlQuery.setFirstResult(offset);
-        sqlQuery.setMaxResults(limit);
-        result = sqlQuery.getResultList();
+        result = session.createNamedQuery("HibernateIdentityObject.findEnabledIdentitiesSortByLastLoginTime",
+                                          Tuple.class)
+                        .setFirstResult(offset)
+                        .setMaxResults(limit)
+                        .getResultList();
         List<String> inactiveUsers = result.stream()
-          .filter(t -> Long.parseLong(t.get(1, String.class)) < sinceTime)
-          .map(t -> t.get(0, String.class))
-          .toList();
+                                           .filter(t -> Long.parseLong(t.get(1, String.class)) < sinceTime)
+                                           .map(t -> t.get(0, String.class))
+                                           .toList();
         int inactiveUsersSize = inactiveUsers.size();
         for (String userName : inactiveUsers) {
-          setEnabled(userName, false, true, true);
+          if (CollectionUtils.isEmpty(orgService.getMembershipHandler()
+                                                .findMembershipsByUserAndGroup(userName, "/platform/administrators"))
+              && (StringUtils.isBlank(groupId)
+                  || CollectionUtils.isNotEmpty(orgService.getMembershipHandler()
+                                                          .findMembershipsByUserAndGroup(userName, groupId)))) {
+            setEnabled(userName, false, true, true);
+            disabledCount += 1;
+          }
         }
-        disabledCount += inactiveUsersSize;
         offset += limit;
         if (inactiveUsersSize != result.size()) {
           // The users who already logged in lately is already reached since the

--- a/component/identity/src/test/java/io/meeds/portal/identity/TestUserAutomaticDeactivation.java
+++ b/component/identity/src/test/java/io/meeds/portal/identity/TestUserAutomaticDeactivation.java
@@ -68,7 +68,7 @@ public class TestUserAutomaticDeactivation extends AbstractKernelTest {// NOSONA
   }
 
   public void testShouldNotDisableUsersWhenNotInactive() {
-    assertEquals(0, userDao.disableInactiveUsers(5));
+    assertEquals(0, userDao.disableInactiveUsers(null, 5));
   }
 
   @SuppressWarnings("deprecation")
@@ -84,14 +84,14 @@ public class TestUserAutomaticDeactivation extends AbstractKernelTest {// NOSONA
     userDao.saveUser(user, true);
     restartTransaction();
 
-    assertEquals(1, userDao.disableInactiveUsers(5));
+    assertEquals(1, userDao.disableInactiveUsers(null, 5));
     restartTransaction();
 
     user = userDao.findUserByName(userName, UserStatus.ANY);
     assertFalse(user.isEnabled());
     assertTrue(user.isAutomaticDeactivation());
 
-    assertEquals(0, userDao.disableInactiveUsers(5));
+    assertEquals(0, userDao.disableInactiveUsers(null, 5));
   }
 
 }

--- a/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/rest/UserRestResourcesV1.java
@@ -98,6 +98,8 @@ public class UserRestResourcesV1 implements ResourceContainer {
 
   public static final String             UNCHANGED_NEW_PASSWORD_ERROR_CODE = "UNCHANGED_NEW_PASSWORD";
 
+  public static final String             CREATION_SOURCE_UI             = "ui";
+
   public static final UserFieldValidator USERNAME_VALIDATOR             = new UserFieldValidator("userName", true, false);
 
   public static final UserFieldValidator EMAIL_VALIDATOR                = new UserFieldValidator("email", false, false);
@@ -274,6 +276,7 @@ public class UserRestResourcesV1 implements ResourceContainer {
     user.setFirstName(firstName);
     user.setLastName(lastName);
     user.setPassword(password);
+    user.setCreationSource(CREATION_SOURCE_UI);
     try {
        organizationService.getUserHandler().createUser(user, true);
     } catch (ObjectAlreadyExistsException objectAlreadyExistsException) {


### PR DESCRIPTION
This change will treat the following tasks:
- Review the Create User operation.
- Review the operation Enable User.
- Review the operation Disable User.
- Allow to specify a time for group members.
- Do not deactivate automatically user when platform admin.

In addition, this change adds a new String parameter `groupId` to the `disableInactiveUsers` method. This `groupId` represents the ID of the group to which the automatic deactivation will be applied. We also added an extra condition to prevent deactivating users who belong to the admin group. On the analytics side, a new attribute `User Source` has been added to indicate the original source of user creation and the labels of the other attributes have also been updated.
