### PR TITLE
fix: Allow to authenticate a null Spring Authentication Object

### DIFF
--- a/component/web/security/src/main/java/io/meeds/spring/web/security/PortalAuthenticationManager.java
+++ b/component/web/security/src/main/java/io/meeds/spring/web/security/PortalAuthenticationManager.java
@@ -71,6 +71,7 @@ public class PortalAuthenticationManager implements AuthenticationProvider {
     try {
       Identity identity = getCurrentIdentity(request);
       if (isAnonymousUser(identity)
+          && authentication != null
           && authentication.getPrincipal() instanceof String username) {
         identity = getCurrentIdentity(request, username);
       }


### PR DESCRIPTION
This change will allow considering a null authentication as an anonymous user in Spring Portal Authentication Provider.