### PR TITLE
fix: validate uploaded SVG files before exposing them - EXO-86346

### DIFF
--- a/component/common/src/main/java/org/exoplatform/upload/SvgUploadValidator.java
+++ b/component/common/src/main/java/org/exoplatform/upload/SvgUploadValidator.java
@@ -1,0 +1,275 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.upload;
+
+import java.io.BufferedInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+import java.util.zip.GZIPInputStream;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.apache.commons.fileupload2.core.FileUploadException;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Rejects unsafe SVG uploads without modifying the uploaded file.
+ * <p>
+ * This validator is intentionally SVG-only. Non-SVG files are not opened or
+ * parsed by this class.
+ */
+public class SvgUploadValidator implements UploadFileValidator {
+
+  public static final String INFECTED_SVG_MESSAGE = "Infected file detected. Uploading is forbidden";
+
+  private static final long DEFAULT_MAX_SVG_VALIDATION_SIZE = 10L * 1024L * 1024L;
+
+  private final long        maxSvgValidationSize;
+
+  public SvgUploadValidator() {
+    this(DEFAULT_MAX_SVG_VALIDATION_SIZE);
+  }
+
+  public SvgUploadValidator(long maxSvgValidationSize) {
+    this.maxSvgValidationSize = maxSvgValidationSize;
+  }
+
+  @Override
+  public boolean supports(String fileName, String mimeType) {
+    return isSvgMimeType(mimeType) || isSvgFileName(fileName) || isSvgzFileName(fileName);
+  }
+
+  @Override
+  public void validate(String fileName, String mimeType, InputStream inputStream) throws FileUploadException {
+    if (inputStream == null) {
+      throw new FileUploadException("Unable to validate SVG file");
+    }
+
+    try {
+      validateSvg(openSvgValidationInputStream(fileName, inputStream));
+    } catch (UnsafeSvgException e) {
+      throw new FileUploadException(INFECTED_SVG_MESSAGE, e);
+    } catch (SvgTooLargeException e) {
+      throw new FileUploadException("SVG file is too large to be safely validated", e);
+    } catch (SAXException e) {
+      throw new FileUploadException("Invalid SVG file", e);
+    } catch (ParserConfigurationException | IOException e) {
+      throw new FileUploadException("Unable to validate SVG file", e);
+    }
+  }
+
+  private InputStream openSvgValidationInputStream(String fileName, InputStream inputStream) throws IOException {
+    InputStream nonClosingInputStream = new NonClosingInputStream(inputStream);
+    InputStream bufferedInputStream = new BufferedInputStream(nonClosingInputStream);
+    InputStream svgInputStream = isSvgzFileName(fileName) ? new GZIPInputStream(bufferedInputStream) : bufferedInputStream;
+    return new MaxBytesInputStream(svgInputStream, maxSvgValidationSize);
+  }
+
+  private void validateSvg(InputStream inputStream) throws ParserConfigurationException, SAXException, IOException {
+    SAXParserFactory factory = SAXParserFactory.newInstance(); // NOSONAR
+    factory.setNamespaceAware(true);
+    factory.setXIncludeAware(false);
+    configureSecureFeature(factory, "http://apache.org/xml/features/disallow-doctype-decl", true);
+    configureSecureFeature(factory, "http://xml.org/sax/features/external-general-entities", false);
+    configureSecureFeature(factory, "http://xml.org/sax/features/external-parameter-entities", false);
+    configureSecureFeature(factory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+    SAXParser saxParser = factory.newSAXParser();
+    saxParser.parse(new InputSource(inputStream), new SvgSafetyHandler());
+  }
+
+  private void configureSecureFeature(SAXParserFactory factory, String feature, boolean value)
+      throws ParserConfigurationException, SAXException {
+    factory.setFeature(feature, value);
+  }
+
+  private boolean isSvgMimeType(String mimeType) {
+    return mimeType != null && "image/svg+xml".equalsIgnoreCase(trimMimeTypeParameters(mimeType));
+  }
+
+  private String trimMimeTypeParameters(String mimeType) {
+    int separatorIndex = mimeType.indexOf(';');
+    if (separatorIndex >= 0) {
+      return mimeType.substring(0, separatorIndex).trim();
+    }
+    return mimeType.trim();
+  }
+
+  private boolean isSvgFileName(String fileName) {
+    return fileName != null && fileName.toLowerCase(Locale.ROOT).endsWith(".svg");
+  }
+
+  private boolean isSvgzFileName(String fileName) {
+    return fileName != null && fileName.toLowerCase(Locale.ROOT).endsWith(".svgz");
+  }
+
+  /**
+   * Prevents validators or XML parsers from closing the caller-owned upload
+   * stream.
+   */
+  private static class NonClosingInputStream extends FilterInputStream { // NOSONAR
+
+    NonClosingInputStream(InputStream inputStream) {
+      super(inputStream);
+    }
+
+    @Override
+    public void close() throws IOException {
+      // The caller owns the original upload stream.
+    }
+  }
+
+  /**
+   * Bounds SVG validation work without requiring the whole file to be loaded in
+   * memory first.
+   */
+  private static class MaxBytesInputStream extends FilterInputStream {
+
+    private final long maxBytes;
+
+    private long       bytesRead;
+
+    MaxBytesInputStream(InputStream inputStream, long maxBytes) {
+      super(inputStream);
+      this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+      int read = super.read();
+      if (read >= 0) {
+        incrementBytesRead(1);
+      }
+      return read;
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length) throws IOException {
+      int read = super.read(bytes, offset, length);
+      if (read > 0) {
+        incrementBytesRead(read);
+      }
+      return read;
+    }
+
+    private void incrementBytesRead(long increment) throws IOException {
+      bytesRead += increment;
+      if (maxBytes > 0 && bytesRead > maxBytes) {
+        throw new SvgTooLargeException();
+      }
+    }
+  }
+
+  private static class SvgSafetyHandler extends DefaultHandler {
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+      String tagName = normalizeXmlName(localName, qName);
+      if (isDangerousSvgTag(tagName)) {
+        throw new UnsafeSvgException("Unsafe SVG tag detected: " + tagName);
+      }
+
+      for (int i = 0; i < attributes.getLength(); i++) {
+        String attributeName = normalizeXmlName(attributes.getLocalName(i), attributes.getQName(i));
+        String attributeValue = attributes.getValue(i);
+        if (isDangerousSvgAttribute(attributeName, attributeValue)) {
+          throw new UnsafeSvgException("Unsafe SVG attribute detected: " + attributeName);
+        }
+      }
+    }
+
+    @Override
+    public void processingInstruction(String target, String data) throws SAXException {
+      if (target != null && "xml-stylesheet".equalsIgnoreCase(target)) {
+        throw new UnsafeSvgException("External stylesheet processing instruction detected");
+      }
+    }
+
+    private static String normalizeXmlName(String localName, String qName) {
+      String name = localName == null || localName.isEmpty() ? qName : localName;
+      if (name == null) {
+        return "";
+      }
+      int namespaceSeparatorIndex = name.indexOf(':');
+      if (namespaceSeparatorIndex >= 0 && namespaceSeparatorIndex + 1 < name.length()) {
+        name = name.substring(namespaceSeparatorIndex + 1);
+      }
+      return name.toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean isDangerousSvgTag(String tagName) {
+      return "script".equals(tagName)
+          || "foreignobject".equals(tagName)
+          || "iframe".equals(tagName)
+          || "object".equals(tagName)
+          || "embed".equals(tagName)
+          || "applet".equals(tagName);
+    }
+
+    private static boolean isDangerousSvgAttribute(String attributeName, String attributeValue) {
+      if (attributeName == null || attributeName.isEmpty()) {
+        return false;
+      }
+      if (attributeName.startsWith("on")) {
+        return true;
+      }
+      if (attributeValue == null) {
+        return false;
+      }
+
+      String normalizedValue = removeAsciiWhitespaces(attributeValue).toLowerCase(Locale.ROOT);
+      return normalizedValue.startsWith("javascript:")
+          || normalizedValue.contains("javascript:")
+          || normalizedValue.startsWith("data:text/html")
+          || normalizedValue.contains("data:text/html");
+    }
+
+    private static String removeAsciiWhitespaces(String value) {
+      StringBuilder result = new StringBuilder(value.length());
+      for (int i = 0; i < value.length(); i++) {
+        char c = value.charAt(i);
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r' && c != '\f') {
+          result.append(c);
+        }
+      }
+      return result.toString().trim();
+    }
+  }
+
+  private static class UnsafeSvgException extends SAXException {
+
+    private static final long serialVersionUID = 1L;
+
+    UnsafeSvgException(String message) {
+      super(message);
+    }
+  }
+
+  private static class SvgTooLargeException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+  }
+}

