### PR TITLE
fix: Fix restore default pages option - EXO-88526 - eXIP7.3.0.9

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -174,9 +174,21 @@ public class UserPortalConfigService implements Startable {
       return false;
     }
     List<NewPortalConfig> configs = newPortalConfigListener.getPortalConfigs(type, name);
+    boolean firstConfig = true;
     for(NewPortalConfig config : configs) {
       config = config.clone();
-      config.setImportMode(importMode.name());
+      // A site's pages/navigation are contributed by several configs (one
+      // per module), imported one at a time below. OVERWRITE's orphan
+      // destruction acts on the whole site on every single pass, so
+      // applying it on every config would let each module's pass wipe out
+      // what the previous modules' passes just restored, leaving only the
+      // last-processed module's content. Orphans must be destroyed once,
+      // so only the first pass keeps the requested OVERWRITE; later passes
+      // fall back to MERGE (same as OVERWRITE minus destroyOrphan) to
+      // additively restore their own module's content without re-wiping.
+      ImportMode passImportMode = (!firstConfig && importMode == ImportMode.OVERWRITE) ? ImportMode.MERGE : importMode;
+      firstConfig = false;
+      config.setImportMode(passImportMode.name());
       config.setOverrideMode(true);
       HashSet<String> ownerName = new HashSet<>();
       ownerName.add(name);


### PR DESCRIPTION
Prior to this change, restoring a site's pages/navigation with `OVERWRITE` repeated the destructive "remove everything not in the template" step once per contributing module (e.g. `sites`, `digital-workplace`), so each module's pass wiped out whatever the previous module's pass had just restored — leaving only the last-processed module's content.
This change will limit the destructive `OVERWRITE` pass to the first contributing module and downgrade every later pass to `MERGE`, so every module's content is restored together and only content declared by none of them gets removed.