### PR TITLE
fix: Allow using Autowired annotated Component dependencies in Service beans - Meeds-io/meeds#2469

### DIFF
--- a/component/common/src/main/java/io/meeds/spring/kernel/KernelContainerLifecyclePlugin.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/KernelContainerLifecyclePlugin.java
@@ -18,6 +18,7 @@
  */
 package io.meeds.spring.kernel;
 
+import java.lang.reflect.Modifier;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,9 +38,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.picocontainer.Startable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
@@ -62,25 +63,26 @@ import org.exoplatform.services.rest.resource.ResourceContainer;
 
 import io.meeds.spring.kernel.annotation.Exclude;
 import io.meeds.spring.kernel.model.SpringBeanComponentAdapter;
+import io.meeds.spring.kernel.model.SpringBeanProxyFactoryBean;
 
 import jakarta.servlet.ServletContext;
 
 public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin {
 
-  private static final Logger                        LOG                     =
-                                                         LoggerFactory.getLogger(KernelContainerLifecyclePlugin.class);
+  private static final Logger                                 LOG                     =
+                                                                  LoggerFactory.getLogger(KernelContainerLifecyclePlugin.class);
 
-  private static Map<String, BeanDefinitionRegistry> springBeanRegistries    = new ConcurrentHashMap<>();
+  private static Map<String, ConfigurableListableBeanFactory> springBeanRegistries    = new ConcurrentHashMap<>();
 
-  private static Map<String, ApplicationContext>     springContexts          = new ConcurrentHashMap<>();
+  private static Map<String, ApplicationContext>              springContexts          = new ConcurrentHashMap<>();
 
-  private static Map<String, Runnable>               springContextsInitTasks = new ConcurrentHashMap<>();
+  private static Map<String, Runnable>                        springContextsInitTasks = new ConcurrentHashMap<>();
 
-  private static boolean                             kernelAlreadyBooted     = false;
+  private static boolean                                      kernelAlreadyBooted     = false;
 
   public static void addSpringContext(String servletContextName,
                                       ApplicationContext applicationContext,
-                                      BeanDefinitionRegistry beanDefinitionRegistry,
+                                      ConfigurableListableBeanFactory beanFactory,
                                       Runnable springContextInitTask) {
     if (kernelAlreadyBooted) {
       LOG.warn("Adding Spring context '{}' happened too late in Server startup, spring beans will not be injected for this context",
@@ -89,7 +91,7 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
     }
     LOG.info("Add Spring context '{}' to inject its Beans in Kernel as available components", servletContextName);
     springContexts.put(servletContextName, applicationContext);
-    springBeanRegistries.put(servletContextName, beanDefinitionRegistry);
+    springBeanRegistries.put(servletContextName, beanFactory);
     if (springContextInitTask != null) {
       springContextsInitTasks.put(servletContextName, springContextInitTask);
     }
@@ -139,17 +141,17 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
                                   adapter.getComponentImplementation())) {
         return;
       }
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Add Kernel Component '{}' in Spring contexts [{}]",
-                  componentKey.getName(),
-                  StringUtils.join(springContexts.keySet(), ", "));
-      }
       springContexts.forEach((servletContextName, applicationContext) -> {
-        BeanDefinitionRegistry beanRegistry = springBeanRegistries.get(servletContextName);
+        ConfigurableListableBeanFactory beanRegistry = springBeanRegistries.get(servletContextName);
         String componentKeyName = componentKey.getName();
         if (!beanRegistry.containsBeanDefinition(componentKeyName)) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Add Kernel Component '{}' in Spring context [{}]",
+                      componentKey.getName(),
+                      servletContextName);
+          }
           RootBeanDefinition beanDefinition = createBeanDefinition(componentKey, portalContainer);