--- a/component/common/src/main/java/org/exoplatform/upload/UploadFileValidator.java
+++ b/component/common/src/main/java/org/exoplatform/upload/UploadFileValidator.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.upload;
+
+import java.io.InputStream;
+
+import org.apache.commons.fileupload2.core.FileUploadException;
+
+/**
+ * Validates uploaded files without altering their content.
+ * <p>
+ * Implementations must be selective in {@link #supports(String, String)} so the
+ * centralized upload service does not inspect large unrelated files such as
+ * Office documents, PDFs, archives, videos, etc.
+ */
+public interface UploadFileValidator {
+
+  /**
+   * @param fileName uploaded file name
+   * @param mimeType detected or enriched MIME type
+   * @return true only when this validator must inspect the uploaded file
+   */
+  boolean supports(String fileName, String mimeType);
+
+  /**
+   * Validates the uploaded file in read-only mode.
+   * <p>
+   * The provided {@link InputStream} is owned by the caller. Implementations must
+   * read from it but must not close it.
+   * <p>
+   * The stream is expected to be positioned at the beginning of the uploaded
+   * content. When several validators support the same file, the caller should
+   * provide a fresh stream to each validator.
+   *
+   * @param fileName uploaded file name
+   * @param mimeType detected or enriched MIME type
+   * @param inputStream upload file {@link InputStream}
+   * @throws FileUploadException when the upload must be rejected
+   */
+  void validate(String fileName, String mimeType, InputStream inputStream) throws FileUploadException;
+}

