### PR TITLE
fix: Fix space template creation with long description - MEED-10447 - meeds-io/meeds#4251

### DIFF
--- a/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
+++ b/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
@@ -450,4 +450,7 @@
     </sql>
   </changeSet>
 
+  <changeSet author="idm" id="1.0.0-22" dbms="mysql">
+    <modifyDataType tableName="jbid_io_attr_text_values" columnName="ATTR_VALUE" newDataType="CLOB" />
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION

Prior to this change, creating a space template with a description longer than 256 characters caused an exception, and nothing was displayed in the UI to show creation error. In fact, the ATTR_VALUE column in the jbid_io_attr_text_values table is used to store various data, including space template information. This column was previously defined as VARCHAR(255), which is insufficient for use cases such as space template descriptions that may exceed this limit. With this change, the column type is updated to CLOB in order to support longer text values and prevent errors during storage.

Resolves meeds-io/meeds#4251