-          beanRegistry.registerBeanDefinition(componentKeyName, beanDefinition);
+          ((BeanDefinitionRegistry) beanRegistry).registerBeanDefinition(componentKeyName, beanDefinition);
         } else if (LOG.isDebugEnabled()) {
           LOG.debug("-- Ignore Adding duplicated Kernel Component '{}' in Spring contexts {}",
                     componentKey.getName(),
@@ -257,12 +259,13 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
                                                         String senderServletContextName,
                                                         String receiverServletContextName,
                                                         ApplicationContext senderApplicationContext,
-                                                        BeanDefinitionRegistry receiverBeanRegistry,
+                                                        ConfigurableListableBeanFactory receiverBeanRegistry,
                                                         Map<String, BeanDefinition> beansMap) {
     beansMap.forEach((beanName, senderBeanDefinition) -> {
       Class<Object> beanClassName = getClass(senderBeanDefinition.getBeanClassName());
       Class beanClassNameInterface = beanNameToComponentKey(senderBeanDefinition.getBeanClassName());
       if (beanClassName != null
+          && portalContainer.getComponentAdapter(senderBeanDefinition.getBeanClassName()) == null
           && !receiverBeanRegistry.containsBeanDefinition(beanName)
           && !receiverBeanRegistry.containsBeanDefinition(senderBeanDefinition.getBeanClassName())
           && !receiverBeanRegistry.containsBeanDefinition(beanClassNameInterface.getTypeName())) {
@@ -272,15 +275,28 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
                   beanClassNameInterface,
                   senderServletContextName,
                   receiverServletContextName);
-        RootBeanDefinition receiverBeanDefinition = createBeanDefinition(beanName,
-                                                                         beanClassNameInterface,
-                                                                         senderBeanDefinition,
-                                                                         portalContainer,
-                                                                         senderApplicationContext,
-                                                                         receiverServletContextName);
-        receiverBeanRegistry.registerBeanDefinition(beanClassNameInterface.getName(), receiverBeanDefinition);
+        RootBeanDefinition receiverBeanDefinition = createProxyBeanDefinition(beanClassNameInterface,
+                                                                              () -> getBeanInstance(senderApplicationContext,
+                                                                                                    portalContainer,
+                                                                                                    beanName,
+                                                                                                    beanClassNameInterface,
+                                                                                                    receiverServletContextName));
+        ((BeanDefinitionRegistry) receiverBeanRegistry).registerBeanDefinition(beanName, receiverBeanDefinition);
       }
     });
+  }
+
+  private static RootBeanDefinition createProxyBeanDefinition(Class<?> beanClass, Supplier<?> targetSupplier) {
+    if (!beanClass.isInterface() && Modifier.isFinal(beanClass.getModifiers())) {
+      throw new IllegalStateException("Cannot proxy final class: " + beanClass.getName());
+    }
+    RootBeanDefinition bd = new RootBeanDefinition(SpringBeanProxyFactoryBean.class);
+    bd.getPropertyValues().add("exposedType", beanClass);
+    bd.getPropertyValues().add("targetSupplier", targetSupplier);
+    bd.setSynthetic(true);
+    bd.setLazyInit(true);
+    bd.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+    return bd;
   }
 
   private static boolean isIgnoreKernelComponent(PortalContainer portalContainer,
@@ -296,38 +312,19 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
            || GenericDAO.class.isAssignableFrom(componentImplementation);
   }
 
