### PR TITLE
fix: Fix Restore Default Pages deleting custom admin sections - EXO-88526 - eXIP7.3.0.9 

### DIFF
--- a/component/api/src/main/java/org/exoplatform/portal/mop/importer/ImportConfig.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/importer/ImportConfig.java
@@ -29,10 +29,18 @@ public class ImportConfig {
     /** . */
     final boolean createMissing;
 
+    /** . */
+    final boolean destroyNestedOrphan;
+
     public ImportConfig(boolean destroyOrphan, boolean updatedSame, boolean createMissing) {
+        this(destroyOrphan, updatedSame, createMissing, false);
+    }
+
+    public ImportConfig(boolean destroyOrphan, boolean updatedSame, boolean createMissing, boolean destroyNestedOrphan) {
         this.destroyOrphan = destroyOrphan;
         this.updatedSame = updatedSame;
         this.createMissing = createMissing;
+        this.destroyNestedOrphan = destroyNestedOrphan;
     }
 
     /**
@@ -50,5 +58,16 @@ public class ImportConfig {
 
     public boolean getCreateMissing() {
         return createMissing;
+    }
+
+    /**
+     * Returns true when an orphan node nested inside a default page should be
+     * destroyed, even when {@link #destroyOrphan} leaves an orphan that isn't
+     * inside any default page alone.
+     *
+     * @return the destroy nested orphan value
+     */
+    public boolean getDestroyNestedOrphan() {
+        return destroyNestedOrphan;
     }
 }

