### PR TITLE
feat: Unify Quartz Scheduler Service in Kernel as Infrastructure Layer Service

### DIFF
--- a/component/common/src/main/java/io/meeds/spring/kernel/PortalApplicationContextInitializer.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/PortalApplicationContextInitializer.java
@@ -44,6 +44,7 @@ public abstract class PortalApplicationContextInitializer extends SpringBootServ
     // Used to disable LogBack initialization in WebApp context after having
     // initialized it already in Meeds Server globally
     System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+    System.setProperty("spring.quartz.auto-startup", "false");
 
     this.servletContext = servletContext;
     this.servletContext.setInitParameter("spring.profiles.active", StringUtils.join(ExoContainer.getProfiles(), ","));

--- a/component/common/src/main/java/io/meeds/spring/kernel/QuartzConfiguration.java
+++ b/component/common/src/main/java/io/meeds/spring/kernel/QuartzConfiguration.java
@@ -21,6 +21,8 @@ package io.meeds.spring.kernel;
 import org.quartz.Scheduler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 
 import org.exoplatform.services.scheduler.impl.QuartzSheduler;
 
@@ -32,6 +34,33 @@ import org.exoplatform.services.scheduler.impl.QuartzSheduler;
 public class QuartzConfiguration {
 
   @Bean
+  @Primary
+  public SchedulerFactoryBean quartzSchedulerFactoryBean(QuartzSheduler quartzSheduler) {
+    return new SchedulerFactoryBean() {
+      @Override
+      public Scheduler getScheduler() {
+        return quartzSheduler.getQuartzSheduler();
+      }
+
+      @Override
+      public void afterPropertiesSet() {
+        // no new Quartz scheduler creation
+      }
+
+      @Override
+      public void start() {
+        // Kernel owns startup
+      }
+
+      @Override
+      public void destroy() {
+        // Kernel owns shutdown
+      }
+    };
+  }
+
+  @Bean
+  @Primary
   public Scheduler scheduler(QuartzSheduler quartzSheduler) {
     return quartzSheduler.getQuartzSheduler();
   }


### PR DESCRIPTION
Prior to this change, the Quartz Scheduler was added by Spring Context multiplying the number of threads created. This change will integrate the Kernel Quartz Scheduler Service into Spring Based contexts in order to centralize the Job Scheduling and associated resources.