### PR TITLE
fix: MySQL IDM NAME Columns Collation - EXO-87644

### DIFF
--- a/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
+++ b/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
@@ -457,4 +457,22 @@
     </modifySql>
   </changeSet>
 
+  <changeSet author="idm" id="1.0.0-exo-87644-01" dbms="mysql">
+    <sql>
+      ALTER TABLE jbid_realm MODIFY COLUMN NAME VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    </sql>
+  </changeSet>
+
+  <changeSet author="idm" id="1.0.0-exo-87644-02" dbms="mysql">
+    <sql>
+      ALTER TABLE jbid_io_type MODIFY COLUMN NAME VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    </sql>
+  </changeSet>
+
+  <changeSet author="idm" id="1.0.0-exo-87644-03" dbms="mysql">
+    <sql>
+      ALTER TABLE jbid_io MODIFY COLUMN NAME VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this change, the collation of `jbid_realm.NAME`, `jbid_io_type.NAME` and `jbid_io.NAME` isn't using the `UTF-8`. This change ensures to use the right collation to avoid the error `Illegal mix of collations (latin1_general_cs,IMPLICIT) and (utf8mb4_0900_ai_ci,COERCIBLE) for operation '='`.