-  private static <T> RootBeanDefinition createBeanDefinition(Class<T> keyClass, PortalContainer portalContainer) {
+  private static <T> RootBeanDefinition createBeanDefinition(Class<T> keyClass,
+                                                             PortalContainer portalContainer) {
     RootBeanDefinition beanDefinition = new RootBeanDefinition(keyClass,
                                                                () -> getComponentInstance(portalContainer, keyClass));
-    beanDefinition.setLazyInit(true);
     beanDefinition.setDependencyCheck(AbstractBeanDefinition.DEPENDENCY_CHECK_NONE);
+    beanDefinition.setScope(ConfigurableBeanFactory.SCOPE_SINGLETON);
+    beanDefinition.setAutowireCandidate(true);
+    beanDefinition.setSynthetic(true);
+    beanDefinition.setLazyInit(true);
     return beanDefinition;
   }
 
-  private static RootBeanDefinition createBeanDefinition(String beanName,
-                                                         Class<Object> beanClassName,
-                                                         BeanDefinition originatingBeanDefinition,
-                                                         PortalContainer portalContainer,
-                                                         ApplicationContext senderApplicationContext,
-                                                         String receiverServletContextName) {
-    RootBeanDefinition receiverBeanDefinition = new RootBeanDefinition(beanClassName,
-                                                                       () -> getBeanInstance(senderApplicationContext,
-                                                                                             portalContainer,
-                                                                                             beanName,
-                                                                                             beanClassName,
-                                                                                             receiverServletContextName));
-    receiverBeanDefinition.setLazyInit(true);
-    receiverBeanDefinition.setAutowireCandidate(true);
-    receiverBeanDefinition.setSynthetic(true);
-    receiverBeanDefinition.setAutowireMode(AutowireCapableBeanFactory.AUTOWIRE_NO);
-    receiverBeanDefinition.setScope(ConfigurableBeanFactory.SCOPE_SINGLETON);
-    receiverBeanDefinition.setDependencyCheck(AbstractBeanDefinition.DEPENDENCY_CHECK_NONE);
-    receiverBeanDefinition.setBeanClass(beanClassName);
-    receiverBeanDefinition.setOriginatingBeanDefinition(originatingBeanDefinition);
-    return receiverBeanDefinition;
-  }
-
-  private static Map<String, BeanDefinition> getEligibleBeans(BeanDefinitionRegistry beanRegistry) {
+  private static Map<String, BeanDefinition> getEligibleBeans(ConfigurableListableBeanFactory beanRegistry) {
     String[] beanNames = beanRegistry.getBeanDefinitionNames();
     return Stream.of(beanNames)
                  .map(beanName -> {
@@ -426,12 +423,11 @@ public class KernelContainerLifecyclePlugin extends BaseContainerLifecyclePlugin
                                         Class<Object> beanClassName,
                                         String contextName) {
     boolean beanExistsInKernel = portalContainer.getComponentAdapter(beanClassName) != null;
-    LOG.trace("Retrieve Bean with name '{}' from Kernel Container using class '{}' in detstination to '{}'. Found = {}",
-              beanName,
-              beanClassName,
-              contextName,
-              beanExistsInKernel);
     if (beanExistsInKernel) {
+      LOG.trace("Retrieve Bean with name '{}' from Kernel Container using class '{}' in detstination to '{}'",
+                beanName,
+                beanClassName,
+                contextName);
       return portalContainer.getComponentInstanceOfType(beanClassName);
     } else {
       return getBeanInstance(applicationContext, beanName, contextName);

--- a/component/common/src/main/java/io/meeds/spring/kernel/PortalApplicationContext.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/PortalApplicationContext.java
@@ -22,11 +22,9 @@ import static io.meeds.spring.kernel.KernelContainerLifecyclePlugin.addSpringCon
 
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext;
 
@@ -64,12 +62,12 @@ public class PortalApplicationContext extends AnnotationConfigServletWebServerAp
     if (async) {
       addSpringContext(servletContext.getServletContextName(),
                        this,
-                       (BeanDefinitionRegistry) beanFactory,
+                       beanFactory,
                        () -> finishSpringContextStartupAsync(beanFactory));
     } else {
       addSpringContext(servletContext.getServletContextName(),
                        this,
-                       (BeanDefinitionRegistry) beanFactory,
+                       beanFactory,
                        () -> finishSpringContextStartup(beanFactory));
     }
   }
@@ -110,9 +108,8 @@ public class PortalApplicationContext extends AnnotationConfigServletWebServerAp
                servletContext.getServletContextName(),
                System.currentTimeMillis() - start);
     } catch (Exception e) {
-      throw new IllegalStateException(String.format("Error While finishing Beans Initialization in context '%s' with Bean names [%s] (May be related to issue Meeds-io/meeds#2469)",
-                                                    servletContext.getServletContextName(),
-                                                    StringUtils.join(beanFactory.getBeanDefinitionNames(), " , ")),
+      throw new IllegalStateException(String.format("Error While finishing Beans Initialization in context '%s'",
+                                                    servletContext.getServletContextName()),
                                       e);
     }
   }

--- a/component/common/src/main/java/io/meeds/spring/kernel/model/SpringBeanProxyFactoryBean.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/model/SpringBeanProxyFactoryBean.java
@@ -1,0 +1,92 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.spring.kernel.model;
+
+import java.util.function.Supplier;
+
+import org.springframework.aop.TargetSource;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.factory.FactoryBean;
+
+import lombok.Setter;
+
+/**
+ * Used to inject Beans from a Spring content to another by avoiding
+ * `AutowiredAnnotationBeanPostProcessor` which will attempt to resolve
+ * `@Autowired` Bean dependencies again. See Meeds-io/meeds#2469
+ */
+public class SpringBeanProxyFactoryBean<T> implements FactoryBean<T> {
+
+  @Setter
+  private Class<T>              exposedType;
+
+  @Setter
+  private Supplier<? extends T> targetSupplier;
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public T getObject() {
+    ProxyFactory proxyFactory = new ProxyFactory();
+    boolean isInterface = exposedType.isInterface();
+    proxyFactory.setProxyTargetClass(!isInterface);
+    if (isInterface) {
+      proxyFactory.setInterfaces(exposedType);
+    } else {
+      proxyFactory.setTargetClass(exposedType);
+    }
+    proxyFactory.setTargetSource(new TargetSource() {
+      private T target;
+
+      @Override
+      public Class<?> getTargetClass() {
+        return exposedType;
+      }
+
+      @Override
+      public boolean isStatic() {
+        return false;
+      }
+
+      @Override
+      public T getTarget() {
+        T local = target;
+        if (local == null) {
+          synchronized (this) {
+            local = target;
+            if (local == null) {
+              local = targetSupplier.get();
+              if (local == null) {
+                throw new IllegalStateException("No shared bean found for " + exposedType.getName());
+              }
+              target = local;
+            }
+          }
+        }
+        return local;
+      }
+    });
+    return (T) proxyFactory.getProxy();
+  }
+
+  @Override
+  public Class<?> getObjectType() {
+    return exposedType;
+  }
+
+}

--- a/component/common/src/test/java/io/meeds/spring/kernel/test/SpringBeanFactoryInterceptor.java
+++ b/component/common/src/test/java/io/meeds/spring/kernel/test/SpringBeanFactoryInterceptor.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
@@ -49,7 +48,7 @@ public class SpringBeanFactoryInterceptor implements BeanFactoryPostProcessor, A
     LOG.info("Integrating Spring Context with Container. Application name = '{}' using Kernel configuration class '{}'",
              applicationContext.getApplicationName(),
              getTestClass());
-    addSpringContext("test", applicationContext, (BeanDefinitionRegistry) beanFactory, null);
+    addSpringContext("test", applicationContext, beanFactory, null);
     bootContainer(getTestClass());
   }
 


### PR DESCRIPTION
Prior to this change, the Spring Shared Service Beans weren't able to be injected to other Spring Contexts when it depends on Components (annotated with `@Component`). This change will allow to inject Beans annotated by `@Service` which has dependencies injected through `@Autowired` annotation which are annotated with `@Component` only. It has been made possible by using Spring AOP Proxy Factory rather than injecting the bean instance in order to avoid the bean to be re-processed using `AutowiredAnnotationBeanPostProcessor`.