--- a/component/common/src/main/java/org/exoplatform/upload/UploadService.java
+++ b/component/common/src/main/java/org/exoplatform/upload/UploadService.java
@@ -19,6 +19,7 @@
 package org.exoplatform.upload;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,6 +40,7 @@ import org.apache.commons.fileupload2.core.FileUploadException;
 import org.apache.commons.fileupload2.core.ProgressListener;
 import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletDiskFileUpload;
 
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.PortalContainerInfo;
 import org.exoplatform.services.log.ExoLogger;
@@ -64,6 +66,8 @@ public class UploadService {
   private static final Pattern        UPLOAD_ID_PATTERN      = Pattern.compile("[^(\\./\\\\)]*");
 
   private List<MimeTypeUploadPlugin>  plugins;
+
+  private List<UploadFileValidator>   uploadFileValidators;
 
   private Map<String, UploadResource> uploadResources        = new LinkedHashMap<>();
 
@@ -138,15 +142,10 @@ public class UploadService {
     DiskFileItem fileItem = getFileItem(request, upResource);
     upResource.setFileName(fileItem.getName());
     upResource.setMimeType(fileItem.getContentType());
+    applyMimeTypeUploadPlugins(upResource, fileItem.getName());
     if (upResource.getStatus() == UploadResource.UPLOADED_STATUS) {
       writeFile(upResource, fileItem);
-    }
-    if (plugins != null) {
-      for (MimeTypeUploadPlugin plugin : plugins) {
-        String mimeType = plugin.getMimeType(fileItem.getName());
-        if (mimeType != null)
-          upResource.setMimeType(mimeType);
-      }
+      validateUploadedFile(upResource);
     }
   }
 
@@ -184,6 +183,7 @@ public class UploadService {
 
     upResource.setFileName(fileName);
     upResource.setMimeType(headers.get(RequestStreamReader.CONTENT_TYPE));
+    applyMimeTypeUploadPlugins(upResource, fileName);
     upResource.setStoreLocation(uploadLocation_ + "/" + uploadId + "." + fileName);
     upResource.setEstimatedSize(contentLength);
     File fileStore = new File(upResource.getStoreLocation());
@@ -192,16 +192,54 @@ public class UploadService {
     } else {
       throw new IllegalStateException("Wasn't able to create a file with uploadId " + uploadId);
     }
-    FileOutputStream output = new FileOutputStream(fileStore);
-    reader.readBodyData(inputStream, contentType, output);
+    try (FileOutputStream output = new FileOutputStream(fileStore)) {
+      reader.readBodyData(inputStream, contentType, output);
+    }
 
     if (upResource.getStatus() == UploadResource.UPLOADING_STATUS) {
+      validateUploadedFile(upResource);
       upResource.setStatus(UploadResource.UPLOADED_STATUS);
       return;
     }
 
     uploadResources.remove(uploadId);
     fileStore.delete();
+  }
+
+  private void applyMimeTypeUploadPlugins(UploadResource upResource, String fileName) {
+    if (plugins == null) {
+      return;
+    }
+    for (MimeTypeUploadPlugin plugin : plugins) {
+      String mimeType = plugin.getMimeType(fileName);
+      if (mimeType != null)
+        upResource.setMimeType(mimeType);
+    }
+  }
+
+  private void validateUploadedFile(UploadResource upResource) throws FileUploadException {
+    if (getUploadFileValidators().isEmpty()
+        || upResource == null
+        || upResource.getStoreLocation() == null) {
+      return;
+    }
+
+    for (UploadFileValidator uploadFileValidator : getUploadFileValidators()) {
+      if (!uploadFileValidator.supports(upResource.getFileName(), upResource.getMimeType())) {
+        continue;
+      }
+      try (InputStream inputStream = new FileInputStream(upResource.getStoreLocation())) {
+        uploadFileValidator.validate(upResource.getFileName(), upResource.getMimeType(), inputStream);
+      } catch (FileUploadException e) {
+        upResource.setStatus(UploadResource.FAILED_STATUS);
+        removeUploadResource(upResource.getUploadId());
+        throw e;
+      } catch (IOException e) {
+        upResource.setStatus(UploadResource.FAILED_STATUS);
+        removeUploadResource(upResource.getUploadId());
+        throw new FileUploadException("Unable to read uploaded file for validation", e);
+      }
+    }
   }
 
   @SuppressWarnings("unchecked")
@@ -401,6 +439,19 @@ public class UploadService {
         fileItem.getPath().toFile().deleteOnExit();
       }
     }
