### PR TITLE
fix: prevent open redirects from login initialURI - EXO-86232

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/login/LoginHandler.java
@@ -19,8 +19,6 @@
 package org.exoplatform.web.login;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -63,6 +61,7 @@ import org.exoplatform.web.application.JspBasedWebHandler;
 import org.exoplatform.web.application.javascript.JavascriptConfigService;
 import org.exoplatform.web.login.recovery.PasswordRecoveryService;
 import org.exoplatform.web.security.AuthenticationRegistry;
+import org.exoplatform.web.security.RedirectUrlValidator;
 import org.exoplatform.web.security.security.AbstractTokenService;
 import org.exoplatform.web.security.security.CookieTokenService;
 import org.exoplatform.web.security.sso.SSOHelper;
@@ -353,28 +352,19 @@ public class LoginHandler extends JspBasedWebHandler {
   }
 
   private String getInitalUri(HttpServletRequest request) {
-    // Obtain initial URI
+    // Obtain and validate initial URI
     String initialURI = request.getParameter("initialURI");
+    String sanitizedInitialURI = RedirectUrlValidator.sanitizeInitialURI(request, initialURI);
 
-    // Otherwise compute one
-    if (initialURI == null || initialURI.length() == 0) {
-      initialURI = request.getContextPath();
-      LOG.debug("No initial URI found, will use default " + initialURI + " instead ");
+    if (StringUtils.isBlank(initialURI)) {
+      LOG.debug("No initial URI found, will use default " + sanitizedInitialURI + " instead ");
+    } else if (StringUtils.equals(initialURI, sanitizedInitialURI)) {
+      LOG.debug("Found initial URI " + sanitizedInitialURI);
     } else {
-      LOG.debug("Found initial URI " + initialURI);
+      LOG.warn("Unsafe initial URI in login link. Redirecting to the portal context path instead.");
     }
 
-    try {
-      URI uri = new URI(initialURI);
-      if ((uri.getHost() != null) && !(uri.getHost().equals(request.getServerName()))) {
-        LOG.warn("Cannot redirect to an URI outside of the current host when using a login redirect. Redirecting to the portal context path instead.");
-        initialURI = request.getContextPath();
-      }
-    } catch (URISyntaxException e) {
-      LOG.warn("Initial URI in login link is malformed. Redirecting to the portal context path instead.");
-      initialURI = request.getContextPath();
-    }
-    return initialURI;
+    return sanitizedInitialURI;
   }
 
   /**

--- a/component/web/security/src/main/java/org/exoplatform/web/security/RedirectUrlValidator.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/security/RedirectUrlValidator.java
@@ -1,0 +1,106 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.web.security;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+
+public final class RedirectUrlValidator {
+
+  private RedirectUrlValidator() {
+  }
+
+  public static String sanitizeInitialURI(HttpServletRequest request, String initialURI) {
+    String fallback = request.getContextPath();
+
+    if (StringUtils.isBlank(initialURI)) {
+      return fallback;
+    }
+
+    String value = initialURI.trim();
+
+    if (containsControlCharacter(value) || containsEncodedControlCharacter(value)) {
+      return fallback;
+    }
+
+    // Browsers may normalize backslashes as slashes while processing redirects.
+    if (value.indexOf('\\') >= 0) {
+      return fallback;
+    }
+
+    // Reject scheme-relative URLs such as //evil.example.
+    if (value.startsWith("//")) {
+      return fallback;
+    }
+
+    // Only local absolute paths are accepted.
+    if (!value.startsWith("/")) {
+      return fallback;
+    }
+
+    // Avoid URL parser differentials based on encoded slashes or backslashes.
+    String lowerValue = value.toLowerCase(Locale.ROOT);
+    if (lowerValue.contains("%2f") || lowerValue.contains("%5c")) {
+      return fallback;
+    }
+
+    try {
+      URI uri = new URI(value);
+
+      // Reject absolute, opaque or host-bearing URIs: http://x, http:x, http:@x, etc.
+      if (uri.isAbsolute() || uri.isOpaque() || uri.getScheme() != null || uri.getHost() != null) {
+        return fallback;
+      }
+
+      String normalizedValue = uri.normalize().toString();
+      String contextPath = request.getContextPath();
+
+      if (StringUtils.isNotBlank(contextPath)
+          && !normalizedValue.equals(contextPath)
+          && !normalizedValue.startsWith(contextPath + "/")) {
+        return fallback;
+      }
+
+      return normalizedValue;
+    } catch (URISyntaxException e) {
+      return fallback;
+    }
+  }
+
+  private static boolean containsControlCharacter(String value) {
+    for (int i = 0; i < value.length(); i++) {
+      if (Character.isISOControl(value.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean containsEncodedControlCharacter(String value) {
+    String lowerValue = value.toLowerCase(Locale.ROOT);
+    return lowerValue.contains("%00")
+        || lowerValue.contains("%0a")
+        || lowerValue.contains("%0d");
+  }
+}

--- a/component/web/security/src/test/java/org/exoplatform/web/login/LoginHandlerInitialUriTest.java
+++ b/component/web/security/src/test/java/org/exoplatform/web/login/LoginHandlerInitialUriTest.java
@@ -1,0 +1,213 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.web.login;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat; // NOSONAR
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.SneakyThrows;
+import sun.misc.Unsafe; // NOSONAR
+
+@RunWith(Parameterized.class)
+public class LoginHandlerInitialUriTest {
+
+  private static final String CONTEXT_PATH = "/portal";          // NOSONAR
+
+  private static final String SERVER_NAME  = "meeds.example.org";
+
+  private final String        initialURI;
+
+  private final String        expectedRedirectURI;
+
+  private LoginHandler        loginHandler;
+
+  public LoginHandlerInitialUriTest(String initialURI, String expectedRedirectURI) {
+    this.initialURI = initialURI;
+    this.expectedRedirectURI = expectedRedirectURI;
+  }
+
+  @Before
+  @SneakyThrows
+  public void setUp() {
+    loginHandler = allocateLoginHandler();
+  }
+
+  @Parameterized.Parameters(name = "{index}: initialURI={0} -> {1}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] { // NOSONAR
+      // --------------------------------------------------------------------
+      // Valid internal redirects
+      // --------------------------------------------------------------------
+      { "/portal", "/portal" }, // NOSONAR
+      { "/portal/", "/portal/" },
+      { "/portal/dw/home", "/portal/dw/home" }, // NOSONAR
+      { "/portal/dw/home?param=value", "/portal/dw/home?param=value" },
+      { "/portal/dw/home#section", "/portal/dw/home#section" },
+      { "/portal/dw/home?param=value#section", "/portal/dw/home?param=value#section" },
+
+      // --------------------------------------------------------------------
+      // Empty / missing values
+      // --------------------------------------------------------------------
+      { null, CONTEXT_PATH },
+      { "", CONTEXT_PATH },
+      { " ", CONTEXT_PATH },
+      { "\t", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // External absolute URLs
+      // --------------------------------------------------------------------
+      { "http://redirect.ywh.at", CONTEXT_PATH },
+      { "https://redirect.ywh.at", CONTEXT_PATH },
+      { "HTTP://redirect.ywh.at", CONTEXT_PATH },
+      { "HTTPS://redirect.ywh.at", CONTEXT_PATH },
+      { "http://meeds.example.org.evil.tld/portal", CONTEXT_PATH },
+      { "https://meeds.example.org.evil.tld/portal", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // Specific reported issue
+      // URI#getHost() may return null, but browser may treat it externally
+      // --------------------------------------------------------------------
+      { "http:@redirect.ywh.at", CONTEXT_PATH },
+      { "https:@redirect.ywh.at", CONTEXT_PATH },
+      { "http:redirect.ywh.at", CONTEXT_PATH },
+      { "https:redirect.ywh.at", CONTEXT_PATH },
+      { "javascript:alert(1)", CONTEXT_PATH },
+      { "data:text/html,evil", CONTEXT_PATH },
+      { "mailto:test@example.org", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // Scheme-relative URLs
+      // --------------------------------------------------------------------
+      { "//redirect.ywh.at", CONTEXT_PATH },
+      { "///redirect.ywh.at", CONTEXT_PATH },
+      { "//meeds.example.org/portal", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // Relative paths not under portal context
+      // --------------------------------------------------------------------
+      { "/", CONTEXT_PATH },
+      { "/dw/home", CONTEXT_PATH },
+      { "/other-context/home", CONTEXT_PATH },
+      { "/portal-other/home", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // Non absolute-path references
+      // --------------------------------------------------------------------
+      { "portal/dw/home", CONTEXT_PATH },
+      { "./portal/dw/home", CONTEXT_PATH },
+      { "../portal/dw/home", CONTEXT_PATH },
+      { "redirect.ywh.at", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // Backslash based browser parsing bypasses
+      // --------------------------------------------------------------------
+      { "\\\\redirect.ywh.at", CONTEXT_PATH },
+      { "/\\redirect.ywh.at", CONTEXT_PATH },
+      { "/portal\\redirect.ywh.at", CONTEXT_PATH },
+      { "/portal/dw\\home", CONTEXT_PATH },
+      { "https:\\\\redirect.ywh.at", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // Encoded slash / backslash bypass attempts
+      // --------------------------------------------------------------------
+      { "%2F%2Fredirect.ywh.at", CONTEXT_PATH },
+      { "%2f%2fredirect.ywh.at", CONTEXT_PATH },
+      { "/portal/%2F%2Fredirect.ywh.at", CONTEXT_PATH },
+      { "/portal/%2f%2fredirect.ywh.at", CONTEXT_PATH },
+      { "/portal/%5Credirect.ywh.at", CONTEXT_PATH },
+      { "/portal/%5credirect.ywh.at", CONTEXT_PATH },
+      { "/portal/dw%2Fhome", CONTEXT_PATH },
+      { "/portal/dw%5Chome", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // Encoded absolute URLs
+      // --------------------------------------------------------------------
+      { "http%3A%2F%2Fredirect.ywh.at", CONTEXT_PATH },
+      { "https%3A%2F%2Fredirect.ywh.at", CONTEXT_PATH },
+      { "http%3a%2f%2fredirect.ywh.at", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // CRLF / header injection attempts
+      // --------------------------------------------------------------------
+      { "/portal/dw/home\r\nLocation: http://redirect.ywh.at", CONTEXT_PATH },
+      { "/portal/dw/home\nLocation: http://redirect.ywh.at", CONTEXT_PATH },
+      { "/portal/dw/home\rLocation: http://redirect.ywh.at", CONTEXT_PATH },
+      { "/portal/dw/home%0d%0aLocation:%20http://redirect.ywh.at", CONTEXT_PATH },
+      { "/portal/dw/home%0D%0ALocation:%20http://redirect.ywh.at", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // Malformed URI values
+      // --------------------------------------------------------------------
+      { "http://[::1", CONTEXT_PATH },
+      { "/portal/dw/home[", CONTEXT_PATH },
+      { "/portal/dw/home]", CONTEXT_PATH },
+      { "/portal/dw/home|test", CONTEXT_PATH },
+
+      // --------------------------------------------------------------------
+      // Normalization cases
+      // Depending on RedirectUrlValidator implementation, these may normalize.
+      // Keep these expected values aligned with the validator behavior.
+      // --------------------------------------------------------------------
+      { "/portal/dw/../home", "/portal/home" },
+      { "/portal/./dw/home", "/portal/dw/home" }
+    });
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  @SneakyThrows
+  public void shouldSanitizeInitialURI() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getParameter("initialURI")).thenReturn(initialURI);
+    when(request.getContextPath()).thenReturn(CONTEXT_PATH);
+    when(request.getServerName()).thenReturn(SERVER_NAME);
+
+    String result = invokeGetInitialUri(request);
+
+    assertThat(result, is(expectedRedirectURI));
+  }
+
+  @SneakyThrows
+  private String invokeGetInitialUri(HttpServletRequest request) {
+    Method method = LoginHandler.class.getDeclaredMethod("getInitalUri", HttpServletRequest.class);
+    method.setAccessible(true);// NOSONAR
+    return (String) method.invoke(loginHandler, request);
+  }
+
+  @SneakyThrows
+  private static LoginHandler allocateLoginHandler() {
+    Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);// NOSONAR
+    Unsafe unsafe = (Unsafe) unsafeField.get(null);
+    return (LoginHandler) unsafe.allocateInstance(LoginHandler.class);
+  }
+}


### PR DESCRIPTION
Prior to this change, LoginHandler relied on `URI#getHost()` to detect external redirect targets. Some malformed URLs can return a null host while still being interpreted by browsers as redirects to external domains, allowing an open redirect through the `initialURI` login parameter.

This change adds a dedicated `RedirectUrlValidator` and applies a strict allowlist policy: **only relative internal paths** under the current portal context are accepted. Unsafe values, including absolute URLs, opaque URIs, scheme-relative URLs, backslashes, encoded slash/backslash sequences, and control characters, are rejected and replaced with the portal context path.