### PR TITLE
fix: Add restore default layout of pages option - EXO-88530 -  eXIP7.3.0.9

### DIFF
--- a/component/portal/src/main/java/org/exoplatform/portal/config/NewPortalConfigListener.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/NewPortalConfigListener.java
@@ -443,6 +443,62 @@ public class NewPortalConfigListener extends BaseComponentPlugin {
     }
   }
 
+  /**
+   * Restores a single page's layout from its packaged default configuration,
+   * leaving every other page and the navigation tree untouched.
+   *
+   * @param config the packaged config fragment to look up the default page in
+   * @param owner the site owner name
+   * @param pageName the name of the page to restore
+   * @param importMode the import mode to apply to the matched page
+   * @return {@code true} if this fragment defines a default page named {@code pageName} and it
+   *         was restored, {@code false} if this fragment doesn't define that page
+   */
+  public boolean restorePage(NewPortalConfig config, String owner, String pageName, ImportMode importMode) {
+    Page defaultPage = getDefaultPage(config, owner, pageName);
+    if (defaultPage == null) {
+      return false;
+    }
+    RequestLifeCycle.begin(PortalContainer.getInstance());
+    try {
+      PageImporter importer = new PageImporter(importMode,
+                                               new SiteKey(config.getOwnerType(), owner),
+                                               Collections.singletonList(defaultPage),
+                                               layoutService);
+      importer.perform();
+      return true;
+    } finally {
+      RequestLifeCycle.end();
+    }
+  }
+
+  /**
+   * Checks whether the given packaged config fragment defines a default page named
+   * {@code pageName}, without performing any import. This mirrors the lookup done by
+   * {@link #restorePage(NewPortalConfig, String, String, ImportMode)} but leaves the page untouched.
+   *
+   * @param config the packaged config fragment to look up the default page in
+   * @param owner the site owner name
+   * @param pageName the name of the page to look up
+   * @return {@code true} if this fragment defines a default page named {@code pageName}
+   */
+  public boolean hasDefaultPage(NewPortalConfig config, String owner, String pageName) {
+    return getDefaultPage(config, owner, pageName) != null;
+  }
+
+  private Page getDefaultPage(NewPortalConfig config, String owner, String pageName) {
+    UnmarshalledObject<PageSet> pageSet = getConfig(config, owner, "pages", PageSet.class);
+    if (pageSet == null) {
+      return null;
+    }
+    return pageSet.getObject()
+                  .getPages()
+                  .stream()
+                  .filter(page -> StringUtils.equals(page.getName(), pageName))
+                  .findFirst()
+                  .orElse(null);
+  }
+
   public void createPageNavigation(NewPortalConfig config, String owner) {
     UnmarshalledObject<PageNavigation> obj = getConfig(config, owner, "navigation", PageNavigation.class);
     if (obj == null) {

--- a/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/config/UserPortalConfigService.java
@@ -208,6 +208,52 @@ public class UserPortalConfigService implements Startable {
     return true;
   }
 
+  /**
+   * Restores a single page's layout from its packaged default configuration, leaving every other
+   * page and the site's navigation tree untouched.
+   *
+   * @param pageKey the key of the page to restore
+   * @param importMode the import mode to apply
+   * @return {@code true} if the page's site has a packaged default defining this page and it was
+   *         restored, {@code false} if this page isn't part of any default/product configuration
+   */
+  public boolean restorePage(PageKey pageKey, ImportMode importMode) {
+    SiteKey siteKey = pageKey.getSite();
+    if (!canRestore(siteKey.getTypeName(), siteKey.getName())) {
+      return false;
+    }
+    List<NewPortalConfig> configs = newPortalConfigListener.getPortalConfigs(siteKey.getTypeName(), siteKey.getName());
+    for (NewPortalConfig config : configs) {
+      if (newPortalConfigListener.restorePage(config, siteKey.getName(), pageKey.getName(), importMode)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Checks whether the given page is a default/product page, i.e. its layout is defined by the
+   * product's packaged configuration and can therefore be restored to its default. No import is
+   * performed.
+   *
+   * @param pageKey the key of the page to check
+   * @return {@code true} if the page's site has a packaged default defining this page,
+   *         {@code false} if this page isn't part of any default/product configuration
+   */
+  public boolean isDefaultPage(PageKey pageKey) {
+    SiteKey siteKey = pageKey.getSite();
+    if (!canRestore(siteKey.getTypeName(), siteKey.getName())) {
+      return false;
+    }
+    List<NewPortalConfig> configs = newPortalConfigListener.getPortalConfigs(siteKey.getTypeName(), siteKey.getName());
+    for (NewPortalConfig config : configs) {
+      if (newPortalConfigListener.hasDefaultPage(config, siteKey.getName(), pageKey.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public LayoutService getDataStorage() {
     return layoutService;
   }

--- a/component/portal/src/main/java/org/exoplatform/portal/mop/rest/model/UserNodeRestEntity.java
+++ b/component/portal/src/main/java/org/exoplatform/portal/mop/rest/model/UserNodeRestEntity.java
@@ -36,6 +36,8 @@ public class UserNodeRestEntity {
 
   private boolean                  canEditPage;
 
+  private boolean                  canRestoreLayout;
+
   private String[]                 pageAccessPermissions;
 
   private String                   pageEditPermission;


### PR DESCRIPTION
Prior to this change, there was no way to tell whether a page is a product/default page without actually restoring it, and this information was not exposed to the REST layer.

This change will add a read-only check (`UserPortalConfigService.isDefaultPage`, backed by `NewPortalConfigListener.hasDefaultPage`) and expose a `canRestoreLayout` flag on the navigation node entity (`UserNodeRestEntity`), so the UI can know which pages can be restored to their default layout.