### PR TITLE
fix: allow to not delete memberships during synchro if the information is not present in LDAP - EXO-87414

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/externalstore/PicketLinkIDMExternalStoreService.java
@@ -222,7 +222,7 @@ public class PicketLinkIDMExternalStoreService implements IDMExternalStoreServic
 
         if (isUpdateInformationOnLogin()) {
           try {
-            getExternalStoreImportService().importEntityToInternalStore(IDMEntityType.USER_MEMBERSHIPS, username, true, false);
+            getExternalStoreImportService().importEntityToInternalStore(IDMEntityType.USER_MEMBERSHIPS, username, true, getExternalStoreImportService().isUpdateDeletedUserMemberships());
           } catch (Exception e) {
             LOG.error("Error while importing user memberships '" + username + "' from external store", e);
           }

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-externalstore-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-externalstore-configuration.xml
@@ -66,6 +66,16 @@
 				<description>If TRUE delete users if they are not present in external store, otherwise disable them (Default : delete users)</description>
 				<value>${exo.idm.externalStore.entries.missing.delete:true}</value>
 			</value-param>
+			<value-param>
+				<name>exo.idm.externalStore.user.memberships.update.delete</name>
+				<description>If TRUE : removed memberships in external user object will be removed in exo</description>
+				<value>${exo.idm.externalStore.user.memberships.update.delete:true}</value>
+			</value-param>
+			<value-param>
+				<name>exo.idm.externalStore.group.memberships.update.delete</name>
+				<description>If TRUE : removed memberships in external group object will be removed in exo</description>
+				<value>${exo.idm.externalStore.group.memberships.update.delete:true}</value>
+			</value-param>
 		</init-params>
 	</component>
 


### PR DESCRIPTION
Sometimes in LDAP, the user membership are not store in 2-directions (group to user with member attribute AND user to group with memberOf attribute) but only in one direction (group to user OR user to group). In this case, when synchronizing it, membership can be removed in exo : If it is stored in group-to-user direction, when you synchronize the user, membership are not seen and then removed in exo. If it is stored in user-to-group direction, when you synchronize the group, membership are not seen and then removed in exo.

This commit add 2 properties to be able to not delete the membership is not present in user or group object exo.idm.externalStore.user.memberships.update.delete exo.idm.externalStore.group.memberships.update.delete

In addition, the commit ensure to correctly use this attribute to ignore membership which are not present it the attribute is true

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
