### PR TITLE
fix: Use Coherent Data Type Cross RDBMS providers - EXO-87220

### DIFF
--- a/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
+++ b/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
@@ -450,7 +450,11 @@
     </sql>
   </changeSet>
 
-  <changeSet author="idm" id="1.0.0-22" dbms="mysql">
-    <modifyDataType tableName="jbid_io_attr_text_values" columnName="ATTR_VALUE" newDataType="CLOB" />
+  <changeSet author="idm" id="1.0.0-exo-87220-01">
+    <modifyDataType tableName="jbid_io_attr_text_values" columnName="ATTR_VALUE" newDataType="LONGTEXT" />
+    <modifySql dbms="mysql">
+      <replace replace="LONGTEXT" with="longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci" />
+    </modifySql>
   </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this change, only MySQL has a big data allowed in `ATTR_VALUE` in IDM '`jbid_io_attr_text_values`' Table. This change makes sure to use a consistant Data Type in this column independently from used RDBMS. In addition, this will allow to use EMOJIs in new Data Type using the '`modifySql`' which will specify the CHARACTER SET to use in MySQL.