### PR TITLE
fix: property exo.ldap.groups.attributes.custom.names have not effect- MEED-10405 - meeds-io/meeds#4216

### DIFF
--- a/component/identity/src/main/java/org/picketlink/idm/impl/configuration/ExoIdentityStoreConfigurationContext.java
+++ b/component/identity/src/main/java/org/picketlink/idm/impl/configuration/ExoIdentityStoreConfigurationContext.java
@@ -101,7 +101,7 @@ public class ExoIdentityStoreConfigurationContext implements IdentityStoreConfig
     // Add custom attributes
     String customNamesPropertyName = LDAP_USERS_ATTRIBUTES_NAMES_PROP;
     String attributesPropertyPrefix = LDAP_USERS_ATTRIBUTES_PROPS_PREFIX;
-    if("GROUP".equals(supportedIdentityType.getName())) {
+    if("GROUP".equals(supportedIdentityType.getName()) || "LDAP_MAPPED_GROUP".equals(supportedIdentityType.getName())) {
       customNamesPropertyName = LDAP_GROUPS_ATTRIBUTES_NAMES_PROP;
       attributesPropertyPrefix = LDAP_GROUPS_ATTRIBUTES_PROPS_PREFIX;
     }


### PR DESCRIPTION
Before this fix, the property is not applied for IdentityObject type LDAP_MAPPED_GROUP, but only for type GROUP This commit ensure to apply it to ldap groups

Resolves meeds-io/meeds#4216

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
