### PR TITLE
fix: Add possibility to configure user as group member in ldap using user attribute - MEED-10412 - meeds-io/meeds#4219

### DIFF
--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-ldap-config.xml
@@ -216,6 +216,14 @@
                 <value>false</value>
               </option>
               <option>
+                <name>childMembershipAttributeName</name>
+                <value>${exo.ldap.users.childMembershipAttributeName:}</value>
+              </option>
+              <option>
+                <name>childMembershipAttributeDN</name>
+                <value>${exo.ldap.users.childMembershipAttributeDN:}</value>
+              </option>
+              <option>
                 <name>createEntryAttributeValues</name>
                 <value>objectClass=top</value>
                 <value>objectClass=inetOrgPerson</value>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/picketlink-idm/picketlink-idm-msad-config.xml
@@ -236,6 +236,14 @@
                 <value>false</value>
               </option>
               <option>
+                <name>childMembershipAttributeName</name>
+                <value>${exo.ldap.users.childMembershipAttributeName:}</value>
+              </option>
+              <option>
+                <name>childMembershipAttributeDN</name>
+                <value>${exo.ldap.users.childMembershipAttributeDN:}</value>
+              </option>
+              <option>
                 <name>createEntryAttributeValues</name>
                 <value>objectClass=top</value>
                 <value>objectClass=inetOrgPerson</value>


### PR DESCRIPTION
Before this fix, it was not possible to configure a user as member of a group in LDAP, using a childAttribute, as the property not exists. The code to do it exists, and is fired via a non existing property

This commit add the property in configuration file in order to be able to use this feature.

Resolves meeds-io/meeds#4219

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