+  }
+
+  private List<UploadFileValidator> getUploadFileValidators() {
+    if (uploadFileValidators == null) {
+      List<UploadFileValidator> services = ExoContainerContext.getCurrentContainer()
+                                                              .getComponentInstancesOfType(UploadFileValidator.class);
+      if (services == null) {
+        uploadFileValidators = new ArrayList<>();
+      } else {
+        uploadFileValidators = new ArrayList<>(services);
+      }
+    }
+    return uploadFileValidators;
   }
 
   public static class UploadLimit {

--- a/component/common/src/test/java/org/exoplatform/upload/TestUploadService.java
+++ b/component/common/src/test/java/org/exoplatform/upload/TestUploadService.java
@@ -18,8 +18,11 @@
  */
 package org.exoplatform.upload;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.exoplatform.component.test.AbstractKernelTest;
 import org.exoplatform.component.test.ConfigurationUnit;
@@ -144,6 +147,29 @@ public class TestUploadService extends AbstractKernelTest {
             assertEquals("Upload id " + notAllowedUploadId
                     + " is not valid, it cannot be null or contain '.' , '/' or '\\'", e.getMessage());
         }
+    }
+
+    @Test
+    public void testShouldRejectUnsafeSvgUpload() throws Exception {
+        SvgUploadValidator validator = new SvgUploadValidator();
+        String unsafeSvg = "<svg xmlns=\"http://www.w3.org/2000/svg\" onload=\"alert(1)\"><rect width=\"10\" height=\"10\"/></svg>";
+
+        try (InputStream inputStream = new ByteArrayInputStream(unsafeSvg.getBytes(StandardCharsets.UTF_8))) {
+            validator.validate("infected.svg", "image/svg+xml", inputStream);
+            fail("Unsafe SVG upload must be rejected");
+        } catch (FileUploadException e) {
+            assertEquals(SvgUploadValidator.INFECTED_SVG_MESSAGE, e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSvgValidatorShouldNotSupportNonSvgFiles() {
+        SvgUploadValidator validator = new SvgUploadValidator();
+
+        assertFalse(validator.supports("document.xml", "application/xml"));
+        assertFalse(validator.supports("page.html", "text/html"));
+        assertFalse(validator.supports("presentation.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"));
+        assertFalse(validator.supports("spreadsheet.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
     }
 
     private void assertFileCreation(String fileName) {

--- a/component/common/src/test/resources/conf/services/upload-service.xml
+++ b/component/common/src/test/resources/conf/services/upload-service.xml
@@ -33,4 +33,8 @@
     </init-params>
   </component>
 
+  <component>
+    <type>org.exoplatform.upload.SvgUploadValidator</type>
+  </component>
+
 </configuration>

--- a/component/web/controller/src/main/java/org/exoplatform/web/handler/UploadHandler.java
+++ b/component/web/controller/src/main/java/org/exoplatform/web/handler/UploadHandler.java
@@ -21,6 +21,7 @@ package org.exoplatform.web.handler;
 import java.io.Writer;
 import java.net.URLEncoder;
 
+import org.apache.commons.fileupload2.core.FileUploadException;
 import org.apache.commons.lang3.StringUtils;
 import org.gatein.common.text.EntityEncoder;
 
@@ -118,7 +119,19 @@ public class UploadHandler extends WebRequestHandler {
             value.append("\n  }\n}");
             writer.append(value);
         } else if (uploadActionService == UploadServiceAction.UPLOAD) {
+          try {
             service.createUploadResource(req);
+          } catch (FileUploadException e) {
+            if (!res.isCommitted()) {
+              res.resetBuffer();
+              res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+              res.setContentType("text/plain");
+              res.setCharacterEncoding("UTF-8");
+
+              String message = StringUtils.defaultIfBlank(e.getMessage(), "Upload failed");
+              res.getWriter().write(message);
+            }
+          }
         } else if (uploadActionService == UploadServiceAction.DELETE) {
             service.removeUploadResource(uploadIds[0]);
         } else if (uploadActionService == UploadServiceAction.ABORT) {

--- a/web/portal/src/main/webapp/WEB-INF/conf/portal/controller-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/portal/controller-configuration.xml
@@ -49,6 +49,10 @@
   </component>
 
   <component>
+    <type>org.exoplatform.upload.SvgUploadValidator</type>
+  </component>
+
+  <component>
     <type>org.exoplatform.download.DownloadService</type>
     <init-params>
       <value-param>


### PR DESCRIPTION
Add upload file validators to the centralized upload service and reject SVG files containing unsafe active content. The validation is selective and stream-based, so unrelated uploads such as Office documents, PDFs, archives, and videos are not inspected or altered. Return the upload rejection message to the client so the UI can display a clear error.