### PR TITLE
feat: Avoid throwing Exception in Tests with Mocked Group Handler - EXO-86389

### DIFF
--- a/component/identity/src/test/java/org/exoplatform/services/organization/mock/InMemoryGroupHandler.java
+++ b/component/identity/src/test/java/org/exoplatform/services/organization/mock/InMemoryGroupHandler.java
@@ -246,6 +246,11 @@ public class InMemoryGroupHandler implements GroupHandler {
                                      .toList();
   }
 
+  @Override
+  public void clearGroupCache(String groupId) {
+    // Nothing to do
+  }
+
   private void preSave(Group group, boolean isNew) {
     for (GroupEventListener listener : groupListeners) {
       try {


### PR DESCRIPTION
Prior to this change, the `InMemoryGroupHandler` was throwing an exception when a service calls `clearGroupCache` method. This change ensure to override the default Interface behavior by adding an empty method for Test scope.