### PR TITLE
feat: Enhance Organization API to allow undecorate a decorated IDM Entity bfore persisting - EXO-87220

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
@@ -996,6 +996,9 @@ public class GroupDAOImpl extends AbstractDAOImpl implements GroupHandler {
   }
 
   private org.picketlink.idm.api.Group persistGroup(Group exoGroup) throws Exception {
+    for (GroupDecoratorPlugin decoratorPlugin : decoratorPlugins) {
+      exoGroup = decoratorPlugin.undecorate(exoGroup);
+    }
 
     org.picketlink.idm.api.Group jbidGroup = null;
 

--- a/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
+++ b/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
@@ -450,7 +450,11 @@
     </sql>
   </changeSet>
 
-  <changeSet author="idm" id="1.0.0-22" dbms="mysql">
-    <modifyDataType tableName="jbid_io_attr_text_values" columnName="ATTR_VALUE" newDataType="CLOB" />
+  <changeSet author="idm" id="1.0.0-meed-10447-01">
+    <modifyDataType tableName="jbid_io_attr_text_values" columnName="ATTR_VALUE" newDataType="VARCHAR(2048)" />
+    <modifySql dbms="mysql">
+      <replace replace="VARCHAR(2048)" with="VARCHAR(2048) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci" />
+    </modifySql>
   </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
This change will enhance API to allow undecorate a decorated Group or User before persisting it.
In addition, prior to this change, only MySQL has a big data allowed in `ATTR_VALUE` in IDM '`jbid_io_attr_text_values`' Table. This change makes sure to use a consistant Data Type in this column independently from used RDBMS. In
addition, this will allow to use EMOJIs in new Data Type using the '`modifySql`' which will specify the CHARACTER SET to use in MySQL.