--- a/component/api/src/main/java/org/exoplatform/portal/mop/importer/ImportMode.java
+++ b/component/api/src/main/java/org/exoplatform/portal/mop/importer/ImportMode.java
@@ -42,7 +42,15 @@ public enum ImportMode {
     /**
      * Overwrite data whatsoever.
      */
-    OVERWRITE(new ImportConfig(true, true, true));
+    OVERWRITE(new ImportConfig(true, true, true)),
+
+    /**
+     * Import data when it does not exist, update data when it exists, same as MERGE for a node
+     * that isn't inside any default page (independent custom content at the site's navigation
+     * root is always preserved), but destroys an orphan nested inside a default page (e.g. a page
+     * added, pasted or left behind inside an existing default section).
+     */
+    RESTORE_DEFAULTS(new ImportConfig(false, true, true, true));
 
     /** . */
     public final ImportConfig config;

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/importer/NavigationFragmentImporter.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/importer/NavigationFragmentImporter.java
@@ -46,6 +46,14 @@ import org.exoplatform.portal.tree.diff.ListDiff;
 
 public class NavigationFragmentImporter {
 
+    /**
+     * Depths at (and below) which an orphan is considered to be at a top-level
+     * section rather than inside a default page: 0 is this fragment's own
+     * attachment point, 1 is its direct children (e.g. the "home" wrapper's own
+     * children -- the top-level admin sections themselves).
+     */
+    private static final int TOP_LEVEL_MAX_DEPTH = 1;
+
     private static final ListAdapter<PageNodeContainer, String> PAGE_NODE_CONTAINER_ADAPTER = new ListAdapter<PageNodeContainer, String>() {
         public int size(PageNodeContainer list) {
             List<PageNode> nodes = list.getNodes();
@@ -146,8 +154,17 @@ public class NavigationFragmentImporter {
             // Collect labels
             Map<NodeContext<?>, Map<Locale, org.exoplatform.portal.mop.State>> labelMap = new HashMap<NodeContext<?>, Map<Locale, org.exoplatform.portal.mop.State>>();
 
-            // Perform save
-            perform(src, from, labelMap);
+            // Depth 0 is this fragment's own attachment point (e.g. the site
+            // navigation root); depth 1 is its direct default children (e.g. the
+            // "home" wrapper's own children -- the top-level admin sections
+            // themselves). A node found at either of these two levels is a
+            // top-level section, not something inside a default page, so under
+            // RESTORE_DEFAULTS it must be preserved even if it's an orphan (e.g. a
+            // brand-new custom section added as a sibling of an existing one).
+            // From depth 2 on, we're nested inside a default page (e.g. inside an
+            // existing section), so an orphan there is a candidate for removal
+            // (e.g. a page added or left behind inside that section).
+            perform(src, from, labelMap, 0);
 
             // Save the node
             navigationService.saveNode(root, null);
@@ -168,7 +185,8 @@ public class NavigationFragmentImporter {
     private void perform(PageNodeContainer src,
                          NodeContext<?> dst,
                          Map<NodeContext<?>,
-                         Map<Locale, org.exoplatform.portal.mop.State>> labelMap) {
+                         Map<Locale, org.exoplatform.portal.mop.State>> labelMap,
+                         int depth) {
         navigationService.rebaseNode(dst, Scope.CHILDREN, null);
 
         //
@@ -212,8 +230,8 @@ public class NavigationFragmentImporter {
             //
             switch (change.type) {
                 case SAME:
-                    // Perform recursively
-                    perform(srcChild, dstChild, labelMap);
+                    // Perform recursively, one level deeper
+                    perform(srcChild, dstChild, labelMap, depth + 1);
 
                     //
                     if (config.updatedSame) {
@@ -235,7 +253,9 @@ public class NavigationFragmentImporter {
                         }
                         previousChild = dstChild;
                     } else {
-                        if (config.destroyOrphan) {
+                        boolean topLevelSection = depth <= TOP_LEVEL_MAX_DEPTH;
+                        boolean destroy = topLevelSection ? config.destroyOrphan : (config.destroyOrphan || config.destroyNestedOrphan);
+                        if (destroy) {
                             dstChild.removeNode();
                         } else {
                             previousChild = dstChild;

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/importer/NavigationImporter.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/importer/NavigationImporter.java
@@ -83,6 +83,7 @@ public class NavigationImporter {
                 break;
             case MERGE:
             case OVERWRITE:
+            case RESTORE_DEFAULTS:
                 dst = new NavigationContext(key, new NavigationState(src.getPriority()));
                 service.saveNavigation(dst);
                 break;

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/importer/PageImporter.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/importer/PageImporter.java
@@ -77,6 +77,7 @@ public class PageImporter {
                     break;
                 case MERGE:
                 case OVERWRITE:
+                case RESTORE_DEFAULTS:
                     dst = src;
                     break;
                 default:

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/importer/PortalConfigImporter.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/importer/PortalConfigImporter.java
@@ -59,6 +59,7 @@ public class PortalConfigImporter {
                 break;
             case MERGE:
             case OVERWRITE:
+            case RESTORE_DEFAULTS:
                 dst = src;
                 break;
             default:

--- a/component/portal/src/test/java/org/exoplatform/portal/mop/importer/TestNavigationFragmentImporterRestoreDefaults.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/mop/importer/TestNavigationFragmentImporterRestoreDefaults.java
@@ -1,0 +1,242 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.portal.mop.importer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Locale;
+
+import org.exoplatform.component.test.AbstractKernelTest;
+import org.exoplatform.component.test.ConfigurationUnit;
+import org.exoplatform.component.test.ConfiguredBy;
+import org.exoplatform.component.test.ContainerScope;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.model.NavigationFragment;
+import org.exoplatform.portal.config.model.PageNavigation;
+import org.exoplatform.portal.config.model.PageNode;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.mop.navigation.NavigationContext;
+import org.exoplatform.portal.mop.navigation.NavigationState;
+import org.exoplatform.portal.mop.navigation.Node;
+import org.exoplatform.portal.mop.navigation.NodeContext;
+import org.exoplatform.portal.mop.navigation.Scope;
+import org.exoplatform.portal.mop.service.NavigationService;
+import org.exoplatform.portal.mop.storage.DescriptionStorage;
+import org.exoplatform.portal.pom.data.ContainerData;
+import org.exoplatform.portal.pom.data.PortalData;
+
+/**
+ * Reproduces the reported "Restore default pages" scenario against the real
+ * admin-site navigation shape, where every section ("general", "organisation"...)
+ * is nested one level below a single "home" wrapper node:
+ * <ul>
+ * <li>a copy/paste leftover living inside an already-default section must be
+ * removed by {@link ImportMode#RESTORE_DEFAULTS};</li>
+ * <li>a page cut out of one default section and pasted into another default
+ * section must be removed from where it landed, and recreated at its default
+ * location;</li>
+ * <li>a brand-new custom section added as a sibling of "general" (i.e. also
+ * nested under "home", exactly like every other admin section) must survive
+ * untouched.</li>
+ * </ul>
+ */
+@ConfiguredBy({
+  @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.portal.component.portal-configuration.xml"),
+  @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/test.navigation.configuration.xml") })
+public class TestNavigationFragmentImporterRestoreDefaults extends AbstractKernelTest {
+
+  private NavigationService   service;
+
+  private DescriptionStorage  descriptionStorage;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    PortalContainer container = PortalContainer.getInstance();
+    this.service = container.getComponentInstanceOfType(NavigationService.class);
+    this.descriptionStorage = container.getComponentInstanceOfType(DescriptionStorage.class);
+    begin();
+  }
+
+  // Each test uses its own site name: they share no state (in-memory tree
+  // caching keyed by site+navigation collides across tests otherwise).
+  private void createSite(String siteName) throws Exception {
+    ContainerData containerData = new ContainerData(null,
+                                                     "testcontainer_" + siteName,
+                                                     "",
+                                                     "",
+                                                     "",
+                                                     "",
+                                                     "",
+                                                     "",
+                                                     "",
+                                                     "",
+                                                     "",
+                                                     "",
+                                                     null,
+                                                     null,
+                                                     Collections.emptyList(),
+                                                     Collections.emptyList());
+    PortalData portal = new PortalData(null,
+                                       siteName,
+                                       SiteType.PORTAL.getName(),
+                                       null,
+                                       null,
+                                       null,
+                                       new ArrayList<>(),
+                                       null,
+                                       null,
+                                       null,
+                                       containerData,
+                                       true,
+                                       9,
+                                       0);
+    PortalContainer.getInstance().getComponentInstanceOfType(org.exoplatform.portal.mop.storage.SiteStorage.class).create(portal);
+
+    NavigationContext nav = new NavigationContext(SiteKey.portal(siteName), new NavigationState(1));
+    service.saveNavigation(nav);
+    restartTransaction();
+  }
+
+  public void testStrayNestedDuplicateIsRemovedButCustomSectionIsKept() throws Exception {
+    String siteName = "restore_defaults_stray_test";
+    createSite(siteName);
+
+    // Build the corrupted live tree, mirroring the real admin site: everything
+    // lives under a single "home" wrapper. "general" is a default section whose
+    // "notification" child was copy/pasted, leaving a stray duplicate behind.
+    // "myCustomSection" is a brand-new admin-added section, a sibling of
+    // "general" under "home" -- exactly where a real admin would add one.
+    NavigationContext nav = service.loadNavigation(SiteKey.portal(siteName));
+    NodeContext<?> root = service.loadNode(Node.MODEL, nav, Scope.ALL, null);
+    NodeContext<?> home = root.add(null, "home");
+    home.add(null, "myCustomSection");
+    NodeContext<?> general = home.add(null, "general");
+    general.add(null, "notification");
+    general.add(null, "notification-copy-12345");
+    service.saveNode(root, null);
+    restartTransaction();
+
+    // The default tree only ever declared "home" > "general" > "notification".
+    PageNode notification = new PageNode();
+    notification.setName("notification");
+    notification.setLabel("Notification");
+
+    PageNode general2 = new PageNode();
+    general2.setName("general");
+    general2.setLabel("General");
+    general2.getNodes().add(notification);
+
+    PageNode home2 = new PageNode();
+    home2.setName("home");
+    home2.setLabel("Home");
+    home2.getNodes().add(general2);
+
+    NavigationFragment fragment = new NavigationFragment();
+    fragment.setParentURI(null);
+    fragment.getNodes().add(home2);
+
+    PageNavigation src = new PageNavigation(SiteType.PORTAL.getName(), siteName);
+    src.setPriority(1);
+    src.addFragment(fragment);
+
+    new NavigationImporter(Locale.ENGLISH, ImportMode.RESTORE_DEFAULTS, src, service, descriptionStorage).perform();
+    restartTransaction();
+
+    nav = service.loadNavigation(SiteKey.portal(siteName));
+    Node reloadedRoot = service.loadNode(Node.MODEL, nav, Scope.ALL, null).getNode();
+    Node reloadedHome = reloadedRoot.getChild("home");
+    assertNotNull("the default 'home' wrapper must still exist", reloadedHome);
+
+    Node reloadedGeneral = reloadedHome.getChild("general");
+    assertNotNull("the default 'general' section must still exist", reloadedGeneral);
+    assertNotNull("the default 'notification' child must still exist",
+                  reloadedGeneral.getChild("notification"));
+    assertNull("the copy/paste leftover nested under a default section must be removed by RESTORE_DEFAULTS",
+               reloadedGeneral.getChild("notification-copy-12345"));
+    assertNotNull("a brand-new custom section, nested under 'home' exactly like every real admin section, "
+        + "must never be touched by RESTORE_DEFAULTS just because it isn't a top-level fragment child",
+                  reloadedHome.getChild("myCustomSection"));
+  }
+
+  public void testCutItemBetweenTwoDefaultSectionsIsRestoredToItsDefaultLocation() throws Exception {
+    String siteName = "restore_defaults_cut_test";
+    createSite(siteName);
+
+    // Build the corrupted live tree: "notification" was cut out of "general"
+    // (its default section) and pasted into "organisation" (a different
+    // default section), so "general" is missing it and "organisation" has it
+    // as a stray extra.
+    NavigationContext nav = service.loadNavigation(SiteKey.portal(siteName));
+    NodeContext<?> root = service.loadNode(Node.MODEL, nav, Scope.ALL, null);
+    NodeContext<?> home = root.add(null, "home");
+    home.add(null, "general");
+    NodeContext<?> organisation = home.add(null, "organisation");
+    organisation.add(null, "notification");
+    service.saveNode(root, null);
+    restartTransaction();
+
+    // The default tree declares "notification" under "general", not under "organisation".
+    PageNode notification = new PageNode();
+    notification.setName("notification");
+    notification.setLabel("Notification");
+
+    PageNode general = new PageNode();
+    general.setName("general");
+    general.setLabel("General");
+    general.getNodes().add(notification);
+
+    PageNode organisation2 = new PageNode();
+    organisation2.setName("organisation");
+    organisation2.setLabel("Organisation");
+
+    PageNode home2 = new PageNode();
+    home2.setName("home");
+    home2.setLabel("Home");
+    home2.getNodes().add(general);
+    home2.getNodes().add(organisation2);
+
+    NavigationFragment fragment = new NavigationFragment();
+    fragment.setParentURI(null);
+    fragment.getNodes().add(home2);
+
+    PageNavigation src = new PageNavigation(SiteType.PORTAL.getName(), siteName);
+    src.setPriority(1);
+    src.addFragment(fragment);
+
+    new NavigationImporter(Locale.ENGLISH, ImportMode.RESTORE_DEFAULTS, src, service, descriptionStorage).perform();
+    restartTransaction();
+
+    nav = service.loadNavigation(SiteKey.portal(siteName));
+    Node reloadedHome = service.loadNode(Node.MODEL, nav, Scope.ALL, null).getNode().getChild("home");
+
+    Node reloadedGeneral = reloadedHome.getChild("general");
+    assertNotNull("the default 'general' section must still exist", reloadedGeneral);
+    assertNotNull("the cut item must be recreated at its default location ('general')",
+                  reloadedGeneral.getChild("notification"));
+
+    Node reloadedOrganisation = reloadedHome.getChild("organisation");
+    assertNotNull("the default 'organisation' section must still exist", reloadedOrganisation);
+    assertNull("the stray left behind by the cut, inside a different default section ('organisation'), "
+        + "must be removed by RESTORE_DEFAULTS",
+               reloadedOrganisation.getChild("notification"));
+  }
+}


### PR DESCRIPTION
Prior to this change, restoring default pages (ImportMode) had no way to tell apart a custom section an admin added at the top level of a site's navigation from a stray node left behind inside a default section (e.g. from a copy/paste or a cut-and-paste between sections). Both were treated as plain orphans, so the mode either destroyed custom top-level sections it should have preserved, or left orphaned duplicates behind inside default sections.
This change adds a dedicated RESTORE_DEFAULTS import mode, backed by a new destroyNestedOrphan flag on ImportConfig:
- Top-level nodes (the fragment's own attachment point and its direct children, e.g. custom sections added as siblings of "general" under "home") are preserved even when they are orphans, same as MERGE.
- Nodes nested deeper, inside an existing default section, are treated as stray leftovers and destroyed, same as OVERWRITE.