### PR TITLE
fix: MySQL IDM NAME Columns Collation - EXO-87644

### DIFF
--- a/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
+++ b/component/identity/src/main/resources/db/changelog/idm.db.changelog-1.0.0.xml
@@ -457,21 +457,21 @@
     </modifySql>
   </changeSet>
 
-  <changeSet author="idm" id="1.0.0-exo-87644-01" dbms="mysql">
+  <changeSet author="idm" id="1.0.0-exo-87644-04" dbms="mysql">
     <sql>
-      ALTER TABLE jbid_realm MODIFY COLUMN NAME VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+      ALTER TABLE jbid_realm MODIFY COLUMN NAME VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
     </sql>
   </changeSet>
 
-  <changeSet author="idm" id="1.0.0-exo-87644-02" dbms="mysql">
+  <changeSet author="idm" id="1.0.0-exo-87644-05" dbms="mysql">
     <sql>
-      ALTER TABLE jbid_io_type MODIFY COLUMN NAME VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+      ALTER TABLE jbid_io_type MODIFY COLUMN NAME VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
     </sql>
   </changeSet>
 
-  <changeSet author="idm" id="1.0.0-exo-87644-03" dbms="mysql">
+  <changeSet author="idm" id="1.0.0-exo-87644-06" dbms="mysql">
     <sql>
-      ALTER TABLE jbid_io MODIFY COLUMN NAME VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+      ALTER TABLE jbid_io MODIFY COLUMN NAME VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
     </sql>
   </changeSet>
 


### PR DESCRIPTION
Prior to this change, the collation of `jbid_realm.NAME`, `jbid_io_type.NAME` and `jbid_io.NAME` is using the `UTF-8` in Case InSensitive which was added recently to use the right collation to avoid the error `Illegal mix of collations (latin1_general_cs,IMPLICIT) and (utf8mb4_0900_ai_ci,COERCIBLE) for operation '='`. This change Makes the collation UTF-8 but Case Sensitive to avoid a unicity constraint exception.